### PR TITLE
Add linting to CI

### DIFF
--- a/.github/actions/prepare-app-env/action.yml
+++ b/.github/actions/prepare-app-env/action.yml
@@ -1,0 +1,55 @@
+name: Prepare application environment
+description: Performs setup steps common to jobs that need to run the application
+inputs:
+  skip-ruby:
+    description: Allows skipping Ruby setup for jobs where it isn't required
+    required: false
+    default: "false"
+  skip-node:
+    description: Allows skipping Node.js setup for jobs where it isn't required
+    required: false
+    default: "false"
+  node-version:
+    description: The version of Node.js to install
+    required: false
+    default: "18.x"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Ruby
+      if: ${{ inputs.skip-ruby == 'false' }}
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
+    - name: Set up Node
+      if: ${{ inputs.skip-node == 'false' }}
+      uses: actions/setup-node@v2.5.0
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install yarn
+      if: ${{ inputs.skip-node == 'false' }}
+      run: npm install yarn -g
+      shell: bash
+
+    - name: Yarn cache
+      if: ${{ inputs.skip-node == 'false' }}
+      id: yarn-cache
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+      shell: bash
+
+    - name: Set up yarn cache
+      if: ${{ inputs.skip-node == 'false' }}
+      uses: actions/cache@v2.1.7
+      with:
+        path: ${{ steps.yarn-cache.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Install node.js dependencies
+      if: ${{ inputs.skip-node == 'false' }}
+      run: yarn install
+      shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - "**"
+      - "!main"
+
+jobs:
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Prepare application environment
+        uses: ./.github/actions/prepare-app-env
+
+      - name: Run Prettier
+        run: yarn prettier --check --ignore-unknown --loglevel warn '**/*'
+
+  rubocop:
+    name: Rubocop
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Prepare application environment
+        uses: ./.github/actions/prepare-app-env
+
+      - name: Run Rubocop
+        run: bin/bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,23 @@
-AllCops:
-  NewCops: enable
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml
 
-Style/StringLiterals:
-  Enabled: false
-Style/FrozenStringLiteralComment:
-  Enabled: false
-Style/SignalException:
-  Enabled: false
-Metrics/MethodLength:
-  Enabled: false
+inherit_from:
+  - node_modules/@prettier/plugin-ruby/rubocop.yml
+
+inherit_mode:
+  merge:
+    - Exclude
+
+Style/NumericLiterals:
+  Exclude:
+    - db/schema.rb
+
+Style/BlockDelimiters:
+  Exclude:
+    - app/services/feature_flag.rb
+
+Style/MethodCalledOnDoEndBlock:
+  Exclude:
+    - app/services/feature_flag.rb

--- a/bin/lint
+++ b/bin/lint
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-bin/bundle exec rubocop --auto-correct-all
+bin/bundle exec rubocop --autocorrect-all
 yarn prettier --write --ignore-unknown '**/*'

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -3,7 +3,8 @@
 # NOTE: to have a dev-mode tool do its thing in production.
 if Rails.env.development?
   require "annotate"
-  task :set_annotation_options do
+  desc "Configure the annotate gem"
+  task set_annotation_options: :environment do
     # You can override any of these by setting an environment variable of the
     # same name.
     Annotate.set_defaults(


### PR DESCRIPTION
### Context

We want to ensure that the project is using the linting tools.

### Changes proposed in this pull request

This change introduces a GitHub action used in Find, that runs the
linting tools as a status check.

Once this is merged, I will make this a required check for merging a
change.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
