### PR TITLE
Add a page with links to the relevant referral form

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,8 @@
 class PagesController < ApplicationController
+  def complete
+    @eligibility_check = EligibilityCheck.find(session[:eligibility_check_id])
+  end
+
   def start
   end
 end

--- a/app/controllers/reporting_as_controller.rb
+++ b/app/controllers/reporting_as_controller.rb
@@ -8,7 +8,8 @@ class ReportingAsController < ApplicationController
     @reporting_as_form =
       ReportingAsForm.new(reporting_as_params.merge(eligibility_check:))
     if @reporting_as_form.save
-      redirect_to confirmation_path
+      session[:eligibility_check_id] = eligibility_check.id
+      redirect_to complete_path
     else
       render :new
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,19 @@
 module ApplicationHelper
+  def link_to_referral_form_for(reporting_as = "public")
+    link = {
+      employer: {
+        title: "Teacher misconduct referral form for use by employers",
+        url:
+          "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1105692/Teacher_Misconduct_Referral_Form_for__Employers__8_.docx"
+      },
+      public: {
+        title:
+          "Teacher misconduct referral form for use by members of the public",
+        url:
+          "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1105693/Teacher_misconduct_referral_form_for_members_of_the_public.docx"
+      }
+    }.with_indifferent_access
+
+    link_to link[reporting_as][:title], link[reporting_as][:url]
+  end
 end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -9,4 +9,8 @@
 #
 class EligibilityCheck < ApplicationRecord
   validates :reporting_as, presence: true
+
+  def reporting_as_employer?
+    reporting_as&.to_sym == :employer
+  end
 end

--- a/app/views/pages/complete.html.erb
+++ b/app/views/pages/complete.html.erb
@@ -1,0 +1,31 @@
+<% content_for :page_title, 'You need to complete a referral form' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You need to complete a referral form</h1>
+
+    <p class="govuk_body">
+      Based on what you've told us, you need to fill out the teacher misconduct
+      referral form for use by <%= @eligibility_check.reporting_as_employer? ? "employers" : "members of the public" %>.
+    </p>
+
+    <h2 class="govuk-heading-m">What you need to do next</h2>
+
+    <p class="govuk_body">Download the referral form:</p>
+
+    <p class="govuk_body">
+      <%= link_to_referral_form_for(@eligibility_check.reporting_as) %>
+    </p>
+    <p class="govuk_body">
+      Fill out the form, and email it to:<br><%= mail_to t('service.email') %>
+    </p>
+
+    <h2 class="govuk-heading-m">Contacting TRA about this report</h2>
+
+    <p class="govuk_body">
+      Call <%= t('service.phone') %> or email:<br>
+      <%= mail_to t('service.email') %>
+    </p>
+    <p class="govuk_body">Monday to Friday, 9am to 5pm (except public holidays)</p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: redirect("/start")
 
-  get "/confirmation", to: "pages#confirmation"
+  get "/complete", to: "pages#complete"
   get "/start", to: "pages#start"
   get "/who", to: "reporting_as#new"
   post "/who", to: "reporting_as#create"

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -11,4 +11,24 @@ require "rails_helper"
 
 RSpec.describe EligibilityCheck, type: :model do
   it { is_expected.to validate_presence_of(:reporting_as) }
+
+  describe "#reporting_as_employer?" do
+    subject { described_class.new(reporting_as:).reporting_as_employer? }
+
+    let(:reporting_as) { nil }
+
+    it { is_expected.to be_falsey }
+
+    context "when reporting_as is public" do
+      let(:reporting_as) { "public" }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when reporting_as is employer" do
+      let(:reporting_as) { "employer" }
+
+      it { is_expected.to be_truthy }
+    end
+  end
 end

--- a/spec/system/service_wizard_spec.rb
+++ b/spec/system/service_wizard_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Service wizard", type: :system do
     when_i_choose_reporting_as_an_employer
     when_i_press_continue
 
-    then_i_see_the_confirmation_page
+    then_i_see_the_completion_page
   end
 
   it "form errors" do
@@ -37,14 +37,12 @@ RSpec.describe "Service wizard", type: :system do
     expect(page).to have_content("There is a problem")
   end
 
-  def then_i_see_the_confirmation_page
-    expect(page).to have_current_path("/confirmation")
+  def then_i_see_the_completion_page
+    expect(page).to have_current_path("/complete")
     expect(page).to have_title(
-      "We have received your report of serious misconduct - Refer serious misconduct by a teacher"
+      "You need to complete a referral form - Refer serious misconduct by a teacher"
     )
-    expect(page).to have_content(
-      "We have received your report of serious misconduct"
-    )
+    expect(page).to have_content("You need to complete a referral form")
   end
 
   def then_i_see_the_employer_or_public_question


### PR DESCRIPTION
### Context

When someone completes the eligibility screener, they should see
guidance on the appropriate referral form they need to use.

### Changes proposed in this pull request

Currently, the forms are hosted on GOV.UK so we opted to hotlink to them
and accept the maintenance that comes with hotlinking. This is
preferable over having to host them in the service and keep them in sync
with the GOV.UK ones.

This change introduces a simple session based method to persist teh
eligibility check across multiple steps of the form.

It is anticipated that this will evolve into something like the
solutions on Find and Access.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1007" alt="Screenshot 2022-10-14 at 12 09 08 pm" src="https://user-images.githubusercontent.com/3126/195834482-67f81a9d-bcd8-43c0-be54-c4cbc09f29ef.png">
<img width="1029" alt="Screenshot 2022-10-14 at 12 08 26 pm" src="https://user-images.githubusercontent.com/3126/195834488-c4e54051-5afd-495c-b71b-98592c05c5c0.png">