### PR TITLE
Add an action to run tests on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  rspec:
+    name: Rspec
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-retries 5
+          --health-timeout 5s
+
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/refer_serious_misconduct_test
+      RAILS_ENV: test
+      RAILS_MASTER_KEY: ${{secrets.RAILS_MASTER_KEY}}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Prepare application environment
+        uses: ./.github/actions/prepare-app-env
+
+      - name: Build frontend
+        run: bin/rails assets:precompile
+
+      - name: Setup DB
+        run: bin/rails db:prepare
+
+      - name: Run tests
+        run: bin/bundle exec rspec --format documentation


### PR DESCRIPTION
### Context

We want to run the tests as part of the status checks on GitHub.

### Changes proposed in this pull request

This sets up a basic action to run RSpec.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
