### PR TITLE
Add employer form hub page

### DIFF
--- a/app/assets/stylesheets/_task-list.scss
+++ b/app/assets/stylesheets/_task-list.scss
@@ -1,0 +1,67 @@
+// Task list pattern
+
+.app-task-list {
+  list-style-type: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  @include govuk-media-query($from: tablet) {
+    min-width: 550px;
+  }
+}
+
+.app-task-list__section {
+  @include govuk-font($size:24, $weight: bold);
+}
+
+.app-task-list__section-number {
+  @include govuk-media-query($from: tablet) {
+    min-width: govuk-spacing(6);
+    padding-right: 0;
+  }
+}
+
+.app-task-list__items {
+  @include govuk-font($size: 19);
+  @include govuk-responsive-margin(9, "bottom");
+  list-style: none;
+  padding-left: 0;
+  @include govuk-media-query($from: tablet) {
+    padding-left: govuk-spacing(6);
+  }
+}
+
+.app-task-list__item {
+  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: 0 !important;
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
+  @include govuk-clearfix;
+}
+
+.app-task-list__item:first-child {
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.app-task-list__task-name {
+  display: block;
+  @include govuk-media-query($from: 450px) {
+    float: left;
+  }
+}
+
+// The `app-task-list__task-completed` class was previously used on the task
+// list for the completed tag (changed in 86c90ec) – it's still included here to
+// avoid breaking task lists in existing prototypes.
+.app-task-list__tag,
+.app-task-list__task-completed {
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: 450px) {
+    float: right;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+

--- a/app/assets/stylesheets/_task-list.scss
+++ b/app/assets/stylesheets/_task-list.scss
@@ -11,7 +11,7 @@
 }
 
 .app-task-list__section {
-  @include govuk-font($size:24, $weight: bold);
+  @include govuk-font($size: 24, $weight: bold);
 }
 
 .app-task-list__section-number {
@@ -64,4 +64,3 @@
     margin-bottom: 0;
   }
 }
-

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -3,6 +3,7 @@ $govuk-new-link-styles: true;
 $govuk-assets-path: "/";
 
 @import "govuk-frontend/govuk/all";
+@import "_task-list.scss";
 
 .app-govuk-related-navigation {
   @include govuk-text-colour;

--- a/app/components/task_list_component.html.erb
+++ b/app/components/task_list_component.html.erb
@@ -1,0 +1,5 @@
+<ol class="app-task-list">
+  <% sections.each_with_index do |section, idx| %>
+    <%= render TaskListSectionComponent.new(section: section, number: idx + 1) %>
+  <% end %>
+</ol>

--- a/app/components/task_list_component.rb
+++ b/app/components/task_list_component.rb
@@ -1,0 +1,8 @@
+class TaskListComponent < ViewComponent::Base
+  attr_reader :sections
+
+  def initialize(sections:)
+    super
+    @sections = sections
+  end
+end

--- a/app/components/task_list_section_component.html.erb
+++ b/app/components/task_list_section_component.html.erb
@@ -1,0 +1,18 @@
+<li class="app-task-list__section app-task-list__section--numbered">
+  <h2 class="app-task-list__section-heading">
+    <span class="app-task-list__section-number"><%= number %>.</span>
+    <%= label %>
+  </h2>
+  <ul class="app-task-list__items">
+    <% items.each do |item| %>
+      <li class="app-task-list__item">
+        <span class="app-task-list__task-name">
+          <a href="<%= item.path %>" aria-describedby="<%= item.label.parameterize %>"><%= item.label %></a>
+        </span>
+        <strong class="govuk-tag app-task-list__tag govuk-tag--grey" id="<%= item.label.parameterize %>">
+          <%= item.status.to_s.humanize %>
+        </strong>
+      </li>
+    <% end %>
+  </ul>
+</li>

--- a/app/components/task_list_section_component.rb
+++ b/app/components/task_list_section_component.rb
@@ -1,0 +1,11 @@
+class TaskListSectionComponent < ViewComponent::Base
+  attr_reader :number, :section
+
+  delegate :label, :items, :path, to: :section
+
+  def initialize(number:, section:)
+    super
+    @number = number
+    @section = section
+  end
+end

--- a/app/controllers/concerns/enforce_question_order.rb
+++ b/app/controllers/concerns/enforce_question_order.rb
@@ -5,6 +5,7 @@ module EnforceQuestionOrder
   included { before_action :redirect_to_next_question }
 
   def redirect_to_next_question
+    return if referrals_request?
     redirect_to(start_url) and return if start_page_is_required?
     return if all_questions_answered?
     return if previous_question_answered?
@@ -101,5 +102,9 @@ module EnforceQuestionOrder
 
   def serious_misconduct_needs_answer?
     eligibility_check.serious_misconduct.nil?
+  end
+
+  def referrals_request?
+    controller_name == "referrals"
   end
 end

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -1,0 +1,31 @@
+class ReferralsController < ApplicationController
+  def new
+    @referral_form = ReferralForm.new(referral: Referral.new)
+  end
+
+  def edit
+    @referral_form = ReferralForm.new(referral:)
+  end
+
+  def update
+    @referral_form = ReferralForm.new(referral:)
+
+    if @referral_form.save
+      # TODO: TBC
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    referral.destroy!
+    redirect_to start_path
+  end
+
+  private
+
+  def referral
+    # TODO: This needs integration with current_user check
+    @referral ||= Referral.find(params[:id])
+  end
+end

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -1,4 +1,6 @@
 class ReferralsController < ApplicationController
+  before_action :check_employer_form_feature_flag_enabled
+
   def new
     @referral_form = ReferralForm.new(referral: Referral.new)
   end
@@ -27,5 +29,11 @@ class ReferralsController < ApplicationController
   def referral
     # TODO: This needs integration with current_user check
     @referral ||= Referral.find(params[:id])
+  end
+
+  def check_employer_form_feature_flag_enabled
+    unless FeatureFlags::FeatureFlag.active?(:employer_form)
+      redirect_to start_path
+    end
   end
 end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -24,7 +24,9 @@ class ReferralForm
   private
 
   def sections_valid
-    sections.map(&:items).flatten.map(&:status).uniq == [:complete]
+    unless sections.map(&:items).flatten.map(&:status).uniq == [:complete]
+      errors.add(:base, "Please complete all sections of the referral")
+    end
   end
 
   def about_you_section

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -1,0 +1,96 @@
+class ReferralForm
+  include ActiveModel::Model
+
+  attr_accessor :referral
+
+  # TODO: Replace these with something reading from :referral model fields
+  ReferralSection = Struct.new(:number, :label, :items)
+  ReferralSectionItem = Struct.new(:label, :path, :status)
+
+  validate :sections_valid
+
+  def save
+    valid?
+  end
+
+  def sections
+    [
+      about_you_section,
+      about_the_person_you_are_referring_section,
+      the_allegation_section
+    ]
+  end
+
+  private
+
+  def sections_valid
+    sections.map(&:items).flatten.map(&:status).uniq == [:complete]
+  end
+
+  def about_you_section
+    ReferralSection.new(
+      1,
+      I18n.t("referral_form.about_you"),
+      [
+        ReferralSectionItem.new(
+          I18n.t("referral_form.your_details"),
+          "#",
+          :not_started_yet
+        ),
+        ReferralSectionItem.new(
+          I18n.t("referral_form.your_organisation"),
+          "#",
+          :not_started_yet
+        )
+      ]
+    )
+  end
+
+  def about_the_person_you_are_referring_section
+    ReferralSection.new(
+      2,
+      I18n.t("referral_form.about_the_person_you_are_referring"),
+      [
+        ReferralSectionItem.new(
+          I18n.t("referral_form.personal_details"),
+          "#",
+          :not_started_yet
+        ),
+        ReferralSectionItem.new(
+          I18n.t("referral_form.contact_details"),
+          "#",
+          :not_started_yet
+        ),
+        ReferralSectionItem.new(
+          I18n.t("referral_form.about_their_role"),
+          "#",
+          :not_started_yet
+        )
+      ]
+    )
+  end
+
+  def the_allegation_section
+    ReferralSection.new(
+      3,
+      I18n.t("referral_form.the_allegation"),
+      [
+        ReferralSectionItem.new(
+          I18n.t("referral_form.details_of_the_allegation"),
+          "#",
+          :not_started_yet
+        ),
+        ReferralSectionItem.new(
+          I18n.t("referral_form.previous_allegations"),
+          "#",
+          :not_started_yet
+        ),
+        ReferralSectionItem.new(
+          I18n.t("referral_form.evidence_and_supporting_information"),
+          "#",
+          :not_started_yet
+        )
+      ]
+    )
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -1,0 +1,10 @@
+# == Schema Information
+#
+# Table name: referrals
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Referral < ApplicationRecord
+end

--- a/app/views/referrals/edit.html.erb
+++ b/app/views/referrals/edit.html.erb
@@ -1,0 +1,27 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: @referral_form, url: referral_path, method: :put do |f| %>
+      <h1 class="govuk-heading-xl"><%= t("referral_form.heading") %></h1>
+      <%= render TaskListComponent.new(sections: @referral_form.sections) %>
+      <button class="govuk-button" data-module="govuk-button">
+        Review and send
+      </button>
+    <% end %>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          I don’t want to continue
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <p>
+          You can delete your draft:<br>
+          <%= govuk_button_to "Delete your draft referral", referral_path(params[:id]), method: :delete %>
+        </p>
+        <p>
+          Drafts are automatically deleted after 6 months of no activity. We’ll send you an email before deleting it.
+        </p>
+      </div>
+    </details>
+  </div>
+</div>

--- a/app/views/referrals/new.html.erb
+++ b/app/views/referrals/new.html.erb
@@ -1,0 +1,27 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: @referral_form, url: referrals_path, method: :post do |f| %>
+      <h1 class="govuk-heading-xl"><%= t("referral_form.heading") %></h1>
+      <%= render TaskListComponent.new(sections: @referral_form.sections) %>
+      <button class="govuk-button" data-module="govuk-button">
+        Review and send
+      </button>
+    <% end %>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          I don’t want to continue
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <p>
+          You can delete your draft:<br>
+          <%= govuk_button_to "Delete your draft referral", start_path %>
+        </p>
+        <p>
+          Drafts are automatically deleted after 6 months of no activity. We’ll send you an email before deleting it.
+        </p>
+      </div>
+    </details>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,23 @@ en:
     info: Information
     warning: Warning
     success: Success
+  referral_form:
+    heading: Your allegation of serious misconduct
+    about_you: About you
+    your_details: Your details
+    your_organisation: Your organisation
+    about_the_person_you_are_referring: About the person you are referring
+    personal_details: Personal details
+    contact_details: Contact details
+    about_their_role: About their role
+    the_allegation: The allegation
+    details_of_the_allegation: Details of the allegation
+    previous_allegations: Previous allegations
+    evidence_and_supporting_information: Evidence and supporting information
+    statuses:
+      not_started_yet: Not started yet
+      incomplete: Incomplete
+      completed: Completed
 
   activemodel:
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
 
   root to: redirect("/start")
 
+  resources :referrals, except: %i[show]
+
   namespace :support_interface, path: "/support" do
     resources :eligibility_checks, only: [:index]
     mount FeatureFlags::Engine => "/features"

--- a/db/migrate/20221026103526_add_referrals.rb
+++ b/db/migrate/20221026103526_add_referrals.rb
@@ -1,0 +1,5 @@
+class AddReferrals < ActiveRecord::Migration[7.0]
+  def change
+    create_table :referrals, &:timestamps
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_24_151643) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_26_103526) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,4 +70,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_24_151643) do
     t.index ["unlock_token"], name: "index_staff_on_unlock_token", unique: true
   end
 
+  create_table "referrals", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 end

--- a/spec/components/task_list_component_spec.rb
+++ b/spec/components/task_list_component_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe TaskListComponent, type: :component do
+  let(:sections) do
+    [
+      OpenStruct.new(
+        number: 1,
+        label: "Do laundry",
+        items: [
+          OpenStruct.new(
+            label: "Light wash",
+            path: "/light-wash",
+            status: :completed
+          ),
+          OpenStruct.new(
+            label: "Dark wash",
+            path: "/dark-wash",
+            status: :not_started_yet
+          )
+        ]
+      ),
+      OpenStruct.new(
+        number: 2,
+        label: "Make a sandwich",
+        items: [
+          OpenStruct.new(
+            label: "Butter bread",
+            path: "/butter-bread",
+            status: :incomplete
+          ),
+          OpenStruct.new(
+            label: "Add filling",
+            path: "/add-filling",
+            status: :not_started_yet
+          )
+        ]
+      )
+    ]
+  end
+
+  subject(:rendered) { render_inline(described_class.new(sections:)) }
+
+  it "renders numbered sections" do
+    expect(rendered.css(".app-task-list__section-number")[0].text).to eq("1.")
+    expect(rendered.css(".app-task-list__section-heading")[0].text).to include(
+      "Do laundry"
+    )
+
+    expect(rendered.css(".app-task-list__section-number")[1].text).to eq("2.")
+    expect(rendered.css(".app-task-list__section-heading")[1].text).to include(
+      "Make a sandwich"
+    )
+  end
+
+  it "renders section items" do
+    expect(rendered.css(".app-task-list__item")[0].text).to include(
+      "Light wash"
+    )
+    expect(rendered.css(".app-task-list__item")[1].text).to include("Dark wash")
+    expect(rendered.css(".app-task-list__item")[2].text).to include(
+      "Butter bread"
+    )
+    expect(rendered.css(".app-task-list__item")[3].text).to include(
+      "Add filling"
+    )
+  end
+
+  it "renders section item links" do
+    expect(rendered.css(".app-task-list__item a")[0][:href]).to eq(
+      "/light-wash"
+    )
+    expect(rendered.css(".app-task-list__item a")[1][:href]).to eq("/dark-wash")
+    expect(rendered.css(".app-task-list__item a")[2][:href]).to eq(
+      "/butter-bread"
+    )
+    expect(rendered.css(".app-task-list__item a")[3][:href]).to eq(
+      "/add-filling"
+    )
+  end
+
+  it "renders section item status" do
+    expect(rendered.css(".app-task-list__tag")[0].text).to include("Completed")
+    expect(rendered.css(".app-task-list__tag")[1].text).to include(
+      "Not started yet"
+    )
+    expect(rendered.css(".app-task-list__tag")[2].text).to include("Incomplete")
+    expect(rendered.css(".app-task-list__tag")[3].text).to include(
+      "Not started yet"
+    )
+  end
+end

--- a/spec/forms/referral_form_spec.rb
+++ b/spec/forms/referral_form_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe ReferralForm do
+  describe "save" do
+    let(:sections) do
+      [
+        OpenStruct.new(
+          items: [
+            OpenStruct.new(status: :incomplete),
+            OpenStruct.new(status: :complete)
+          ]
+        ),
+        OpenStruct.new(
+          items: [
+            OpenStruct.new(status: :complete),
+            OpenStruct.new(status: :complete)
+          ]
+        )
+      ]
+    end
+
+    subject(:form) { described_class.new(referral: Referral.new) }
+
+    before { allow(form).to receive(:sections).and_return(sections) }
+
+    it "checks statuses of referral sections" do
+      expect(form.save).to be false
+    end
+
+    context "when statuses are all complete" do
+      let(:sections) do
+        [
+          OpenStruct.new(
+            items: [
+              OpenStruct.new(status: :complete),
+              OpenStruct.new(status: :complete)
+            ]
+          ),
+          OpenStruct.new(
+            items: [
+              OpenStruct.new(status: :complete),
+              OpenStruct.new(status: :complete)
+            ]
+          )
+        ]
+      end
+
+      it "checks statuses of referral sections" do
+        expect(form.save).to be true
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,6 +78,7 @@ RSpec.configure do |config|
   config.before(:each, type: :system) { driven_by(:cuprite) }
 
   config.include FactoryBot::Syntax::Methods
+  config.include ViewComponent::TestHelpers, type: :component
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/system/user_deletes_a_draft_referral_spec.rb
+++ b/spec/system/user_deletes_a_draft_referral_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "User deletes a draft referral" do
+  scenario "User deletes a draft referral" do
+    given_the_service_is_open
+    and_the_employer_form_feature_is_active
+    and_i_have_an_existing_referral
+    when_i_visit_the_referral_summary
+    and_i_dont_want_to_continue
+    then_the_draft_referral_is_deleted
+  end
+
+  private
+
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_the_employer_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_i_have_an_existing_referral
+    @referral = Referral.create!
+  end
+
+  def when_i_visit_the_referral_summary
+    visit edit_referral_path(@referral)
+  end
+
+  def and_i_dont_want_to_continue
+    find(:button, text: "Delete your draft referral", visible: false).trigger(
+      "click"
+    )
+  end
+
+  def then_the_draft_referral_is_deleted
+    expect { @referral.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end

--- a/spec/system/user_views_a_referral_summary_spec.rb
+++ b/spec/system/user_views_a_referral_summary_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "User views an existing referral summary" do
+  scenario "Views referral summary sections" do
+    given_the_service_is_open
+    and_the_employer_form_feature_is_active
+    and_i_have_an_existing_referral
+    when_i_visit_the_referral_summary
+    then_i_see_the_referral_as_sections
+  end
+
+  private
+
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_the_employer_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_i_have_an_existing_referral
+    @referral = Referral.create!
+  end
+
+  def when_i_visit_the_referral_summary
+    visit edit_referral_path(@referral)
+  end
+
+  def then_i_see_the_referral_as_sections
+    expect(page).to have_content("Your allegation of serious misconduct")
+
+    within(all(".app-task-list__section").first) do
+      expect(page).to have_content("1. About you")
+    end
+
+    within(all(".app-task-list__section")[1]) do
+      expect(page).to have_content("2. About the person you are referring")
+    end
+
+    within(all(".app-task-list__section").last) do
+      expect(page).to have_content("3. The allegation")
+    end
+  end
+end


### PR DESCRIPTION
### Context

The various sections of the employer form will be summarized on a _hub_ page.
Prototype: https://teacher-misconduct.herokuapp.com/report/tasks

https://trello.com/c/W5ryTx7r/858-add-employer-form-hub-page

### Changes proposed in this pull request

- Adds (empty) `referrals` table and model
- Adds a `TaskListComponent` consistent with the prototype
- Adds a `ReferralForm` form class to back the summary page
- Adds very basic controller actions to show or destroy a `Referral`

![image](https://user-images.githubusercontent.com/93511/197824416-c83b8a98-e30e-41d5-b578-dce47bbdc36c.png)


### Guidance to review

Some of the actions here are intentionally lightweight until we have more meaningful validations and complete journeys.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
