### PR TITLE
Add flash component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "propshaft"
 gem "puma", "~> 5.0"
 gem "rails", "~> 7.0.3"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
+gem "view_component"
 
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,6 +382,7 @@ DEPENDENCIES
   syntax_tree-haml
   syntax_tree-rbs
   tzinfo-data
+  view_component
   web-console
 
 RUBY VERSION

--- a/app/components/flash_message_component.html.erb
+++ b/app/components/flash_message_component.html.erb
@@ -1,0 +1,8 @@
+<%= govuk_notification_banner(
+  title_text: title,
+  classes: classes,
+  html_attributes: { role: role },
+) do |notification_banner| %>
+  <% notification_banner.heading(text: heading) %>
+  <%= body %>
+<% end %>

--- a/app/components/flash_message_component.rb
+++ b/app/components/flash_message_component.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+class FlashMessageComponent < ViewComponent::Base
+  ALLOWED_PRIMARY_KEYS = %i[info warning success].freeze
+  DEVISE_PRIMARY_KEYS = { alert: :warning, notice: :info }.freeze
+
+  def initialize(flash:)
+    super
+    @flash = flash.to_hash.symbolize_keys!
+  end
+
+  def message_key
+    key =
+      flash.keys.detect do |k|
+        ALLOWED_PRIMARY_KEYS.include?(k) || DEVISE_PRIMARY_KEYS.keys.include?(k)
+      end
+    DEVISE_PRIMARY_KEYS[key] || key
+  end
+
+  def title
+    I18n.t(message_key, scope: :notification_banner)
+  end
+
+  def classes
+    "govuk-notification-banner--#{message_key}"
+  end
+
+  def role
+    %i[warning success].include?(message_key) ? "alert" : "region"
+  end
+
+  def heading
+    messages.is_a?(Array) ? messages[0] : messages
+  end
+
+  def body
+    if messages.is_a?(Array) && messages.count >= 2
+      tag.p(messages[1], class: "govuk-body")
+    end
+  end
+
+  def render?
+    !flash.empty? && message_key
+  end
+
+  private
+
+  def messages
+    flash[message_key] || flash[DEVISE_PRIMARY_KEYS.key(message_key)]
+  end
+
+  attr_reader :flash
+end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -28,10 +28,11 @@
     <%= govuk_skip_link %>
 
     <%= navigation %>
-  
+
     <div class="govuk-width-container">
       <%= govuk_back_link(href: yield(:back_link_url)) if content_for?(:back_link_url) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
+        <%= render(FlashMessageComponent.new(flash: flash)) %>
         <%= yield %>
       </main>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,11 @@ en:
     phone: 020 7593 5393
     url: https://refer-serious-misconduct.education.gov.uk
 
+  notification_banner:
+    info: Information
+    warning: Warning
+    success: Success
+
   activemodel:
     errors:
       models:


### PR DESCRIPTION


### Context

We aren't rendering a flash message anywhere currently, and will need one for some of our forms.

### Changes proposed in this pull request

Copy the flash component from Find a lost TRN, including support for Devise's flash messages. Render this in the base layout.

### Guidance to review

Just a copy/paste from Find, this will be testable once its integrated with the current Staff sign in work.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
