### PR TITLE
Add okcomputer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "govuk_feature_flags",
     git: "https://github.com/DFE-Digital/govuk_feature_flags.git",
     branch: "main"
 gem "jsbundling-rails"
+gem "okcomputer", "~> 1.18"
 gem "pg", "~> 1.4"
 gem "propshaft"
 gem "puma", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,7 @@ GEM
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    okcomputer (1.18.4)
     pagy (5.10.1)
       activesupport
     parallel (1.22.1)
@@ -348,6 +349,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   govuk_feature_flags!
   jsbundling-rails
+  okcomputer (~> 1.18)
   pg (~> 1.4)
   prettier_print
   propshaft

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,7 @@
+OkComputer.logger = Rails.logger
+OkComputer.mount_at = "health"
+
+OkComputer::Registry.register "postgresql", OkComputer::ActiveRecordCheck.new
+OkComputer::Registry.register "version", OkComputer::AppVersionCheck.new
+
+OkComputer.make_optional %w[version]

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Health check", type: :request do
+  describe "GET /health" do
+    it "responds successfully" do
+      get "/health"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /health/all" do
+    it "responds successfully" do
+      get "/health/all"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /health/postgresql" do
+    it "responds successfully" do
+      get "/health/postgresql"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /health/version" do
+    it "responds successfully" do
+      get "/health/version"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
### Context

The app needs a health endpoint.

### Changes proposed in this pull request

Okcomputer is used commonly in other services and is a good fit here.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
