### PR TITLE
Add the "is a teacher" question

### DIFF
--- a/app/controllers/concerns/enforce_question_order.rb
+++ b/app/controllers/concerns/enforce_question_order.rb
@@ -32,26 +32,17 @@ module EnforceQuestionOrder
 
   def questions
     [
-      { path: who_path, needs_answer: ask_for_reporting_as? },
+      { path: who_path, needs_answer: reporting_as_needs_answer? },
+      { path: is_a_teacher_path, needs_answer: is_a_teacher_needs_answer? },
       {
         path: unsupervised_teaching_path,
-        needs_answer: ask_for_unsupervised_teaching?
-      },
-      {
-        path: no_jurisdiction_unsupervised_path,
-        needs_answer: ask_for_no_jurisdiction_unsupervised?
+        needs_answer: unsupervised_teaching_needs_answer?
       },
       {
         path: teaching_in_england_path,
-        needs_answer: ask_for_teaching_in_england?
+        needs_answer: teaching_in_england_needs_answer?
       },
-      { path: no_jurisdiction_path, needs_answer: ask_for_no_jurisdiction? },
-      { path: serious_path, needs_answer: ask_for_serious_misconduct? },
-      { path: you_should_know_path, needs_answer: false },
-      {
-        path: not_serious_misconduct_path,
-        needs_answer: ask_for_not_serious_misconduct?
-      }
+      { path: serious_path, needs_answer: serious_misconduct_needs_answer? }
     ]
   end
 
@@ -77,42 +68,28 @@ module EnforceQuestionOrder
 
     previous_question = questions[requested_question_index - 1]
 
-    previous_question[:needs_answer] == false
+    !previous_question[:needs_answer]
   end
 
-  def ask_for_reporting_as?
+  def reporting_as_needs_answer?
     eligibility_check.reporting_as.nil?
   end
 
-  def ask_for_unsupervised_teaching?
+  def unsupervised_teaching_needs_answer?
+    return false if eligibility_check.is_teacher?
+
     eligibility_check.unsupervised_teaching.nil?
   end
 
-  def ask_for_no_jurisdiction_unsupervised?
-    !eligibility_check.unsupervised_teaching?
+  def is_a_teacher_needs_answer?
+    eligibility_check.is_teacher.nil?
   end
 
-  def ask_for_teaching_in_england?
-    return false unless eligibility_check.unsupervised_teaching?
-
+  def teaching_in_england_needs_answer?
     eligibility_check.teaching_in_england.nil?
   end
 
-  def ask_for_no_jurisdiction?
-    !eligibility_check.teaching_in_england?
-  end
-
-  def ask_for_serious_misconduct?
-    return false unless eligibility_check.teaching_in_england?
-
+  def serious_misconduct_needs_answer?
     eligibility_check.serious_misconduct.nil?
-  end
-
-  def ask_for_not_serious_misconduct?
-    !eligibility_check.serious_misconduct?
-  end
-
-  def ask_for_you_should_know?
-    eligibility_check.serious_misconduct?
   end
 end

--- a/app/controllers/is_teacher_controller.rb
+++ b/app/controllers/is_teacher_controller.rb
@@ -1,0 +1,21 @@
+class IsTeacherController < ApplicationController
+  def new
+    @is_teacher_form = IsTeacherForm.new
+  end
+
+  def create
+    @is_teacher_form =
+      IsTeacherForm.new(is_teacher_form_params.merge(eligibility_check:))
+    if @is_teacher_form.save
+      next_question
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def is_teacher_form_params
+    params.require(:is_teacher_form).permit(:is_teacher)
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :redirect_to_next_question, only: %i[start complete]
+  skip_before_action :redirect_to_next_question
 
   def complete
     @eligibility_check =

--- a/app/controllers/serious_misconduct_controller.rb
+++ b/app/controllers/serious_misconduct_controller.rb
@@ -9,7 +9,11 @@ class SeriousMisconductController < ApplicationController
         serious_misconduct_form_params.merge(eligibility_check:)
       )
     if @serious_misconduct_form.save
-      next_question
+      if eligibility_check.serious_misconduct?
+        next_question
+      else
+        redirect_to(not_serious_misconduct_path)
+      end
     else
       render :new
     end

--- a/app/controllers/teaching_in_england_controller.rb
+++ b/app/controllers/teaching_in_england_controller.rb
@@ -9,7 +9,11 @@ class TeachingInEnglandController < ApplicationController
         teaching_in_england_form_params.merge(eligibility_check:)
       )
     if @teaching_in_england_form.save
-      next_question
+      if eligibility_check.teaching_in_england?
+        next_question
+      else
+        redirect_to(no_jurisdiction_path)
+      end
     else
       render :new
     end

--- a/app/controllers/unsupervised_teaching_controller.rb
+++ b/app/controllers/unsupervised_teaching_controller.rb
@@ -9,7 +9,11 @@ class UnsupervisedTeachingController < ApplicationController
         unsupervised_teaching_form_params.merge(eligibility_check:)
       )
     if @unsupervised_teaching_form.save
-      next_question
+      if eligibility_check.unsupervised_teaching?
+        next_question
+      else
+        redirect_to(no_jurisdiction_unsupervised_path)
+      end
     else
       render :new
     end

--- a/app/forms/is_teacher_form.rb
+++ b/app/forms/is_teacher_form.rb
@@ -1,0 +1,15 @@
+class IsTeacherForm
+  include ActiveModel::Model
+
+  attr_accessor :eligibility_check, :is_teacher
+
+  validates :eligibility_check, presence: true
+  validates :is_teacher, inclusion: { in: %w[yes no not_sure] }
+
+  def save
+    return false unless valid?
+
+    eligibility_check.is_teacher = is_teacher
+    eligibility_check.save
+  end
+end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -3,6 +3,7 @@
 # Table name: eligibility_checks
 #
 #  id                    :bigint           not null, primary key
+#  is_teacher            :string
 #  reporting_as          :string           not null
 #  serious_misconduct    :string
 #  teaching_in_england   :string
@@ -12,6 +13,10 @@
 #
 class EligibilityCheck < ApplicationRecord
   validates :reporting_as, presence: true
+
+  def is_teacher?
+    %w[yes not_sure].include?(is_teacher)
+  end
 
   def reporting_as_employer?
     reporting_as&.to_sym == :employer

--- a/app/views/is_teacher/new.html.erb
+++ b/app/views/is_teacher/new.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, "#{'Error: ' if @is_teacher_form.errors.any?}Is the allegation about a teacher?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @is_teacher_form, url: is_a_teacher_url, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_radio_buttons_fieldset :is_teacher, legend: { size: 'xl', text: 'Is the allegation about a teacher?' } do %>
+        <%= f.hidden_field :is_teacher %>
+        <%= f.govuk_radio_button :is_teacher, "yes", label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :is_teacher, "no", label: { text: "No" } %>
+        <%= f.govuk_radio_button :is_teacher, "not_sure", label: { text: "I’m not sure" } do %>
+          <p class="govuk_body">
+            If you’re not sure, please continue to report your allegation and the Teaching Regulation Agency will assess it.
+          </p>
+        <% end %>
+      <% end %>
+      <%= f.govuk_submit prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/pages/no_jurisdiction.html.erb
+++ b/app/views/pages/no_jurisdiction.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, 'You need to make your referral somewhere else' %>
-
+<% content_for :back_link_url, url_for(:back) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/no_jurisdiction_unsupervised.html.erb
+++ b/app/views/pages/no_jurisdiction_unsupervised.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, 'You need to report this misconduct somewhere else' %>
+<% content_for :back_link_url, url_for(:back) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/not_serious_misconduct.html.erb
+++ b/app/views/pages/not_serious_misconduct.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, 'You need to report this misconduct somewhere else' %>
+<% content_for :back_link_url, url_for(:back) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,22 +7,26 @@ en:
   activemodel:
     errors:
       models:
+        is_teacher_form:
+          attributes:
+            is_teacher:
+              inclusion: Tell us if the allegation is about a teacher
         reporting_as_form:
           attributes:
             reporting_as:
               blank: Tell us if you are reporting as an employer or a member of the public
-        teaching_unsupervised_form:
-          attributes:
-            teaching_unsupervised:
-              blank: Tell us if the teacher was teaching unsupervised
-        teaching_in_england_form:
-          attributes:
-            teaching_in_england:
-              inclusion: Tell us if you are reporting a teacher who is teaching in England
         serious_misconduct_form:
           attributes:
             serious_misconduct:
               inclusion: Tell us if you are reporting serious misconduct
+        teaching_in_england_form:
+          attributes:
+            teaching_in_england:
+              inclusion: Tell us if you are reporting a teacher who is teaching in England
+        unsupervised_teaching_form:
+          attributes:
+            unsupervised_teaching:
+              blank: Tell us if they were teaching unsupervised
 
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   get "/start", to: "pages#start"
   get "/who", to: "reporting_as#new"
   post "/who", to: "reporting_as#create"
+  get "/is-a-teacher", to: "is_teacher#new"
+  post "/is-a-teacher", to: "is_teacher#create"
   get "/unsupervised-teaching", to: "unsupervised_teaching#new"
   post "/unsupervised-teaching", to: "unsupervised_teaching#create"
   get "/no-jurisdiction-unsupervised", to: "pages#no_jurisdiction_unsupervised"

--- a/db/migrate/20221019094346_add_is_teacher_to_eligibility_check.rb
+++ b/db/migrate/20221019094346_add_is_teacher_to_eligibility_check.rb
@@ -1,0 +1,5 @@
+class AddIsTeacherToEligibilityCheck < ActiveRecord::Migration[7.0]
+  def change
+    add_column :eligibility_checks, :is_teacher, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_18_131100) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_19_094346) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_18_131100) do
     t.string "serious_misconduct"
     t.string "teaching_in_england"
     t.string "unsupervised_teaching"
+    t.string "is_teacher"
   end
 
   create_table "feature_flags_features", force: :cascade do |t|

--- a/spec/forms/is_teacher_form_spec.rb
+++ b/spec/forms/is_teacher_form_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe IsTeacherForm, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:eligibility_check) }
+    it do
+      is_expected.to validate_inclusion_of(:is_teacher).in_array(
+        %w[yes no not_sure]
+      )
+    end
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    let(:eligibility_check) { EligibilityCheck.new }
+    let(:form) { described_class.new(eligibility_check:, is_teacher:) }
+    let(:is_teacher) { "yes" }
+
+    it { is_expected.to be_truthy }
+
+    context "when is_teacher is blank" do
+      let(:is_teacher) { "" }
+
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:eligibility_check) { EligibilityCheck.new }
+    let(:form) { described_class.new(eligibility_check:, is_teacher: "yes") }
+
+    it "saves the eligibility check" do
+      save
+      expect(eligibility_check.is_teacher).to be_truthy
+    end
+  end
+end

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -3,6 +3,7 @@
 # Table name: eligibility_checks
 #
 #  id                    :bigint           not null, primary key
+#  is_teacher            :string
 #  reporting_as          :string           not null
 #  serious_misconduct    :string
 #  teaching_in_england   :string

--- a/spec/system/eligibility_screener_spec.rb
+++ b/spec/system/eligibility_screener_spec.rb
@@ -14,8 +14,14 @@ RSpec.describe "Eligibility screener", type: :system do
     then_i_see_a_validation_error
     when_i_choose_reporting_as_an_employer
     when_i_press_continue
+    then_i_see_the_is_a_teacher_page
 
+    when_i_press_continue
+    then_i_see_a_validation_error
+    when_i_choose_no
+    when_i_press_continue
     then_i_see_the_unsupervised_teaching_page
+
     when_i_press_continue
     then_i_see_a_validation_error
     when_i_choose_not_sure
@@ -26,8 +32,8 @@ RSpec.describe "Eligibility screener", type: :system do
     when_i_go_back
     when_i_choose_yes
     when_i_press_continue
-
     then_i_see_the_teaching_in_england_page
+
     when_i_press_continue
     then_i_see_a_validation_error
     when_i_choose_not_sure
@@ -38,8 +44,8 @@ RSpec.describe "Eligibility screener", type: :system do
     when_i_go_back
     when_i_choose_yes
     when_i_press_continue
-
     then_i_see_the_serious_misconduct_question
+
     when_i_press_continue
     then_i_see_a_validation_error
     when_i_choose_not_sure
@@ -50,10 +56,9 @@ RSpec.describe "Eligibility screener", type: :system do
     when_i_go_back
     when_i_choose_yes
     when_i_press_continue
-
     then_i_see_the_you_should_know_page
-    when_i_press_continue
 
+    when_i_press_continue
     then_i_see_the_completion_page
   end
 
@@ -83,6 +88,14 @@ RSpec.describe "Eligibility screener", type: :system do
     expect(page).to have_content(
       "Are you reporting as an employer or member of the public?"
     )
+  end
+
+  def then_i_see_the_is_a_teacher_page
+    expect(page).to have_current_path("/is-a-teacher")
+    expect(page).to have_title(
+      "Is the allegation about a teacher? - Refer serious misconduct by a teacher"
+    )
+    expect(page).to have_content("Is the allegation about a teacher?")
   end
 
   def then_i_see_the_no_jurisdiction_page
@@ -180,12 +193,16 @@ RSpec.describe "Eligibility screener", type: :system do
     choose "I’m reporting as an employer", visible: false
   end
 
+  def when_i_choose_reporting_as_public
+    choose "I’m reporting as a member of the public", visible: false
+  end
+
   def when_i_choose_yes
     choose "Yes", visible: false
   end
 
   def when_i_go_back
-    page.go_back
+    click_link "Back"
   end
 
   def when_i_press_continue

--- a/spec/system/question_order_spec.rb
+++ b/spec/system/question_order_spec.rb
@@ -16,19 +16,19 @@ RSpec.describe "Question order", type: :system do
     when_i_visit_the_serious_misconduct_page
     then_i_see_the_start_page
 
-    when_i_visit_you_should_know_page
-    then_i_see_the_start_page
-
     when_i_visit_the_complete_page
     then_i_see_the_start_page
 
     when_i_press_start
     when_i_choose_employer
     when_i_press_continue
-    then_i_see_the_unsupervised_teaching_page
+    then_i_see_the_is_a_teacher_page
+
+    when_i_visit_unsupervised_teaching_page
+    then_i_see_the_is_a_teacher_page
 
     when_i_visit_the_serious_misconduct_page
-    then_i_see_the_unsupervised_teaching_page
+    then_i_see_the_is_a_teacher_page
 
     when_i_choose_yes
     when_i_press_continue
@@ -42,6 +42,10 @@ RSpec.describe "Question order", type: :system do
 
   def given_the_service_is_open
     FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def then_i_see_the_is_a_teacher_page
+    expect(page).to have_current_path("/is-a-teacher")
   end
 
   def then_i_see_the_reporting_as_page
@@ -65,7 +69,7 @@ RSpec.describe "Question order", type: :system do
   end
 
   def when_i_choose_yes
-    choose "Yes, they do unsupervised teaching work", visible: false
+    choose "Yes", visible: false
   end
 
   def when_i_press_continue
@@ -86,6 +90,10 @@ RSpec.describe "Question order", type: :system do
 
   def when_i_visit_the_service
     visit root_path
+  end
+
+  def when_i_visit_unsupervised_teaching_page
+    visit unsupervised_teaching_path
   end
 
   def when_i_visit_you_should_know_page

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -17,13 +17,16 @@ RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
 
     when_i_choose_reporting_as_an_employer
     when_i_press_continue
-    then_i_see_the_unsupervised_teaching_page
+    then_i_see_the_is_a_teacher_page
 
     when_i_choose_yes
     when_i_press_continue
     then_i_see_the_teaching_in_england_page
 
     when_i_choose_yes
+    when_i_press_continue
+    then_i_see_the_you_should_know_page
+
     when_i_press_continue
     then_i_see_the_completion_page
   end
@@ -70,8 +73,12 @@ RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
     expect(page).to have_current_path("/teaching-in-england")
   end
 
-  def then_i_see_the_unsupervised_teaching_page
-    expect(page).to have_current_path("/unsupervised-teaching")
+  def then_i_see_the_is_a_teacher_page
+    expect(page).to have_current_path("/is-a-teacher")
+  end
+
+  def then_i_see_the_you_should_know_page
+    expect(page).to have_current_path("/you-should-know")
   end
 
   def when_i_choose_reporting_as_an_employer


### PR DESCRIPTION
### Context

We want to determine if the allegation is about a teacher.

### Changes proposed in this pull request

This question introduces a new fork and exit page for the flow.

While doing this the complexity of the enforce question order class was
growing because it was handling the non-answerable pages.

To simplify, I moved the logic for these exit pages to the controller
that precedes them. This allows the question ordering class to return to
a single responsibility.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1019" alt="Screenshot 2022-10-21 at 10 33 56 am" src="https://user-images.githubusercontent.com/3126/197164305-1ee4028b-722d-4011-9796-1759bc2ff766.png">
