### PR TITLE
Add the serious misconduct screener question

### DIFF
--- a/app/controllers/reporting_as_controller.rb
+++ b/app/controllers/reporting_as_controller.rb
@@ -9,7 +9,7 @@ class ReportingAsController < ApplicationController
       ReportingAsForm.new(reporting_as_params.merge(eligibility_check:))
     if @reporting_as_form.save
       session[:eligibility_check_id] = eligibility_check.id
-      redirect_to you_should_know_path
+      redirect_to serious_path
     else
       render :new
     end

--- a/app/controllers/serious_misconduct_controller.rb
+++ b/app/controllers/serious_misconduct_controller.rb
@@ -1,0 +1,28 @@
+class SeriousMisconductController < ApplicationController
+  def new
+    @serious_misconduct_form = SeriousMisconductForm.new
+  end
+
+  def create
+    @serious_misconduct_form =
+      SeriousMisconductForm.new(
+        serious_misconduct_form_params.merge(eligibility_check:)
+      )
+    if @serious_misconduct_form.save
+      redirect_to @serious_misconduct_form.success_url
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def eligibility_check
+    @eligibility_check ||=
+      EligibilityCheck.find_by(id: session[:eligibility_check_id])
+  end
+
+  def serious_misconduct_form_params
+    params.require(:serious_misconduct_form).permit(:serious_misconduct)
+  end
+end

--- a/app/forms/serious_misconduct_form.rb
+++ b/app/forms/serious_misconduct_form.rb
@@ -1,0 +1,27 @@
+class SeriousMisconductForm
+  include ActiveModel::Model
+
+  attr_accessor :eligibility_check, :serious_misconduct
+
+  validates :eligibility_check, presence: true
+  validates :serious_misconduct, inclusion: { in: %w[yes no not_sure] }
+
+  def save
+    return false unless valid?
+
+    eligibility_check.serious_misconduct = serious_misconduct
+    eligibility_check.save
+  end
+
+  def eligible?
+    eligibility_check.serious_misconduct?
+  end
+
+  def success_url
+    unless eligible?
+      return Rails.application.routes.url_helpers.not_serious_misconduct_path
+    end
+
+    Rails.application.routes.url_helpers.you_should_know_path
+  end
+end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -2,15 +2,20 @@
 #
 # Table name: eligibility_checks
 #
-#  id           :bigint           not null, primary key
-#  reporting_as :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id                 :bigint           not null, primary key
+#  reporting_as       :string           not null
+#  serious_misconduct :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #
 class EligibilityCheck < ApplicationRecord
   validates :reporting_as, presence: true
 
   def reporting_as_employer?
     reporting_as&.to_sym == :employer
+  end
+
+  def serious_misconduct?
+    %w[yes not_sure].include?(serious_misconduct)
   end
 end

--- a/app/views/pages/not_serious_misconduct.html.erb
+++ b/app/views/pages/not_serious_misconduct.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title, 'You need to report this misconduct somewhere else' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You need to report this misconduct somewhere else</h1>
+
+    <p class="govuk_body">
+      The Teaching Regulation Agency (TRA) will not deal with cases relating to minor misconduct, or a teacher’s performance or competence.
+    </p>
+    <p class="govuk_body">You should:</p>
+    <ol class="govuk-list govuk-list--number">
+      <li>talk to the school or sixth-form college first to try to solve the problem.</li>
+      <li>contact the school’s board of governors or contact the council if you’re not happy with the response.</li>
+    </ol>
+    <p class="govuk_body">You’ll need to provide proof to support your complaint.</p>
+  </div>
+</div>

--- a/app/views/serious_misconduct/new.html.erb
+++ b/app/views/serious_misconduct/new.html.erb
@@ -1,0 +1,63 @@
+<% content_for :page_title, "#{'Error: ' if @serious_misconduct_form.errors.any?}Does the allegation involve serious misconduct?" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @serious_misconduct_form, url: serious_url, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-xl">Does the allegation involve serious misconduct?</h1>
+      <p class="govuk_body">Serious misconduct is unacceptable behaviour that:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+        <li>falls significantly short of the standards expected of a teacher </li>
+        <li>brings the teaching profession into disrepute</li>
+        <li>affects the way someone performs their teaching role</li>
+      </ul>
+      <p class="govuk_body">
+        If the person is convicted of a relevant offence at any time, this is also serious misconduct.
+      </p>
+
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Show examples of serious misconduct and relevant offences
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          
+          <p class="govuk_body">Examples might include:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>committing a criminal offence that results in imprisonment (including a suspended sentence)</li>
+            <li>violence</li>
+            <li>terrorism</li>
+            <li>inappropriate sexual activity</li>
+            <li>voyeurism (including upskirting)</li>
+            <li>revenge pornography (sharing private, sexual materials, either photos or videos, of another person without their consent)</li>
+            <li>sexual communication with a child</li>
+            <li>viewing, taking, making, possessing, distributing or publishing any indecent photograph or image of a child (or permitting any such activity)</li>
+            <li>child cruelty and/or neglect</li>
+            <li>controlling or coercive behaviour</li>
+            <li>harassing and/or stalking</li>
+            <li>intolerance and/or hatred on the grounds of race, religion, sexual orientation or any of the other protected characteristics</li>
+            <li>possessing, supplying or producing class A, B or C drugs</li>
+            <li>fraud or serious dishonesty</li>
+            <li>theft from a person or other serious theft</li>
+            <li>arson and other major criminal damage</li>
+            <li>possession of prohibited firearms, knives or other weapons</li>
+            <li>serious offences where alcohol or drugs are involved</li>
+          </ul>
+        </div>
+      </details>
+
+      <%= f.govuk_radio_buttons_fieldset :serious_misconduct, legend: { size: 'm', text: 'Is the allegation about serious misconduct?' } do %>
+        <%= f.hidden_field :serious_misconduct %>
+        <%= f.govuk_radio_button :serious_misconduct, "yes", label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :serious_misconduct, "no", label: { text: "No" } %>
+        <%= f.govuk_radio_button :serious_misconduct, "not_sure", label: { text: "I’m not sure" } do %>
+          <p class="govuk_body">
+            If you’re not sure, please continue to report your allegation and the Teaching Regulation Agency will assess it.
+          </p>
+        <% end %>
+      <% end %>
+      <%= f.govuk_submit prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,3 +11,7 @@ en:
           attributes:
             reporting_as:
               blank: Tell us if you are reporting as an employer or a member of the public
+        serious_misconduct_form:
+          attributes:
+            serious_misconduct:
+              inclusion: Tell us if you are reporting serious misconduct

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,14 @@
 Rails.application.routes.draw do
   root to: redirect("/start")
 
-  get "/complete", to: "pages#complete"
   get "/start", to: "pages#start"
   get "/who", to: "reporting_as#new"
   post "/who", to: "reporting_as#create"
   get "/you-should-know", to: "pages#you_should_know"
+  get "/serious", to: "serious_misconduct#new"
+  post "/serious", to: "serious_misconduct#create"
+  get "/not-serious-misconduct", to: "pages#not_serious_misconduct"
+  get "/complete", to: "pages#complete"
 
   namespace :support_interface, path: "/support" do
     get "/", to: "support_interface#index"

--- a/db/migrate/20221014132544_add_serious_misconduct_to_eligibility_check.rb
+++ b/db/migrate/20221014132544_add_serious_misconduct_to_eligibility_check.rb
@@ -1,0 +1,5 @@
+class AddSeriousMisconductToEligibilityCheck < ActiveRecord::Migration[7.0]
+  def change
+    add_column :eligibility_checks, :serious_misconduct, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_14_082246) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_14_132544) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_14_082246) do
     t.string "reporting_as", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "serious_misconduct"
   end
 
   create_table "feature_flags_features", force: :cascade do |t|

--- a/spec/forms/serious_misconduct_form_spec.rb
+++ b/spec/forms/serious_misconduct_form_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe SeriousMisconductForm, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:eligibility_check) }
+    it do
+      is_expected.to validate_inclusion_of(:serious_misconduct).in_array(
+        %w[yes no not_sure]
+      )
+    end
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    let(:eligibility_check) { EligibilityCheck.new }
+    let(:form) { described_class.new(eligibility_check:, serious_misconduct:) }
+    let(:serious_misconduct) { "yes" }
+
+    it { is_expected.to be_truthy }
+
+    context "when serious_misconduct is blank" do
+      let(:serious_misconduct) { "" }
+
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:eligibility_check) { EligibilityCheck.new }
+    let(:form) do
+      described_class.new(eligibility_check:, serious_misconduct: "yes")
+    end
+
+    it "saves the eligibility check" do
+      save
+      expect(eligibility_check.serious_misconduct).to be_truthy
+    end
+  end
+
+  describe "#eligible?" do
+    subject { described_class.new(eligibility_check:).eligible? }
+
+    let(:eligibility_check) { EligibilityCheck.new(serious_misconduct:) }
+
+    context "when there is serious misconduct" do
+      let(:serious_misconduct) { "yes" }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when there is not serious misconduct" do
+      let(:serious_misconduct) { "no" }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -2,10 +2,11 @@
 #
 # Table name: eligibility_checks
 #
-#  id           :bigint           not null, primary key
-#  reporting_as :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id                 :bigint           not null, primary key
+#  reporting_as       :string           not null
+#  serious_misconduct :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #
 require "rails_helper"
 
@@ -27,6 +28,28 @@ RSpec.describe EligibilityCheck, type: :model do
 
     context "when reporting_as is employer" do
       let(:reporting_as) { "employer" }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe "#serious_misconduct?" do
+    subject { described_class.new(serious_misconduct:).serious_misconduct? }
+
+    context "when the value is no" do
+      let(:serious_misconduct) { "no" }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when the value is yes" do
+      let(:serious_misconduct) { "yes" }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when the value is not_sure" do
+      let(:serious_misconduct) { "not_sure" }
 
       it { is_expected.to be_truthy }
     end

--- a/spec/system/eligibility_screener_spec.rb
+++ b/spec/system/eligibility_screener_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe "Service wizard", type: :system do
+RSpec.describe "Eligibility screener", type: :system do
   it "happy path" do
     given_the_service_is_open
     when_i_visit_the_service
@@ -10,24 +10,27 @@ RSpec.describe "Service wizard", type: :system do
     when_i_press_start
     then_i_see_the_employer_or_public_question
 
+    when_i_press_continue
+    then_i_see_a_validation_error
     when_i_choose_reporting_as_an_employer
+    when_i_press_continue
+    then_i_see_the_serious_misconduct_question
+
+    when_i_press_continue
+    then_i_see_a_validation_error
+    when_i_choose_not_sure
+    then_i_see_the_not_sure_hint
+    when_i_choose_no
+    when_i_press_continue
+    then_i_see_the_not_serious_misconduct_page
+    when_i_go_back
+    when_i_choose_yes
     when_i_press_continue
 
     then_i_see_the_you_should_know_page
     when_i_press_continue
 
     then_i_see_the_completion_page
-  end
-
-  it "form errors" do
-    given_the_service_is_open
-    when_i_visit_the_service
-    then_i_see_the_start_page
-
-    when_i_press_start
-    then_i_see_the_employer_or_public_question
-    when_i_press_continue
-    then_i_see_a_validation_error
   end
 
   private
@@ -58,6 +61,22 @@ RSpec.describe "Service wizard", type: :system do
     )
   end
 
+  def then_i_see_the_not_sure_hint
+    expect(page).to have_content(
+      "If you’re not sure, please continue to report your allegation and the Teaching Regulation Agency will assess it."
+    )
+  end
+
+  def then_i_see_the_not_serious_misconduct_page
+    expect(page).to have_current_path("/not-serious-misconduct")
+    expect(page).to have_title(
+      "You need to report this misconduct somewhere else - Refer serious misconduct by a teacher"
+    )
+    expect(page).to have_content(
+      "You need to report this misconduct somewhere else"
+    )
+  end
+
   def then_i_see_the_you_should_know_page
     expect(page).to have_current_path("/you-should-know")
     expect(page).to have_title(
@@ -66,14 +85,40 @@ RSpec.describe "Service wizard", type: :system do
     expect(page).to have_content("What completing this report means for you")
   end
 
+  def then_i_see_the_serious_misconduct_question
+    expect(page).to have_current_path("/serious")
+    expect(page).to have_title(
+      "Does the allegation involve serious misconduct? - Refer serious misconduct by a teacher"
+    )
+    expect(page).to have_content(
+      "Does the allegation involve serious misconduct?"
+    )
+  end
+
   def then_i_see_the_start_page
     expect(page).to have_current_path("/start")
     expect(page).to have_title("Refer serious misconduct by a teacher")
     expect(page).to have_content("Refer serious misconduct by a teacher")
   end
 
+  def when_i_choose_no
+    choose "No", visible: false
+  end
+
+  def when_i_choose_not_sure
+    choose "I’m not sure", visible: false
+  end
+
   def when_i_choose_reporting_as_an_employer
     choose "I’m reporting as an employer", visible: false
+  end
+
+  def when_i_choose_yes
+    choose "Yes", visible: false
+  end
+
+  def when_i_go_back
+    page.go_back
   end
 
   def when_i_press_continue


### PR DESCRIPTION
One of the questions in the screener asks if you are reporting serious
misconduct.

Choosing "no" prompts you to report the issue somewhere else.

Both "yes" and "I'm not sure" take you to the next step in the flow.

The "I'm not sure" option also displays a hint as to what to do next.

This question was created using the recently added form generator.

There is no back link present, nor any object orchestrating the question
order. These will be added in subsequent PRs.

I was using this question as a qay of verifying the form generator was
configured appropriately for the refer project.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

| Name | Screen |
| - | - |
| Default | <img width="996" alt="Screenshot 2022-10-17 at 12 42 07 pm" src="https://user-images.githubusercontent.com/3126/196169322-55123733-62aa-4324-a7fa-69710b93cf8b.png"> |
| Error | <img width="928" alt="Screenshot 2022-10-17 at 12 42 46 pm" src="https://user-images.githubusercontent.com/3126/196169450-7bf8dfea-456f-434b-a0b0-13388f5a9b60.png"> |
| Not sure |  <img width="786" alt="Screenshot 2022-10-17 at 12 43 10 pm" src="https://user-images.githubusercontent.com/3126/196169507-9f27a044-e1be-4156-a8ba-f84fe02d2f40.png"> |
| Choosing No | <img width="991" alt="Screenshot 2022-10-17 at 12 42 57 pm" src="https://user-images.githubusercontent.com/3126/196169558-8ccbc6c7-f8e9-4b2c-ac6e-eb6f9da79997.png"> |



