### PR TITLE
Add a service open feature flag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ gem "bootsnap", require: false
 gem "cssbundling-rails"
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
+gem "govuk_feature_flags",
+    git: "https://github.com/DFE-Digital/govuk_feature_flags.git",
+    branch: "main"
 gem "jsbundling-rails"
 gem "pg", "~> 1.4"
 gem "propshaft"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/DFE-Digital/govuk_feature_flags.git
+  revision: cd496739d594058a88b844c1deef577ad84ed47a
+  branch: main
+  specs:
+    govuk_feature_flags (0.1.0)
+      rails (>= 7.0.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -338,6 +346,7 @@ DEPENDENCIES
   dotenv-rails (~> 2.8)
   govuk-components
   govuk_design_system_formbuilder
+  govuk_feature_flags!
   jsbundling-rails
   pg (~> 1.4)
   prettier_print

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,5 +2,10 @@ class ApplicationController < ActionController::Base
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 
   http_basic_authenticate_with name: ENV.fetch("SUPPORT_USERNAME", nil),
-                               password: ENV.fetch("SUPPORT_PASSWORD", nil)
+                               password: ENV.fetch("SUPPORT_PASSWORD", nil),
+                               unless: -> {
+                                 FeatureFlags::FeatureFlag.active?(
+                                   "service_open"
+                                 )
+                               }
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,44 +1,5 @@
-<!DOCTYPE html>
-<html lang="en" class="govuk-template">
-  <head>
-    <title><%= [yield(:page_title).presence, t('service.name')].compact.join(' - ') %></title>
+<% content_for :content do %>
+  <%= yield %>
+<% end %>
 
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
-
-    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
-    <%= tag :meta, property: 'og:image', content: asset_path('images/govuk-opengraph-image.png') %>
-    <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
-    <%= favicon_link_tag asset_path('images/favicon.ico') %>
-    <%= favicon_link_tag asset_path('images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
-
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-  </head>
-
-  <body class="govuk-template__body">
-    <script>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
-
-    <%= govuk_skip_link %>
-
-    <%= govuk_header(service_name: "GOV.UK Rails Boilerplate") do |header| %>
-      <%= header.navigation_item(text: "Navigation item 1", href: "#", active: true) %>
-      <%= header.navigation_item(text: "Navigation item 2", href: "#") %>
-      <%= header.navigation_item(text: "Navigation item 3", href: "#") %>
-    <% end %>
-
-    <div class="govuk-width-container">
-      <main class="govuk-main-wrapper" id="main-content" role="main">
-        <%= yield %>
-      </main>
-    </div>
-
-    <%= govuk_footer %>
-  </body>
-</html>
+<%= render template: 'layouts/base' %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <title><%= [yield(:page_title).presence, t('service.name')].compact.join(' - ') %></title>
+
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
+    <%= tag :meta, property: 'og:image', content: asset_path('images/govuk-opengraph-image.png') %>
+    <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
+    <%= favicon_link_tag asset_path('images/favicon.ico') %>
+    <%= favicon_link_tag asset_path('images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
+    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
+    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
+    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
+    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+  </head>
+
+  <body class="govuk-template__body">
+    <script>
+      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+    </script>
+
+    <%= govuk_skip_link %>
+
+    <%= govuk_header(service_name: "GOV.UK Rails Boilerplate") do |header| %>
+      <%= header.navigation_item(text: "Navigation item 1", href: "#", active: true) %>
+      <%= header.navigation_item(text: "Navigation item 2", href: "#") %>
+      <%= header.navigation_item(text: "Navigation item 3", href: "#") %>
+    <% end %>
+
+    <div class="govuk-width-container">
+      <main class="govuk-main-wrapper" id="main-content" role="main">
+        <%= yield %>
+      </main>
+    </div>
+
+    <%= govuk_footer %>
+  </body>
+</html>

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,0 +1,4 @@
+feature_flags:
+  service_open:
+    author: Felix Clack
+    description: Allow users to access the service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   namespace :support_interface, path: "/support" do
     get "/", to: "support_interface#index"
+    mount FeatureFlags::Engine => "/features"
   end
 
   scope via: :all do

--- a/db/migrate/20221011103114_create_feature_flags_features.feature_flags.rb
+++ b/db/migrate/20221011103114_create_feature_flags_features.feature_flags.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from feature_flags (originally 20221005090626)
+class CreateFeatureFlagsFeatures < ActiveRecord::Migration[7.0]
+  def change
+    create_table :feature_flags_features do |t|
+      t.string :name, null: false
+      t.boolean :active, default: false, null: false
+
+      t.timestamps
+    end
+    add_index :feature_flags_features, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2022_10_11_103114) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "feature_flags_features", force: :cascade do |t|
+    t.string "name", null: false
+    t.boolean "active", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_feature_flags_features_on_name", unique: true
+  end
+
+end

--- a/spec/system/support_spec.rb
+++ b/spec/system/support_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe "Support", type: :system do
     when_i_am_authorized_as_a_support_user
     and_i_visit_the_support_page
     then_i_see_the_support_page
+
+    when_i_visit_the_features_page
+    then_i_see_the_feature_page
   end
 
   private
@@ -20,5 +23,13 @@ RSpec.describe "Support", type: :system do
 
   def then_i_see_the_support_page
     expect(page).to have_current_path(support_interface_path)
+  end
+
+  def when_i_visit_the_features_page
+    visit support_interface_feature_flags_path
+  end
+
+  def then_i_see_the_feature_page
+    expect(page).to have_content("Features")
   end
 end


### PR DESCRIPTION
### Context

We want to be able to control access to the service using a feautre
flag.

### Changes proposed in this pull request

We have a new library, govuk_feature_flags, that implements the actual
feature flag function. This change introduces that as a dependency and
configures it for use here.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally

<img width="1044" alt="Screenshot 2022-10-13 at 10 11 17 am" src="https://user-images.githubusercontent.com/3126/195561665-2030e254-6ace-4835-998c-df5e386bc494.png">
