### PR TITLE
Add the teaching in England question

### DIFF
--- a/app/controllers/reporting_as_controller.rb
+++ b/app/controllers/reporting_as_controller.rb
@@ -9,7 +9,7 @@ class ReportingAsController < ApplicationController
       ReportingAsForm.new(reporting_as_params.merge(eligibility_check:))
     if @reporting_as_form.save
       session[:eligibility_check_id] = eligibility_check.id
-      redirect_to serious_path
+      redirect_to teaching_in_england_path
     else
       render :new
     end

--- a/app/controllers/teaching_in_england_controller.rb
+++ b/app/controllers/teaching_in_england_controller.rb
@@ -1,0 +1,28 @@
+class TeachingInEnglandController < ApplicationController
+  def new
+    @teaching_in_england_form = TeachingInEnglandForm.new
+  end
+
+  def create
+    @teaching_in_england_form =
+      TeachingInEnglandForm.new(
+        teaching_in_england_form_params.merge(eligibility_check:)
+      )
+    if @teaching_in_england_form.save
+      redirect_to @teaching_in_england_form.success_url
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def eligibility_check
+    @eligibility_check ||=
+      EligibilityCheck.find_by(id: session[:eligibility_check_id])
+  end
+
+  def teaching_in_england_form_params
+    params.require(:teaching_in_england_form).permit(:teaching_in_england)
+  end
+end

--- a/app/forms/teaching_in_england_form.rb
+++ b/app/forms/teaching_in_england_form.rb
@@ -1,0 +1,27 @@
+class TeachingInEnglandForm
+  include ActiveModel::Model
+
+  attr_accessor :eligibility_check, :teaching_in_england
+
+  validates :eligibility_check, presence: true
+  validates :teaching_in_england, inclusion: { in: %w[yes no not_sure] }
+
+  def save
+    return false unless valid?
+
+    eligibility_check.teaching_in_england = teaching_in_england
+    eligibility_check.save
+  end
+
+  def eligible?
+    eligibility_check.teaching_in_england?
+  end
+
+  def success_url
+    unless eligible?
+      return Rails.application.routes.url_helpers.no_jurisdiction_path
+    end
+
+    Rails.application.routes.url_helpers.serious_path
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,18 +22,19 @@ module ApplicationHelper
   end
 
   def navigation
-    govuk_header(service_name: t('service.name')) do |header|
+    govuk_header(service_name: t("service.name")) do |header|
       case current_namespace
       when "support"
         header.navigation_item(
-        active: current_page?(main_app.support_interface_eligibility_checks_path),
-        href: main_app.support_interface_eligibility_checks_path,
-        text: "Eligibility Checks",
-        ) 
+          active:
+            current_page?(main_app.support_interface_eligibility_checks_path),
+          href: main_app.support_interface_eligibility_checks_path,
+          text: "Eligibility Checks"
+        )
         header.navigation_item(
           active: current_page?(main_app.support_interface_feature_flags_path),
           href: main_app.support_interface_feature_flags_path,
-          text: "Features",
+          text: "Features"
         )
       end
     end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -2,11 +2,12 @@
 #
 # Table name: eligibility_checks
 #
-#  id                 :bigint           not null, primary key
-#  reporting_as       :string           not null
-#  serious_misconduct :string
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
+#  id                  :bigint           not null, primary key
+#  reporting_as        :string           not null
+#  serious_misconduct  :string
+#  teaching_in_england :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #
 class EligibilityCheck < ApplicationRecord
   validates :reporting_as, presence: true
@@ -17,5 +18,9 @@ class EligibilityCheck < ApplicationRecord
 
   def serious_misconduct?
     %w[yes not_sure].include?(serious_misconduct)
+  end
+
+  def teaching_in_england?
+    %w[yes not_sure].include?(teaching_in_england)
   end
 end

--- a/app/views/pages/no_jurisdiction.html.erb
+++ b/app/views/pages/no_jurisdiction.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, 'You need to make your referral somewhere else' %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You need to make your referral somewhere else</h1>
+    <p class="govuk_body">You can refer misconduct in Wales, Scotland or Northern&nbsp;Ireland by contacting:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the <a rel="external" href="http://www.ewc.wales/">Education Workforce Council for Wales</a></li>
+      <li>the <a rel="external" href="http://www.gtcs.org.uk/fitness-to-teach/process/referral.aspx">General Teaching Council for Scotland</a></li>
+      <li>the <a rel="external" href="https://gtcni.org.uk/regulation/making-a-referral">General Teaching Council for Northern Ireland</a></li>
+    </ul>
+  </div>
+</div>

--- a/app/views/support_interface/eligibility_checks/index.html.erb
+++ b/app/views/support_interface/eligibility_checks/index.html.erb
@@ -22,12 +22,17 @@
 
     summary_list.row do |row|
       row.key(text: 'Reporting as')
-      row.value(text: eligibility_check.reporting_as)
+      row.value(text: eligibility_check.reporting_as&.titleize)
+    end
+
+    summary_list.row do |row|
+      row.key(text: 'Teaching in England')
+      row.value(text: eligibility_check.teaching_in_england&.titleize)
     end
 
     summary_list.row do |row|
       row.key(text: 'Serious misconduct')
-      row.value(text: eligibility_check.serious_misconduct)
+      row.value(text: eligibility_check.serious_misconduct&.titleize)
     end
   end %>
 <% end %>

--- a/app/views/teaching_in_england/new.html.erb
+++ b/app/views/teaching_in_england/new.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title, "#{'Error: ' if @teaching_in_england_form.errors.any?}Were they carrying out teaching work in England at the time the alleged misconduct took place?" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @teaching_in_england_form, url: teaching_in_england_url, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_radio_buttons_fieldset :teaching_in_england, legend: { size: 'l', text: 'Were they carrying out teaching work in England at the time the alleged misconduct took place?' } do %>
+        <%= f.hidden_field :teaching_in_england %>
+        <%= f.govuk_radio_button :teaching_in_england, "yes", label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :teaching_in_england, "no", label: { text: "No" } %>
+        <%= f.govuk_radio_button :teaching_in_england, "not_sure", label: { text: "I’m not sure" } do %>
+          <p class="govuk_body">
+            If you’re not sure, please continue to report your allegation and the Teaching Regulation Agency will assess it.
+          </p>
+        <% end %>
+      <% end %>
+      <%= f.govuk_submit prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,13 @@ Rails.application.routes.draw do
   get "/start", to: "pages#start"
   get "/who", to: "reporting_as#new"
   post "/who", to: "reporting_as#create"
-  get "/you-should-know", to: "pages#you_should_know"
+  get "/teaching-in-england", to: "teaching_in_england#new"
+  post "/teaching-in-england", to: "teaching_in_england#create"
   get "/serious", to: "serious_misconduct#new"
   post "/serious", to: "serious_misconduct#create"
   get "/not-serious-misconduct", to: "pages#not_serious_misconduct"
+  get "/no-jurisdiction", to: "pages#no_jurisdiction"
+  get "/you-should-know", to: "pages#you_should_know"
   get "/complete", to: "pages#complete"
 
   namespace :support_interface, path: "/support" do

--- a/db/migrate/20221018093916_add_teaching_in_england_to_eligibility_check.rb
+++ b/db/migrate/20221018093916_add_teaching_in_england_to_eligibility_check.rb
@@ -1,0 +1,5 @@
+class AddTeachingInEnglandToEligibilityCheck < ActiveRecord::Migration[7.0]
+  def change
+    add_column :eligibility_checks, :teaching_in_england, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_14_132544) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_18_093916) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_14_132544) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "serious_misconduct"
+    t.string "teaching_in_england"
   end
 
   create_table "feature_flags_features", force: :cascade do |t|

--- a/spec/forms/teaching_in_england_form_spec.rb
+++ b/spec/forms/teaching_in_england_form_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe TeachingInEnglandForm, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:eligibility_check) }
+    it do
+      is_expected.to validate_inclusion_of(:teaching_in_england).in_array(
+        %w[yes no not_sure]
+      )
+    end
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    let(:eligibility_check) { EligibilityCheck.new }
+    let(:form) { described_class.new(eligibility_check:, teaching_in_england:) }
+    let(:teaching_in_england) { "yes" }
+
+    it { is_expected.to be_truthy }
+
+    context "when teaching_in_england is blank" do
+      let(:teaching_in_england) { "" }
+
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:eligibility_check) { EligibilityCheck.new }
+    let(:form) do
+      described_class.new(eligibility_check:, teaching_in_england: "yes")
+    end
+
+    it "saves the eligibility check" do
+      save
+      expect(eligibility_check.teaching_in_england).to be_truthy
+    end
+  end
+
+  describe "#eligible?" do
+    subject { described_class.new(eligibility_check:).eligible? }
+
+    let(:eligibility_check) { EligibilityCheck.new(teaching_in_england:) }
+
+    context "when they were teaching in England" do
+      let(:teaching_in_england) { "yes" }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when they were not teaching in England" do
+      let(:teaching_in_england) { "no" }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when they are not sure if they were teaching in England" do
+      let(:teaching_in_england) { "not_sure" }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+end

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -2,11 +2,12 @@
 #
 # Table name: eligibility_checks
 #
-#  id                 :bigint           not null, primary key
-#  reporting_as       :string           not null
-#  serious_misconduct :string
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
+#  id                  :bigint           not null, primary key
+#  reporting_as        :string           not null
+#  serious_misconduct  :string
+#  teaching_in_england :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #
 require "rails_helper"
 
@@ -50,6 +51,28 @@ RSpec.describe EligibilityCheck, type: :model do
 
     context "when the value is not_sure" do
       let(:serious_misconduct) { "not_sure" }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe "#teaching_in_england?" do
+    subject { described_class.new(teaching_in_england:).teaching_in_england? }
+
+    context "when the value is no" do
+      let(:teaching_in_england) { "no" }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when the value is yes" do
+      let(:teaching_in_england) { "yes" }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when the value is not_sure" do
+      let(:teaching_in_england) { "not_sure" }
 
       it { is_expected.to be_truthy }
     end

--- a/spec/system/eligibility_screener_spec.rb
+++ b/spec/system/eligibility_screener_spec.rb
@@ -14,8 +14,20 @@ RSpec.describe "Eligibility screener", type: :system do
     then_i_see_a_validation_error
     when_i_choose_reporting_as_an_employer
     when_i_press_continue
-    then_i_see_the_serious_misconduct_question
 
+    then_i_see_the_teaching_in_england_page
+    when_i_press_continue
+    then_i_see_a_validation_error
+    when_i_choose_not_sure
+    then_i_see_the_not_sure_hint
+    when_i_choose_no
+    when_i_press_continue
+    then_i_see_the_no_jurisdiction_page
+    when_i_go_back
+    when_i_choose_yes
+    when_i_press_continue
+
+    then_i_see_the_serious_misconduct_question
     when_i_press_continue
     then_i_see_a_validation_error
     when_i_choose_not_sure
@@ -61,6 +73,16 @@ RSpec.describe "Eligibility screener", type: :system do
     )
   end
 
+  def then_i_see_the_no_jurisdiction_page
+    expect(page).to have_current_path("/no-jurisdiction")
+    expect(page).to have_title(
+      "You need to make your referral somewhere else - Refer serious misconduct by a teacher"
+    )
+    expect(page).to have_content(
+      "You need to make your referral somewhere else"
+    )
+  end
+
   def then_i_see_the_not_sure_hint
     expect(page).to have_content(
       "If you’re not sure, please continue to report your allegation and the Teaching Regulation Agency will assess it."
@@ -74,6 +96,19 @@ RSpec.describe "Eligibility screener", type: :system do
     )
     expect(page).to have_content(
       "You need to report this misconduct somewhere else"
+    )
+  end
+
+  def then_i_see_the_teaching_in_england_page
+    expect(page).to have_current_path("/teaching-in-england")
+    expect(page).to have_title(
+      [
+        "Were they carrying out teaching work in England at the time the alleged misconduct took place?",
+        "Refer serious misconduct by a teacher"
+      ].join(" - ")
+    )
+    expect(page).to have_content(
+      "Were they carrying out teaching work in England at the time the alleged misconduct took place?"
     )
   end
 

--- a/spec/system/support_spec.rb
+++ b/spec/system/support_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe "Support", type: :system do
 
   def then_i_see_the_eligibility_checks_page
     expect(page).to have_current_path(support_interface_eligibility_checks_path)
-    expect(page).to have_title("Eligibility Checks - Refer serious misconduct by a teacher")
+    expect(page).to have_title(
+      "Eligibility Checks - Refer serious misconduct by a teacher"
+    )
     expect(page).to have_content("Eligibility Checks")
     expect(page).to have_content("1 of 1")
   end


### PR DESCRIPTION
The screener includes a question to determine if the person being
referred was teaching in England at the time of alleged offence.

This helps establish jurisdiction.

If the answer is no, then we display a no jurisdiction message and end
the screener at that point.

If the answer is yes or not sure, then we continue with the next
question.

With the addition of this question, the need for an object to
orchestrate the order of the questions is becoming more pressing.

This will happen in an upcoming PR and again will take inspiration from
the implementation in Find.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1000" alt="Screenshot 2022-10-18 at 11 39 39 am" src="https://user-images.githubusercontent.com/3126/196410464-dec719be-1f97-4e34-8b51-ac25ae927cd6.png">

