### PR TITLE
Add the "What this means for you" page

### DIFF
--- a/app/controllers/reporting_as_controller.rb
+++ b/app/controllers/reporting_as_controller.rb
@@ -9,7 +9,7 @@ class ReportingAsController < ApplicationController
       ReportingAsForm.new(reporting_as_params.merge(eligibility_check:))
     if @reporting_as_form.save
       session[:eligibility_check_id] = eligibility_check.id
-      redirect_to complete_path
+      redirect_to you_should_know_path
     else
       render :new
     end

--- a/app/views/pages/you_should_know.html.erb
+++ b/app/views/pages/you_should_know.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, "What completing this report means for you" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <h1 class="govuk-heading-xl">What completing this report means for you</h1>
+    <p class="govuk_body">
+      If TRA decide to investigate this allegation, it could result in the person you’re reporting being banned from teaching.
+    </p>
+
+    <p class="govuk_body">
+      You might need to attend a hearing of a professional conduct panel to give evidence, if the allegation reaches that stage.
+    </p>
+
+    <p class="govuk_body">
+      Your name and the allegation will be shared with the person you’re reporting, and any employer. Your contact details will not be shared.
+    </p>
+
+    <p class="govuk_body">A submitted report is kept for 50 years.</p>
+
+    <%= govuk_button_link_to 'Continue', complete_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9' %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get "/start", to: "pages#start"
   get "/who", to: "reporting_as#new"
   post "/who", to: "reporting_as#create"
+  get "/you-should-know", to: "pages#you_should_know"
 
   namespace :support_interface, path: "/support" do
     get "/", to: "support_interface#index"

--- a/spec/system/service_wizard_spec.rb
+++ b/spec/system/service_wizard_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe "Service wizard", type: :system do
     when_i_choose_reporting_as_an_employer
     when_i_press_continue
 
+    then_i_see_the_you_should_know_page
+    when_i_press_continue
+
     then_i_see_the_completion_page
   end
 
@@ -53,6 +56,14 @@ RSpec.describe "Service wizard", type: :system do
     expect(page).to have_content(
       "Are you reporting as an employer or member of the public?"
     )
+  end
+
+  def then_i_see_the_you_should_know_page
+    expect(page).to have_current_path("/you-should-know")
+    expect(page).to have_title(
+      "What completing this report means for you - Refer serious misconduct by a teacher"
+    )
+    expect(page).to have_content("What completing this report means for you")
   end
 
   def then_i_see_the_start_page


### PR DESCRIPTION
Prior to presenting the completion page in the eligilibility screener,
we want to set expectations about what will happen after referring
someone for serious misconduct.

The design is located at
https://teacher-misconduct.herokuapp.com/report/eligibility/you-should-know.

### Context

Include relevant motivation and context.

### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
