### PR TITLE
Enforce question order

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,10 @@ inherit_mode:
   merge:
     - Exclude
 
+Rails/ApplicationController:
+  Exclude:
+    - app/controllers/support_interface/support_interface_controller.rb
+
 Rails/SaveBang:
   Enabled: false
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include EnforceQuestionOrder
+
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 
   http_basic_authenticate_with name: ENV.fetch("SUPPORT_USERNAME", nil),

--- a/app/controllers/concerns/enforce_question_order.rb
+++ b/app/controllers/concerns/enforce_question_order.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+module EnforceQuestionOrder
+  extend ActiveSupport::Concern
+
+  included { before_action :redirect_to_next_question }
+
+  def redirect_to_next_question
+    redirect_to(start_url) and return if start_page_is_required?
+    return if all_questions_answered?
+    return if previous_question_answered?
+
+    redirect_to next_question_path if request.path != next_question_path
+  end
+
+  def next_question
+    session[:eligibility_check_id] ||= eligibility_check.reload.id
+
+    redirect_to next_question_path
+  end
+
+  private
+
+  def eligibility_check
+    @eligibility_check ||=
+      EligibilityCheck.find_or_initialize_by(id: session[:eligibility_check_id])
+  end
+
+  def start_page_is_required?
+    (eligibility_check.nil? || eligibility_check.new_record?) &&
+      request.path != who_path
+  end
+
+  def questions
+    [
+      { path: who_path, needs_answer: ask_for_reporting_as? },
+      {
+        path: teaching_in_england_path,
+        needs_answer: ask_for_teaching_in_england?
+      },
+      { path: no_jurisdiction_path, needs_answer: ask_for_no_jurisdiction? },
+      { path: serious_path, needs_answer: ask_for_serious_misconduct? },
+      { path: you_should_know_path, needs_answer: false },
+      {
+        path: not_serious_misconduct_path,
+        needs_answer: ask_for_not_serious_misconduct?
+      }
+    ]
+  end
+
+  def next_question_path
+    questions.each { |q| return q[:path] if q[:needs_answer] }
+
+    you_should_know_path
+  end
+
+  def all_questions_answered?
+    questions.none? { |q| q[:needs_answer] }
+  end
+
+  def previous_question_answered?
+    requested_question_index =
+      questions.find_index { |q| q[:path] == request.path }
+
+    path_is_not_a_question = requested_question_index.nil?
+    return false if path_is_not_a_question
+
+    is_first_question = requested_question_index.zero?
+    return true if is_first_question
+
+    previous_question = questions[requested_question_index - 1]
+
+    previous_question[:needs_answer] == false
+  end
+
+  def ask_for_reporting_as?
+    eligibility_check.reporting_as.nil?
+  end
+
+  def ask_for_teaching_in_england?
+    eligibility_check.teaching_in_england.nil?
+  end
+
+  def ask_for_no_jurisdiction?
+    !eligibility_check.teaching_in_england?
+  end
+
+  def ask_for_serious_misconduct?
+    return false unless eligibility_check.teaching_in_england?
+
+    eligibility_check.serious_misconduct.nil?
+  end
+
+  def ask_for_not_serious_misconduct?
+    !eligibility_check.serious_misconduct?
+  end
+
+  def ask_for_you_should_know?
+    eligibility_check.serious_misconduct?
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,11 @@
 class PagesController < ApplicationController
+  skip_before_action :redirect_to_next_question, only: %i[start complete]
+
   def complete
-    @eligibility_check = EligibilityCheck.find(session[:eligibility_check_id])
+    @eligibility_check =
+      EligibilityCheck.find_by(id: session[:eligibility_check_id])
+    return redirect_to(start_path) if @eligibility_check.nil?
+    reset_session
   end
 
   def start

--- a/app/controllers/reporting_as_controller.rb
+++ b/app/controllers/reporting_as_controller.rb
@@ -4,12 +4,11 @@ class ReportingAsController < ApplicationController
   end
 
   def create
-    eligibility_check = EligibilityCheck.new
     @reporting_as_form =
       ReportingAsForm.new(reporting_as_params.merge(eligibility_check:))
     if @reporting_as_form.save
       session[:eligibility_check_id] = eligibility_check.id
-      redirect_to teaching_in_england_path
+      next_question
     else
       render :new
     end

--- a/app/controllers/serious_misconduct_controller.rb
+++ b/app/controllers/serious_misconduct_controller.rb
@@ -9,18 +9,13 @@ class SeriousMisconductController < ApplicationController
         serious_misconduct_form_params.merge(eligibility_check:)
       )
     if @serious_misconduct_form.save
-      redirect_to @serious_misconduct_form.success_url
+      next_question
     else
       render :new
     end
   end
 
   private
-
-  def eligibility_check
-    @eligibility_check ||=
-      EligibilityCheck.find_by(id: session[:eligibility_check_id])
-  end
 
   def serious_misconduct_form_params
     params.require(:serious_misconduct_form).permit(:serious_misconduct)

--- a/app/controllers/support_interface/eligibility_checks_controller.rb
+++ b/app/controllers/support_interface/eligibility_checks_controller.rb
@@ -1,5 +1,5 @@
 module SupportInterface
-  class EligibilityChecksController < ApplicationController
+  class EligibilityChecksController < SupportInterfaceController
     def index
       @eligibility_checks = EligibilityCheck.order(updated_at: :desc).limit(100)
     end

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 module SupportInterface
-  class SupportInterfaceController < ApplicationController
+  class SupportInterfaceController < ActionController::Base
     layout "support_layout"
 
     http_basic_authenticate_with name: ENV["SUPPORT_USERNAME"],
                                  password: ENV["SUPPORT_PASSWORD"]
-
-    def index
-    end
   end
 end

--- a/app/controllers/teaching_in_england_controller.rb
+++ b/app/controllers/teaching_in_england_controller.rb
@@ -9,7 +9,7 @@ class TeachingInEnglandController < ApplicationController
         teaching_in_england_form_params.merge(eligibility_check:)
       )
     if @teaching_in_england_form.save
-      redirect_to @teaching_in_england_form.success_url
+      next_question
     else
       render :new
     end

--- a/app/forms/serious_misconduct_form.rb
+++ b/app/forms/serious_misconduct_form.rb
@@ -12,16 +12,4 @@ class SeriousMisconductForm
     eligibility_check.serious_misconduct = serious_misconduct
     eligibility_check.save
   end
-
-  def eligible?
-    eligibility_check.serious_misconduct?
-  end
-
-  def success_url
-    unless eligible?
-      return Rails.application.routes.url_helpers.not_serious_misconduct_path
-    end
-
-    Rails.application.routes.url_helpers.you_should_know_path
-  end
 end

--- a/app/forms/teaching_in_england_form.rb
+++ b/app/forms/teaching_in_england_form.rb
@@ -12,16 +12,4 @@ class TeachingInEnglandForm
     eligibility_check.teaching_in_england = teaching_in_england
     eligibility_check.save
   end
-
-  def eligible?
-    eligibility_check.teaching_in_england?
-  end
-
-  def success_url
-    unless eligible?
-      return Rails.application.routes.url_helpers.no_jurisdiction_path
-    end
-
-    Rails.application.routes.url_helpers.serious_path
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,17 @@
 Rails.application.routes.draw do
-  root to: redirect("/start")
-
   get "/start", to: "pages#start"
   get "/who", to: "reporting_as#new"
   post "/who", to: "reporting_as#create"
   get "/teaching-in-england", to: "teaching_in_england#new"
   post "/teaching-in-england", to: "teaching_in_england#create"
+  get "/no-jurisdiction", to: "pages#no_jurisdiction"
   get "/serious", to: "serious_misconduct#new"
   post "/serious", to: "serious_misconduct#create"
   get "/not-serious-misconduct", to: "pages#not_serious_misconduct"
-  get "/no-jurisdiction", to: "pages#no_jurisdiction"
   get "/you-should-know", to: "pages#you_should_know"
   get "/complete", to: "pages#complete"
+
+  root to: redirect("/start")
 
   namespace :support_interface, path: "/support" do
     resources :eligibility_checks, only: [:index]

--- a/lib/generators/form/templates/form.erb
+++ b/lib/generators/form/templates/form.erb
@@ -8,7 +8,7 @@ attr_reader <%= attributes.map { |attribute| ":#{attribute.name}" }.join(', ') %
 
   validates :eligibility_check, presence: true
   <% attributes.map do |attribute| -%>
-  validates :<%= attribute.name %>, <%= attribute.type == :boolean ? "inclusion: { in: [true, false] }" : "presence: true" %>
+validates :<%= attribute.name %>, <%= attribute.type == :boolean ? "inclusion: { in: [true, false] }" : "presence: true" %>
   <% end -%>
 
   <% attributes.map do |attribute| -%>
@@ -24,19 +24,5 @@ def <%= attribute.name %>=(value)
 eligibility_check.<%= attribute.name %> = <%= attribute.name %>
     <% end -%>
 eligibility_check.save
-  end
-
-  def eligible?
-    <%= attributes.map { |attribute| "eligibility_check.#{attribute.name}" }.join(' && ') %>
-  end
-
-  def success_url
-    return Rails.application.routes.url_helpers.ineligible_path unless eligible?
-
-    Rails
-      .application
-      .routes
-      .url_helpers
-      .<%= plural_name %>_path
   end
 end

--- a/lib/generators/form/templates/form_controller.erb
+++ b/lib/generators/form/templates/form_controller.erb
@@ -6,7 +6,7 @@ class <%= plural_name.camelize %>Controller < BaseController
   def create
     @<%= model_resource_name %>_form = <%= class_name %>Form.new(<%= model_resource_name %>_form_params.merge(eligibility_check:))
     if @<%= model_resource_name %>_form.save
-      redirect_to @<%= model_resource_name %>_form.success_url
+      next_question
     else
       render :new
     end

--- a/spec/forms/serious_misconduct_form_spec.rb
+++ b/spec/forms/serious_misconduct_form_spec.rb
@@ -39,22 +39,4 @@ RSpec.describe SeriousMisconductForm, type: :model do
       expect(eligibility_check.serious_misconduct).to be_truthy
     end
   end
-
-  describe "#eligible?" do
-    subject { described_class.new(eligibility_check:).eligible? }
-
-    let(:eligibility_check) { EligibilityCheck.new(serious_misconduct:) }
-
-    context "when there is serious misconduct" do
-      let(:serious_misconduct) { "yes" }
-
-      it { is_expected.to be_truthy }
-    end
-
-    context "when there is not serious misconduct" do
-      let(:serious_misconduct) { "no" }
-
-      it { is_expected.to be_falsey }
-    end
-  end
 end

--- a/spec/forms/teaching_in_england_form_spec.rb
+++ b/spec/forms/teaching_in_england_form_spec.rb
@@ -39,28 +39,4 @@ RSpec.describe TeachingInEnglandForm, type: :model do
       expect(eligibility_check.teaching_in_england).to be_truthy
     end
   end
-
-  describe "#eligible?" do
-    subject { described_class.new(eligibility_check:).eligible? }
-
-    let(:eligibility_check) { EligibilityCheck.new(teaching_in_england:) }
-
-    context "when they were teaching in England" do
-      let(:teaching_in_england) { "yes" }
-
-      it { is_expected.to be_truthy }
-    end
-
-    context "when they were not teaching in England" do
-      let(:teaching_in_england) { "no" }
-
-      it { is_expected.to be_falsey }
-    end
-
-    context "when they are not sure if they were teaching in England" do
-      let(:teaching_in_england) { "not_sure" }
-
-      it { is_expected.to be_truthy }
-    end
-  end
 end

--- a/spec/system/question_order_spec.rb
+++ b/spec/system/question_order_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Question order", type: :system do
+  it "is enforced correctly" do
+    given_the_service_is_open
+    when_i_visit_the_service
+    then_i_see_the_start_page
+
+    when_i_visit_the_teaching_in_england_page
+    then_i_see_the_start_page
+
+    when_i_visit_the_serious_misconduct_page
+    then_i_see_the_start_page
+
+    when_i_visit_you_should_know_page
+    then_i_see_the_start_page
+
+    when_i_visit_the_complete_page
+    then_i_see_the_start_page
+
+    when_i_press_start
+    when_i_choose_employer
+    when_i_press_continue
+    then_i_see_the_teaching_in_england_page
+
+    when_i_visit_the_serious_misconduct_page
+    then_i_see_the_teaching_in_england_page
+  end
+
+  private
+
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def then_i_see_the_reporting_as_page
+    expect(page).to have_current_path("/who")
+  end
+
+  def then_i_see_the_start_page
+    expect(page).to have_current_path("/start")
+  end
+
+  def then_i_see_the_teaching_in_england_page
+    expect(page).to have_current_path("/teaching-in-england")
+  end
+
+  def when_i_choose_employer
+    choose "I’m reporting as an employer", visible: false
+  end
+
+  def when_i_press_continue
+    click_on "Continue"
+  end
+
+  def when_i_press_start
+    click_link "Start now"
+  end
+
+  def when_i_visit_the_complete_page
+    visit complete_path
+  end
+
+  def when_i_visit_the_serious_misconduct_page
+    visit serious_path
+  end
+
+  def when_i_visit_the_service
+    visit root_path
+  end
+
+  def when_i_visit_you_should_know_page
+    visit you_should_know_path
+  end
+
+  def when_i_visit_the_teaching_in_england_page
+    visit teaching_in_england_path
+  end
+end

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
     then_i_see_the_start_page
 
     when_i_press_start
+    then_i_see_the_teaching_in_england_page
+
+    when_i_choose_yes
+    when_i_press_continue
     then_i_see_the_employer_or_public_question
 
     when_i_choose_reporting_as_an_employer
@@ -59,8 +63,16 @@ RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
     expect(page).to have_content("Refer serious misconduct by a teacher")
   end
 
+  def then_i_see_the_teaching_in_england_page
+    expect(page).to have_current_path("/teaching-in-england")
+  end
+
   def when_i_choose_reporting_as_an_employer
     choose "I’m reporting as an employer", visible: false
+  end
+
+  def when_i_choose_yes
+    choose "Yes", visible: false
   end
 
   def when_i_press_continue


### PR DESCRIPTION
We want to extract the question order into a single location so that
changes to the order don't cascade throughout the form objects.

This is based on the implementation in Find.

`EnforceQuestionOrder` holds all the logic required to derive the next
question for the current eligibility check.

The last couple of screens in this flow are exceptions to the
implementation as they aren't questions with a persistable answer.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
