### PR TITLE
Add a support interface for eligibility checks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/govuk_feature_flags.git
-  revision: 4c6aa865094b769d9c3ac39bfccd6e8a07bcdd47
+  revision: 2d300b185543863c9b7d161863ed92ab85cac430
   branch: main
   specs:
     govuk_feature_flags (0.1.0)

--- a/app/controllers/support_interface/eligibility_checks_controller.rb
+++ b/app/controllers/support_interface/eligibility_checks_controller.rb
@@ -1,0 +1,7 @@
+module SupportInterface
+  class EligibilityChecksController < ApplicationController
+    def index
+      @eligibility_checks = EligibilityCheck.order(updated_at: :desc).limit(100)
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,26 @@ module ApplicationHelper
 
     link_to link[reporting_as][:title], link[reporting_as][:url]
   end
+
+  def current_namespace
+    request.path.split("/").second
+  end
+
+  def navigation
+    govuk_header(service_name: t('service.name')) do |header|
+      case current_namespace
+      when "support"
+        header.navigation_item(
+        active: current_page?(main_app.support_interface_eligibility_checks_path),
+        href: main_app.support_interface_eligibility_checks_path,
+        text: "Eligibility Checks",
+        ) 
+        header.navigation_item(
+          active: current_page?(main_app.support_interface_feature_flags_path),
+          href: main_app.support_interface_feature_flags_path,
+          text: "Features",
+        )
+      end
+    end
+  end
 end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -27,8 +27,8 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(service_name: t('service.name')) %>
-
+    <%= navigation %>
+  
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= yield %>

--- a/app/views/layouts/support_layout.html.erb
+++ b/app/views/layouts/support_layout.html.erb
@@ -1,1 +1,2 @@
+
 <%= render template: 'layouts/application' %>

--- a/app/views/support_interface/eligibility_checks/index.html.erb
+++ b/app/views/support_interface/eligibility_checks/index.html.erb
@@ -1,0 +1,33 @@
+<% content_for :page_title, 'Eligibility Checks' %>
+
+<h1 class="govuk-heading-l">
+  Eligibility Checks
+  <span class="govuk-caption-l">
+    Ordered by last updated, showing <%= "#{[100, EligibilityCheck.count].min} of #{EligibilityCheck.count}" %> total
+  </span>
+</h1>
+
+<% @eligibility_checks.each do |eligibility_check| %>
+  <h2 class="govuk-heading-m">Eligibility Check #<%= eligibility_check.id %></h2>
+  <%= govuk_summary_list do |summary_list|
+    summary_list.row do |row|
+      row.key(text: 'Created at')
+      row.value(text: eligibility_check.created_at)
+    end
+
+    summary_list.row do |row|
+      row.key(text: 'Updated at')
+      row.value(text: eligibility_check.updated_at)
+    end
+
+    summary_list.row do |row|
+      row.key(text: 'Reporting as')
+      row.value(text: eligibility_check.reporting_as)
+    end
+
+    summary_list.row do |row|
+      row.key(text: 'Serious misconduct')
+      row.value(text: eligibility_check.serious_misconduct)
+    end
+  end %>
+<% end %>

--- a/app/views/support_interface/support_interface/index.html.erb
+++ b/app/views/support_interface/support_interface/index.html.erb
@@ -1,1 +1,0 @@
-<h1 class="govuk-heading-xl">Support Interface</h1>

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,3 +1,4 @@
+layout: support_layout
 feature_flags:
   service_open:
     author: Felix Clack

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,10 @@ Rails.application.routes.draw do
   get "/complete", to: "pages#complete"
 
   namespace :support_interface, path: "/support" do
-    get "/", to: "support_interface#index"
+    resources :eligibility_checks, only: [:index]
     mount FeatureFlags::Engine => "/features"
+
+    root to: redirect("/support/eligibility_checks")
   end
 
   scope via: :all do

--- a/spec/system/support_spec.rb
+++ b/spec/system/support_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 
 RSpec.describe "Support", type: :system do
   it "visiting the support interface" do
+    given_an_eligibility_check_exists
     when_i_am_authorized_as_a_support_user
     and_i_visit_the_support_page
-    then_i_see_the_support_page
+    then_i_see_the_eligibility_checks_page
 
     when_i_visit_the_features_page
     then_i_see_the_feature_page
@@ -13,23 +14,30 @@ RSpec.describe "Support", type: :system do
 
   private
 
-  def when_i_am_authorized_as_a_support_user
-    page.driver.basic_authorize("test", "test")
-  end
-
   def and_i_visit_the_support_page
-    visit support_interface_path
+    visit support_interface_root_path
   end
 
-  def then_i_see_the_support_page
-    expect(page).to have_current_path(support_interface_path)
+  def given_an_eligibility_check_exists
+    EligibilityCheck.create(reporting_as: :employer, serious_misconduct: :yes)
   end
 
-  def when_i_visit_the_features_page
-    visit support_interface_feature_flags_path
+  def then_i_see_the_eligibility_checks_page
+    expect(page).to have_current_path(support_interface_eligibility_checks_path)
+    expect(page).to have_title("Eligibility Checks - Refer serious misconduct by a teacher")
+    expect(page).to have_content("Eligibility Checks")
+    expect(page).to have_content("1 of 1")
   end
 
   def then_i_see_the_feature_page
     expect(page).to have_content("Features")
+  end
+
+  def when_i_am_authorized_as_a_support_user
+    page.driver.basic_authorize("test", "test")
+  end
+
+  def when_i_visit_the_features_page
+    visit support_interface_feature_flags_path
   end
 end


### PR DESCRIPTION
### Context

We want a page in the support interface to provide some visibility into
the eligibility checks that are created by this service.

### Changes proposed in this pull request

Taking inspiration from [Find](https://github.com/DFE-Digital/find-a-lost-trn/pull/53), this change introduces
a basic implementation of a list of `EligibilityCheck`s.

The list is limited to the most recent 100 records. When the list
starts to exceed that limit in production, we can look at adding
pagination.

Also at this point, we haven't added any data anonymisation to this page
as there is nothing personal or specific stored yet. When that changes
we can revisit this decision.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1020" alt="Screenshot 2022-10-18 at 10 24 56 am" src="https://user-images.githubusercontent.com/3126/196394233-9f1f328d-a3c3-40cc-b868-1a73a90650dd.png">
