### PR TITLE
Rename service to Refer serious misconduct

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,5 @@
 en:
   service:
-    name: Report serious misconduct by a teacher
+    name: Refer serious misconduct by a teacher
     email: misconduct.teacher@education.gov.uk
     phone: 020 7593 5393

--- a/spec/system/service_wizard_spec.rb
+++ b/spec/system/service_wizard_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Service wizard", type: :system do
   def then_i_see_the_confirmation_page
     expect(page).to have_current_path("/confirmation")
     expect(page).to have_title(
-      "We have received your report of serious misconduct - Report serious misconduct by a teacher"
+      "We have received your report of serious misconduct - Refer serious misconduct by a teacher"
     )
     expect(page).to have_content(
       "We have received your report of serious misconduct"
@@ -29,8 +29,8 @@ RSpec.describe "Service wizard", type: :system do
 
   def then_i_see_the_start_page
     expect(page).to have_current_path("/start")
-    expect(page).to have_title("Report serious misconduct by a teacher")
-    expect(page).to have_content("Report serious misconduct by a teacher")
+    expect(page).to have_title("Refer serious misconduct by a teacher")
+    expect(page).to have_content("Refer serious misconduct by a teacher")
   end
 
   def when_i_press_start


### PR DESCRIPTION
"Report" is used in the prototype, and it is a more commonly used word and generally better. But "Refer" needs to be the name of the service because it aligns better with the legacy process.
