### PR TITLE
Change how EnforceQuestionOrder is included in controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::Base
-  include EnforceQuestionOrder
-
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 
   http_basic_authenticate_with name: ENV.fetch("SUPPORT_USERNAME", nil),

--- a/app/controllers/is_teacher_controller.rb
+++ b/app/controllers/is_teacher_controller.rb
@@ -1,4 +1,6 @@
 class IsTeacherController < ApplicationController
+  include EnforceQuestionOrder
+
   def new
     @is_teacher_form = IsTeacherForm.new
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,4 @@
 class PagesController < ApplicationController
-  skip_before_action :redirect_to_next_question
-
   def complete
     @eligibility_check =
       EligibilityCheck.find_by(id: session[:eligibility_check_id])

--- a/app/controllers/reporting_as_controller.rb
+++ b/app/controllers/reporting_as_controller.rb
@@ -1,4 +1,6 @@
 class ReportingAsController < ApplicationController
+  include EnforceQuestionOrder
+
   def new
     @reporting_as_form = ReportingAsForm.new(eligibility_check:)
   end

--- a/app/controllers/serious_misconduct_controller.rb
+++ b/app/controllers/serious_misconduct_controller.rb
@@ -1,4 +1,6 @@
 class SeriousMisconductController < ApplicationController
+  include EnforceQuestionOrder
+
   def new
     @serious_misconduct_form = SeriousMisconductForm.new(eligibility_check:)
   end

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SupportInterface
-  class SupportInterfaceController < ActionController::Base
+  class SupportInterfaceController < ApplicationController
     layout "support_layout"
 
     http_basic_authenticate_with name: ENV["SUPPORT_USERNAME"],

--- a/app/controllers/teaching_in_england_controller.rb
+++ b/app/controllers/teaching_in_england_controller.rb
@@ -1,4 +1,6 @@
 class TeachingInEnglandController < ApplicationController
+  include EnforceQuestionOrder
+
   def new
     @teaching_in_england_form = TeachingInEnglandForm.new(eligibility_check:)
   end

--- a/app/controllers/unsupervised_teaching_controller.rb
+++ b/app/controllers/unsupervised_teaching_controller.rb
@@ -1,4 +1,6 @@
 class UnsupervisedTeachingController < ApplicationController
+  include EnforceQuestionOrder
+
   def new
     @unsupervised_teaching_form = UnsupervisedTeachingForm.new
   end


### PR DESCRIPTION
### Context
EnforceQuestionOrder is currently included in the top-level ApplicationController. We'll shortly be introducing a number of controllers (eg—a bunch of Devise ones, the Employer form) that don't require the logic in EnforceQuestionOrder and shouldn't be subject to the before_action redirect it provides. 

Required as part of the staff sign in work https://trello.com/c/igamP4FJ

### Changes proposed in this pull request

Rather than manually skip the before_action wherever it isn't needed, instead do the following:

- Remove EnforceQuestionOrder from ApplicationController
- Add it explicitly in all controllers related to the eligibility checker

Incidentally, this allows us to restore the inheritance relationship between SupportInterfaceController and ApplicationController.

### Guidance to review

Is this approach ok? It's slightly less convenient but probably a better fit given the other stuff we have to build after the eligibility checker.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
