### PR TITLE
Add the reporting as question

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ inherit_mode:
   merge:
     - Exclude
 
+Rails/SaveBang:
+  Enabled: false
+
 Style/NumericLiterals:
   Exclude:
     - db/schema.rb

--- a/app/controllers/reporting_as_controller.rb
+++ b/app/controllers/reporting_as_controller.rb
@@ -1,0 +1,22 @@
+class ReportingAsController < ApplicationController
+  def new
+    @reporting_as_form = ReportingAsForm.new
+  end
+
+  def create
+    eligibility_check = EligibilityCheck.new
+    @reporting_as_form =
+      ReportingAsForm.new(reporting_as_params.merge(eligibility_check:))
+    if @reporting_as_form.save
+      redirect_to confirmation_path
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def reporting_as_params
+    params.require(:reporting_as_form).permit(:reporting_as)
+  end
+end

--- a/app/forms/reporting_as_form.rb
+++ b/app/forms/reporting_as_form.rb
@@ -1,0 +1,15 @@
+class ReportingAsForm
+  include ActiveModel::Model
+
+  attr_accessor :eligibility_check, :reporting_as
+
+  validates :eligibility_check, presence: true
+  validates :reporting_as, presence: true
+
+  def save
+    return false unless valid?
+
+    eligibility_check.reporting_as = reporting_as
+    eligibility_check.save
+  end
+end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -1,0 +1,12 @@
+# == Schema Information
+#
+# Table name: eligibility_checks
+#
+#  id           :bigint           not null, primary key
+#  reporting_as :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+class EligibilityCheck < ApplicationRecord
+  validates :reporting_as, presence: true
+end

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -35,7 +35,7 @@
       You should allow an hour or more to complete your report. The time it will take depends on the case. It will be faster if you’ve prepared the evidence.
     </p>
 
-    <%= govuk_start_button(text: 'Start now', href: confirmation_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
+    <%= govuk_start_button(text: 'Start now', href: who_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
 
     <h2 class="govuk-heading-m">When to use a different form</h2>
     <p class="govuk_body">

--- a/app/views/reporting_as/new.html.erb
+++ b/app/views/reporting_as/new.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title, 'Are you reporting as an employer or member of the public?' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: @reporting_as_form, url: who_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons(:reporting_as,
+        [OpenStruct.new(label: "I’m reporting as an employer", value: :employer), OpenStruct.new(label: "I’m reporting as a member of the public", value: :public)],
+        :value,
+        :label,
+        legend: { size: 'xl', text: 'Are you reporting as an employer or member of the public?' }
+      ) %>
+      <%= f.govuk_submit prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,3 +3,11 @@ en:
     name: Refer serious misconduct by a teacher
     email: misconduct.teacher@education.gov.uk
     phone: 020 7593 5393
+
+  activemodel:
+    errors:
+      models:
+        reporting_as_form:
+          attributes:
+            reporting_as:
+              blank: Tell us if you are reporting as an employer or a member of the public

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
 
   get "/confirmation", to: "pages#confirmation"
   get "/start", to: "pages#start"
+  get "/who", to: "reporting_as#new"
+  post "/who", to: "reporting_as#create"
 
   namespace :support_interface, path: "/support" do
     get "/", to: "support_interface#index"

--- a/db/migrate/20221014082246_create_eligibility_checks.rb
+++ b/db/migrate/20221014082246_create_eligibility_checks.rb
@@ -1,0 +1,8 @@
+class CreateEligibilityChecks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :eligibility_checks do |t|
+      t.string :reporting_as, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_11_103114) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_14_082246) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "eligibility_checks", force: :cascade do |t|
+    t.string "reporting_as", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "feature_flags_features", force: :cascade do |t|
     t.string "name", null: false

--- a/spec/forms/reporting_as_form_spec.rb
+++ b/spec/forms/reporting_as_form_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe ReportingAsForm, type: :model do
+  it { is_expected.to validate_presence_of(:eligibility_check) }
+  it { is_expected.to validate_presence_of(:reporting_as) }
+
+  describe "#save" do
+    subject(:save) { reporting_as_form.save }
+
+    let(:eligibility_check) { EligibilityCheck.new }
+    let(:reporting_as_form) do
+      described_class.new(eligibility_check:, reporting_as:)
+    end
+    let(:reporting_as) { :employer }
+
+    it "saves the reporting_as value on the eligibility check" do
+      expect { save }.to change(eligibility_check, :reporting_as).from(nil).to(
+        "employer"
+      )
+    end
+
+    context "without a value for reporting_as" do
+      let(:reporting_as) { nil }
+
+      it { is_expected.to be_falsey }
+
+      it "returns an informative error message" do
+        save
+        expect(reporting_as_form.errors["reporting_as"]).to eq(
+          [
+            "Tell us if you are reporting as an employer or a member of the public"
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: eligibility_checks
+#
+#  id           :bigint           not null, primary key
+#  reporting_as :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+require "rails_helper"
+
+RSpec.describe EligibilityCheck, type: :model do
+  it { is_expected.to validate_presence_of(:reporting_as) }
+end

--- a/spec/system/service_wizard_spec.rb
+++ b/spec/system/service_wizard_spec.rb
@@ -8,13 +8,33 @@ RSpec.describe "Service wizard", type: :system do
     then_i_see_the_start_page
 
     when_i_press_start
+    then_i_see_the_employer_or_public_question
+
+    when_i_choose_reporting_as_an_employer
+    when_i_press_continue
+
     then_i_see_the_confirmation_page
+  end
+
+  it "form errors" do
+    given_the_service_is_open
+    when_i_visit_the_service
+    then_i_see_the_start_page
+
+    when_i_press_start
+    then_i_see_the_employer_or_public_question
+    when_i_press_continue
+    then_i_see_a_validation_error
   end
 
   private
 
   def given_the_service_is_open
     FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_content("There is a problem")
   end
 
   def then_i_see_the_confirmation_page
@@ -27,10 +47,28 @@ RSpec.describe "Service wizard", type: :system do
     )
   end
 
+  def then_i_see_the_employer_or_public_question
+    expect(page).to have_current_path("/who")
+    expect(page).to have_title(
+      "Are you reporting as an employer or member of the public? - Refer serious misconduct by a teacher"
+    )
+    expect(page).to have_content(
+      "Are you reporting as an employer or member of the public?"
+    )
+  end
+
   def then_i_see_the_start_page
     expect(page).to have_current_path("/start")
     expect(page).to have_title("Refer serious misconduct by a teacher")
     expect(page).to have_content("Refer serious misconduct by a teacher")
+  end
+
+  def when_i_choose_reporting_as_an_employer
+    choose "I’m reporting as an employer", visible: false
+  end
+
+  def when_i_press_continue
+    click_on "Continue"
   end
 
   def when_i_press_start


### PR DESCRIPTION
### Context

The first question of the eligibility screener asks for the context of
the report you are making.

### Changes proposed in this pull request

`EligibilityCheck` is the representation of the outcome of the screener.

As per the approach in Find a Lost TRN and Access Your Teaching Profile,
we're utilising form objects to represent a question and persisting the
answers to the `EligibilityCheck` entity.

There is no session persistence yet but this will be added when we have
multiple questions.

Include a summary of the change.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1016" alt="Screenshot 2022-10-14 at 10 21 11 am" src="https://user-images.githubusercontent.com/3126/195811599-5bc79a03-f4b8-4caa-b3dd-c49b903155cc.png">
