### PR TITLE
Add the confirmation page

### DIFF
--- a/app/views/pages/confirmation.html.erb
+++ b/app/views/pages/confirmation.html.erb
@@ -1,0 +1,37 @@
+<% content_for :page_title, 'We have received your report of serious misconduct' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= govuk_panel(
+      title_text: 'We have received your report of serious misconduct',
+      classes: %w[govuk-!-margin-bottom-6]
+    ) %>
+    <p class="govuk_body">
+      We’ve sent you a confirmation by email. Your confirmation includes a link to view your report.
+    </p>
+
+    <h2 class="govuk-heading-m">What happens next</h2>
+    <p class="govuk_body">
+      Once the Teaching Regulation Agency (TRA) have reviewed the report, they’ll let you know what happens next.
+    </p>
+
+    <p class="govuk_body">TRA could tell you they:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>need more information to decide whether to investigate the case</li>
+      <li>will not investigate the case because it’s outside their remit</li>
+      <li>will not investigate the case because it does not have the potential to result in a prohibition order</li>
+      <li>will launch a formal investigation</li>
+    </ul>
+    <p class="govuk_body">The time it takes for TRA to get back to you will depend on the case.</p>
+    <p class="govuk_body">
+      For more information about what happens next, see our <%= link_to "step-by-step guide", "#" %>.
+    </p>
+
+    <h2 class="govuk-heading-m">Contacting TRA about this report</h2>
+    <p class="govuk_body">
+      Call <%= t('service.phone') %> or email:<br>
+      <%= mail_to t('service.email') %>
+    </p>
+    <p class="govuk_body">Monday to Friday, 9am to 5pm (except public holidays)</p>
+  </div>
+</div>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -35,7 +35,7 @@
       You should allow an hour or more to complete your report. The time it will take depends on the case. It will be faster if you’ve prepared the evidence.
     </p>
 
-    <%= govuk_start_button(text: 'Start now', href: '#', classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
+    <%= govuk_start_button(text: 'Start now', href: confirmation_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
 
     <h2 class="govuk-heading-m">When to use a different form</h2>
     <p class="govuk_body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,5 @@
 en:
   service:
     name: Report serious misconduct by a teacher
-    email: my-service@email
+    email: misconduct.teacher@education.gov.uk
+    phone: 020 7593 5393

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   root to: redirect("/start")
 
+  get "/confirmation", to: "pages#confirmation"
   get "/start", to: "pages#start"
 
   namespace :support_interface, path: "/support" do

--- a/spec/system/service_wizard_spec.rb
+++ b/spec/system/service_wizard_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe "Service wizard", type: :system do
     given_the_service_is_open
     when_i_visit_the_service
     then_i_see_the_start_page
+
+    when_i_press_start
+    then_i_see_the_confirmation_page
   end
 
   private
@@ -14,10 +17,24 @@ RSpec.describe "Service wizard", type: :system do
     FeatureFlags::FeatureFlag.activate(:service_open)
   end
 
+  def then_i_see_the_confirmation_page
+    expect(page).to have_current_path("/confirmation")
+    expect(page).to have_title(
+      "We have received your report of serious misconduct - Report serious misconduct by a teacher"
+    )
+    expect(page).to have_content(
+      "We have received your report of serious misconduct"
+    )
+  end
+
   def then_i_see_the_start_page
     expect(page).to have_current_path("/start")
     expect(page).to have_title("Report serious misconduct by a teacher")
     expect(page).to have_content("Report serious misconduct by a teacher")
+  end
+
+  def when_i_press_start
+    click_link "Start now"
   end
 
   def when_i_visit_the_service


### PR DESCRIPTION
### Context

After someone has submitted their report, they are presented with a
confirmation page as the last step in the process.

### Changes proposed in this pull request

This adds the page as per the designs on
https://teacher-misconduct.herokuapp.com/report/submit/confirmation.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="996" alt="Screenshot 2022-10-13 at 12 56 17 pm" src="https://user-images.githubusercontent.com/3126/195591187-af5f7274-d589-45da-915d-558ae9b6e012.png">
