### PR TITLE
Delete your draft referral page + confirmation page

### DIFF
--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -21,7 +21,13 @@ class ReferralsController < ApplicationController
 
   def destroy
     referral.destroy!
-    redirect_to start_path
+    redirect_to deleted_referral_path
+  end
+
+  def delete
+    referral if params[:id]
+
+    render :delete
   end
 
   private

--- a/app/views/referrals/delete.html.erb
+++ b/app/views/referrals/delete.html.erb
@@ -1,0 +1,16 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Are you sure you want to delete your draft?</h1>
+    <% if @referral %>
+      <%= govuk_button_to "Yes I’m sure – delete it", referral_path(@referral), method: :delete, class: "govuk-button--warning" %>
+      <p>
+        <%= govuk_link_to "Cancel", edit_referral_path(@referral) %>
+      </p>
+    <% else %>
+      <%= govuk_link_to "Yes I’m sure – delete it", deleted_referral_path, class: "govuk-button govuk-button--warning" %>
+      <p>
+        <%= govuk_link_to "Cancel", new_referral_path %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/deleted.html.erb
+++ b/app/views/referrals/deleted.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Your draft has been deleted</h1>
+    <p>You are now signed out.</p>
+    <p>
+      <%= govuk_link_to "Return to service", start_path %>
+    </p>
+  </div>
+</div>

--- a/app/views/referrals/edit.html.erb
+++ b/app/views/referrals/edit.html.erb
@@ -16,7 +16,7 @@
       <div class="govuk-details__text">
         <p>
           You can delete your draft:<br>
-          <%= govuk_button_to "Delete your draft referral", referral_path(params[:id]), method: :delete %>
+          <%= govuk_link_to "Delete your draft referral", delete_referral_path(params[:id]), class: "govuk-button" %>
         </p>
         <p>
           Drafts are automatically deleted after 6 months of no activity. We’ll send you an email before deleting it.

--- a/app/views/referrals/new.html.erb
+++ b/app/views/referrals/new.html.erb
@@ -16,7 +16,7 @@
       <div class="govuk-details__text">
         <p>
           You can delete your draft:<br>
-          <%= govuk_button_to "Delete your draft referral", start_path %>
+          <%= govuk_link_to "Delete your draft referral", delete_referral_path, class: "govuk-button" %>
         </p>
         <p>
           Drafts are automatically deleted after 6 months of no activity. We’ll send you an email before deleting it.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
   root to: redirect("/start")
 
   resources :referrals, except: %i[show]
+  get "/referrals/(:id)/delete", to: "referrals#delete", as: "delete_referral"
+  get "/referrals/deleted", to: "referrals#deleted", as: "deleted_referral"
 
   namespace :support_interface, path: "/support" do
     resources :eligibility_checks, only: [:index]

--- a/spec/system/user_deletes_a_draft_referral_spec.rb
+++ b/spec/system/user_deletes_a_draft_referral_spec.rb
@@ -5,9 +5,16 @@ RSpec.feature "User deletes a draft referral" do
   scenario "User deletes a draft referral" do
     given_the_service_is_open
     and_the_employer_form_feature_is_active
-    and_i_have_an_existing_referral
-    when_i_visit_the_referral_summary
+
+    when_i_make_a_new_referral
     and_i_dont_want_to_continue
+    and_i_confirm_deletion
+    then_the_new_referral_is_discarded
+
+    when_i_have_an_existing_referral
+    and_i_visit_the_referral_summary
+    and_i_dont_want_to_continue
+    and_i_confirm_deletion
     then_the_draft_referral_is_deleted
   end
 
@@ -21,21 +28,36 @@ RSpec.feature "User deletes a draft referral" do
     FeatureFlags::FeatureFlag.activate(:employer_form)
   end
 
-  def and_i_have_an_existing_referral
+  def when_i_have_an_existing_referral
     @referral = Referral.create!
   end
 
-  def when_i_visit_the_referral_summary
+  def and_i_visit_the_referral_summary
     visit edit_referral_path(@referral)
   end
 
+  def when_i_make_a_new_referral
+    visit new_referral_path
+  end
+
   def and_i_dont_want_to_continue
-    find(:button, text: "Delete your draft referral", visible: false).trigger(
-      "click"
-    )
+    find(
+      "a.govuk-button",
+      text: "Delete your draft referral",
+      visible: false
+    ).trigger("click")
+  end
+
+  def and_i_confirm_deletion
+    click_on "Yes I’m sure – delete it"
   end
 
   def then_the_draft_referral_is_deleted
     expect { @referral.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    expect(page).to have_content("Your draft has been deleted")
+  end
+
+  def then_the_new_referral_is_discarded
+    expect(page).to have_content("Your draft has been deleted")
   end
 end


### PR DESCRIPTION
### Context

Referrals can be deleted while in draft state.
https://teacher-misconduct.herokuapp.com/report/delete

### Changes proposed in this pull request

- Adds `/referrals/delete` and `/referrals/deleted` routes for [confirm and confirmation steps](https://teacher-misconduct.herokuapp.com/report/delete)
- Adds deletion flow for new and existing draft referrals.

![image](https://user-images.githubusercontent.com/93511/198060117-590194ff-9e36-44ac-9381-30ebe106b034.png)


### Guidance to review

I've assumed that a user can be making a new referral or editing an existing referral.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
