### PR TITLE
Add sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "pg", "~> 1.4"
 gem "propshaft"
 gem "puma", "~> 5.0"
 gem "rails", "~> 7.0.3"
+gem "sidekiq"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "view_component"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     concurrent-ruby (1.1.10)
+    connection_pool (2.3.0)
     crass (1.0.6)
     cssbundling-rails (1.1.1)
       railties (>= 6.0.0)
@@ -253,6 +254,7 @@ GEM
     rake (13.0.6)
     rbs (2.6.0)
     redcarpet (3.5.1)
+    redis (4.8.0)
     regexp_parser (2.6.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -313,6 +315,10 @@ GEM
     ruby-progressbar (1.11.0)
     shoulda-matchers (5.2.0)
       activesupport (>= 5.2.0)
+    sidekiq (6.5.7)
+      connection_pool (>= 2.2.5)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     solargraph (0.47.2)
       backport (~> 1.2)
       benchmark
@@ -400,6 +406,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   shoulda-matchers
+  sidekiq
   solargraph
   solargraph-rails
   syntax_tree

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bin/rails server -p 3000
 css: yarn build:css --watch
 js: yarn build --watch
+worker: bin/bundle exec sidekiq -C config/sidekiq.yml

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,8 @@ module ReferSeriousMisconduct
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
+    config.active_job.queue_adapter = :sidekiq
+
     config.assets.paths << Rails.root.join(
       "node_modules/govuk-frontend/govuk/assets"
     )

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+require "sidekiq/web"
+
 Rails.application.routes.draw do
   devise_for(
     :staff,
@@ -12,6 +14,7 @@ Rails.application.routes.draw do
   devise_scope :staff do
     authenticate :staff do
       # Mount engines that require staff authentication here
+      mount Sidekiq::Web, at: "sidekiq"
     end
   end
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,12 @@
+development:
+  :concurrency: 10
+
+production:
+  :concurrency: 10
+
+:max_retries: 1
+
+:queues:
+  - critical
+  - default
+  - low

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ end
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 require "capybara/cuprite"
+require "sidekiq/testing"
 
 Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(
@@ -76,6 +77,7 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.before(:each, type: :system) { driven_by(:cuprite) }
+  config.before { Sidekiq::Worker.clear_all }
 
   config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION

### Context

As per ADR #2, we use Sidekiq and Redis for out of band jobs. The specific requirement here is to send Devise emails via Notify, but this setup will also be used for other jobs further down the line.

### Changes proposed in this pull request

Add the sidekiq gem and all required config to use these tools in dev and test. A subsequent PR will ensure Redis is available in production.

### Guidance to review

No real testing required, this will be exercised once Devise invites are built.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
