### PR TITLE
Add basic auth staff sign in

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "view_component"
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails", "~> 2.8"
+  gem "factory_bot_rails"
   gem "rspec-rails"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,11 @@ GEM
       railties (>= 3.2)
     e2mmap (0.1.0)
     erubi (1.11.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     ferrum (0.12)
       addressable (~> 2.5)
       concurrent-ruby (~> 1.1)
@@ -377,6 +382,7 @@ DEPENDENCIES
   devise
   devise_invitable
   dotenv-rails (~> 2.8)
+  factory_bot_rails
   govuk-components
   govuk_design_system_formbuilder
   govuk_feature_flags!

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -3,7 +3,6 @@ module SupportInterface
   class SupportInterfaceController < ApplicationController
     layout "support_layout"
 
-    http_basic_authenticate_with name: ENV["SUPPORT_USERNAME"],
-                                 password: ENV["SUPPORT_PASSWORD"]
+    before_action :authenticate_staff!
   end
 end

--- a/app/lib/anonymous_support_user.rb
+++ b/app/lib/anonymous_support_user.rb
@@ -1,0 +1,9 @@
+class AnonymousSupportUser
+  def has_invitations_left?
+    true
+  end
+
+  def devise_scope
+    :staff
+  end
+end

--- a/app/lib/staff_http_basic_auth_strategy.rb
+++ b/app/lib/staff_http_basic_auth_strategy.rb
@@ -1,0 +1,50 @@
+class StaffHttpBasicAuthStrategy < Warden::Strategies::Base
+  def valid?
+    FeatureFlags::FeatureFlag.active?(:staff_http_basic_auth) || !Staff.exists?
+  end
+
+  def store?
+    false
+  end
+
+  def authenticate!
+    auth = Rack::Auth::Basic::Request.new(env)
+
+    return success!(ANONYMOUS_SUPPORT_USER) if credentials_valid?(auth)
+
+    custom!(
+      [
+        401,
+        {
+          "Content-Type" => "text/plain",
+          "Content-Length" => "0",
+          "WWW-Authenticate" => "Basic realm=\"Application\""
+        },
+        []
+      ]
+    )
+  end
+
+  private
+
+  SUPPORT_USERNAME =
+    Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_USERNAME", "test"))
+  SUPPORT_PASSWORD =
+    Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_PASSWORD", "test"))
+
+  ANONYMOUS_SUPPORT_USER = AnonymousSupportUser.new
+
+  def credentials_valid?(auth)
+    return false unless auth.provided? && auth.basic? && auth.credentials
+
+    valid_comparison?(SUPPORT_USERNAME, auth.credentials.first) &&
+      valid_comparison?(SUPPORT_PASSWORD, auth.credentials.last)
+  end
+
+  def valid_comparison?(correct_value, given_value)
+    ActiveSupport::SecurityUtils.secure_compare(
+      Digest::SHA256.hexdigest(given_value),
+      correct_value
+    )
+  end
+end

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -7,3 +7,6 @@ feature_flags:
   employer_form:
     author: Steve Laing
     description: Allow users to access the employer-specific form
+  staff_http_basic_auth:
+    author: Malcolm Baig
+    description: Allow signing in as a staff user using HTTP Basic authentication. This is useful before staff users have been created, but should otherwise be inactive.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -327,10 +327,10 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.strategies.add(:staff_http_basic_auth, StaffHttpBasicAuthStrategy)
+    manager.default_strategies(scope: :staff).unshift :staff_http_basic_auth
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,11 @@ Rails.application.routes.draw do
       unlocks: "staff/unlocks"
     }
   )
+  devise_scope :staff do
+    authenticate :staff do
+      # Mount engines that require staff authentication here
+    end
+  end
 
   get "/start", to: "pages#start"
   get "/who", to: "reporting_as#new"

--- a/spec/factories/staffs.rb
+++ b/spec/factories/staffs.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :staff do
+    email { "test@example.org" }
+    password { "example" }
+  end
+end

--- a/spec/lib/staff_http_basic_auth_strategy_spec.rb
+++ b/spec/lib/staff_http_basic_auth_strategy_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe StaffHttpBasicAuthStrategy do
+  subject(:staff_http_basic_auth_strategy) { described_class.new(env) }
+
+  let(:env) { {} }
+
+  describe "#valid?" do
+    subject(:valid?) { staff_http_basic_auth_strategy.valid? }
+
+    context "with staff users" do
+      before { create(:staff) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when feature is active" do
+      before { FeatureFlags::FeatureFlag.activate(:staff_http_basic_auth) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when there are no staff users" do
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  describe "#store?" do
+    subject(:store?) { staff_http_basic_auth_strategy.store? }
+
+    it { is_expected.to eq(false) }
+  end
+
+  describe "#authenticate!" do
+    before { staff_http_basic_auth_strategy.authenticate! }
+
+    it "should halt the strategy" do
+      expect(staff_http_basic_auth_strategy.halted?).to eq(true)
+    end
+
+    it "should not be successful" do
+      expect(staff_http_basic_auth_strategy.successful?).to eq(false)
+      expect(staff_http_basic_auth_strategy.custom_response).to eq(
+        [
+          401,
+          {
+            "Content-Length" => "0",
+            "Content-Type" => "text/plain",
+            "WWW-Authenticate" => "Basic realm=\"Application\""
+          },
+          []
+        ]
+      )
+    end
+
+    context "with valid credentials" do
+      let(:env) do
+        { "HTTP_AUTHORIZATION" => "Basic #{Base64.encode64("test:test")}" }
+      end
+
+      it "should be successful" do
+        expect(staff_http_basic_auth_strategy.successful?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,6 +76,8 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.before(:each, type: :system) { driven_by(:cuprite) }
+
+  config.include FactoryBot::Syntax::Methods
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
### Context

Pre-req: https://github.com/DFE-Digital/refer-serious-misconduct/pull/72

When Staff users don't exist on an environment, we need a mechanism to access the support interface.

https://trello.com/c/igamP4FJ

### Changes proposed in this pull request

Mimic the implementation [here](https://github.com/DFE-Digital/find-a-lost-trn/pull/326/) to add a basic auth setup that triggers if either of these are true:

- If the staff_http_basic_auth feature flag is active
- If no Staff users exist

### Guidance to review

Fairly straightforward rip-off of the Find PR linked above, and a necessary pre-requisite to implement and adequately system test the invite functionality.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
