### PR TITLE
Update bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,4 +362,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.1.4
+   2.3.23


### PR DESCRIPTION
### Context

When using Bundler v2.1.4, there's a warning that renders related to the
`DidYouMean` class.

### Changes proposed in this pull request

Upgrading removes that warning.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
