### PR TITLE
Add the start page

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -3,3 +3,32 @@ $govuk-new-link-styles: true;
 $govuk-assets-path: "/";
 
 @import "govuk-frontend/govuk/all";
+
+.app-govuk-related-navigation {
+  @include govuk-text-colour;
+  border-top: 2px solid $govuk-brand-colour;
+
+  &__nav-section {
+    margin-bottom: govuk-spacing(6);
+  }
+
+  &__main-heading {
+    margin-bottom: govuk-spacing(2);
+    margin-top: govuk-spacing(3);
+  }
+
+  &__link-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  &__link {
+    @include govuk-font($size: 16, $weight: regular, $line-height: 1.45);
+    margin-top: govuk-spacing(3);
+
+    @include govuk-media-query($from: tablet) {
+      line-height: 1.28;
+    }
+  }
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,4 @@
 class PagesController < ApplicationController
-  def home
+  def start
   end
 end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -27,11 +27,7 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(service_name: "GOV.UK Rails Boilerplate") do |header| %>
-      <%= header.navigation_item(text: "Navigation item 1", href: "#", active: true) %>
-      <%= header.navigation_item(text: "Navigation item 2", href: "#") %>
-      <%= header.navigation_item(text: "Navigation item 3", href: "#") %>
-    <% end %>
+    <%= govuk_header(service_name: t('service.name')) %>
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -1,0 +1,72 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('service.name') %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive"></span>
+        <a href="#">Contact the police</a> if you think a child is in immediate danger.
+      </strong>
+    </div>
+
+    <p class="govuk-body">
+      The Teaching Regulation Agency (TRA) will only investigate cases where the misconduct is serious enough to potentially result in a prohibition order, meaning the person can no longer teach.
+    </p>
+
+    <p class="govuk-body">You’ll need proof to support your allegation.</p>
+    <p class="govuk-body">
+      Cases of less serious misconduct, and all cases of incompetence, should be dealt with by employers.
+    </p>
+
+    <h2 class="govuk-heading-m">What happens when you submit a report</h2>
+    <p class="govuk_body">
+      See the <%= link_to "step-by-step guide", "#" %> to find out what happens once you submit a report.
+    </p>
+
+    <h2 class="govuk-heading-m">How long it will take to prepare your report</h2>
+    <p class="govuk_body">
+      You should allow an hour or more to complete your report. The time it will take depends on the case. It will be faster if you’ve prepared the evidence.
+    </p>
+
+    <%= govuk_start_button(text: 'Start now', href: '#', classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
+
+    <h2 class="govuk-heading-m">When to use a different form</h2>
+    <p class="govuk_body">
+      If you want to report multiple teachers at once, you need to <%= link_to "complete a different form", "#" %>
+    </p>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <div class="app-govuk-related-navigation">
+      <nav class="app-govuk-related-navigation__nav-section" role="navigation" aria-labelledby="related-nav-related-content">
+        <h2 class="govuk-heading-s app-govuk-related-navigation__main-heading" id="related-nav-related_items-related-content">
+          Related content
+        </h2>
+        <ul class="app-govuk-related-navigation__link-list">
+          <li class="app-govuk-related-navigation__link">
+            <a class="govuk-link app-govuk-related-navigation__section-link app-govuk-related-navigation__section-link--other" href="https://www.gov.uk/government/publications/teacher-misconduct-information-for-teachers">Teacher misconduct: information for teachers</a>
+          </li>
+          <li class="app-govuk-related-navigation__link">
+            <a class="govuk-link app-govuk-related-navigation__section-link app-govuk-related-navigation__section-link--other" href="https://www.gov.uk/guidance/teacher-misconduct-referring-a-case">Teacher misconduct: referring a case</a>
+          </li>
+          <li class="app-govuk-related-navigation__link">
+            <a class="govuk-link app-govuk-related-navigation__section-link app-govuk-related-navigation__section-link--other" href="https://www.gov.uk/government/publications/teacher-misconduct-disciplinary-procedures">Teacher misconduct: disciplinary procedures</a>
+          </li>
+          <li class="app-govuk-related-navigation__link">
+            <a class="govuk-link app-govuk-related-navigation__section-link app-govuk-related-navigation__section-link--other" href="https://www.gov.uk/guidance/teacher-misconduct-regulating-the-teaching-profession">Teacher misconduct: regulating the teaching profession</a>
+          </li>
+          <li class="app-govuk-related-navigation__link">
+            <a class="govuk-link app-govuk-related-navigation__section-link app-govuk-related-navigation__section-link--other" href="https://www.gov.uk/government/publications/teacher-misconduct-information-for-observers">Teacher misconduct hearings: information for observers</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,4 @@
 en:
   service:
-    name: GOV.UK Frontend on Rails
+    name: Report serious misconduct by a teacher
     email: my-service@email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  root to: "pages#home"
+  root to: redirect("/start")
+
+  get "/start", to: "pages#start"
 
   namespace :support_interface, path: "/support" do
     get "/", to: "support_interface#index"

--- a/spec/system/service_wizard_spec.rb
+++ b/spec/system/service_wizard_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Service wizard", type: :system do
+  it "happy path" do
+    given_the_service_is_open
+    when_i_visit_the_service
+    then_i_see_the_start_page
+  end
+
+  private
+
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def then_i_see_the_start_page
+    expect(page).to have_current_path("/start")
+    expect(page).to have_title("Report serious misconduct by a teacher")
+    expect(page).to have_content("Report serious misconduct by a teacher")
+  end
+
+  def when_i_visit_the_service
+    visit root_path
+  end
+end


### PR DESCRIPTION
### Context

There is a prototype for the service we are building. The start page
design is located at
https://teacher-misconduct.herokuapp.com/report/start.

### Changes proposed in this pull request

This change recreates the design of this page but without working
navigation.

The result of pressing the 'Start now' button will be implemented in the
next PR.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
