### PR TITLE
Add staff management page to support

### DIFF
--- a/app/controllers/staff/invitations_controller.rb
+++ b/app/controllers/staff/invitations_controller.rb
@@ -38,7 +38,11 @@ class Staff::InvitationsController < Devise::InvitationsController
     end
   end
 
+  def after_invite_path_for(inviter, invitee)
+    invitee.is_a?(Staff) ? support_interface_staff_index_path : super
+  end
+
   def after_accept_path_for(resource)
-    resource.is_a?(Staff) ? support_interface_root_path : super
+    resource.is_a?(Staff) ? support_interface_staff_index_path : super
   end
 end

--- a/app/controllers/support_interface/staff_controller.rb
+++ b/app/controllers/support_interface/staff_controller.rb
@@ -1,0 +1,7 @@
+module SupportInterface
+  class StaffController < SupportInterfaceController
+    def index
+      @staff = Staff.all
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,10 +39,13 @@ module ApplicationHelper
         header.navigation_item(
           active: request.path.start_with?("/support/staff"),
           text: "Staff",
-          href: main_app.support_interface_staff_index_path,
+          href: main_app.support_interface_staff_index_path
         )
         if current_staff
-          header.navigation_item(href: main_app.staff_sign_out_path, text: "Sign out")
+          header.navigation_item(
+            href: main_app.staff_sign_out_path,
+            text: "Sign out"
+          )
         end
       end
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,6 +36,11 @@ module ApplicationHelper
           href: main_app.support_interface_feature_flags_path,
           text: "Features"
         )
+        header.navigation_item(
+          active: request.path.start_with?("/support/staff"),
+          text: "Staff",
+          href: support_interface_staff_index_path,
+        )
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,8 +39,11 @@ module ApplicationHelper
         header.navigation_item(
           active: request.path.start_with?("/support/staff"),
           text: "Staff",
-          href: support_interface_staff_index_path,
+          href: main_app.support_interface_staff_index_path,
         )
+        if current_staff
+          header.navigation_item(href: main_app.staff_sign_out_path, text: "Sign out")
+        end
       end
     end
   end

--- a/app/views/support_interface/staff/index.html.erb
+++ b/app/views/support_interface/staff/index.html.erb
@@ -1,0 +1,42 @@
+<% content_for :page_title, 'Staff' %>
+
+<h1 class="govuk-heading-l">Staff</h1>
+
+<p class="govuk-body">
+  <%= govuk_button_link_to 'Invite staff user', new_staff_invitation_path %>
+</p>
+
+<% @staff.find_each do |staff| %>
+  <h2 class="govuk-heading-m"><%= staff.email %></h2>
+
+  <%= govuk_summary_list do |summary_list|
+    summary_list.row do |row|
+      row.key { 'Created at' }
+      row.value { staff.created_at.to_s }
+    end
+
+    if staff.created_by_invite?
+      summary_list.row do |row|
+        row.key { 'Invitation status' }
+
+        row.value do
+          if staff.invitation_accepted?
+             govuk_tag(text: "Accepted", colour: "green")
+          else
+            govuk_tag(text: "Not accepted", colour: "red")
+          end
+        end
+      end
+
+      summary_list.row do |row|
+        row.key { 'Invited at' }
+        row.value { staff.invitation_sent_at.to_s }
+      end
+    end
+
+    summary_list.row do |row|
+      row.key { 'Last signed in at' }
+      row.value { staff.last_sign_in_at.to_s }
+    end
+  end %>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}",
+      "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
@@ -74,6 +74,6 @@ Rails.application.configure do
           else
             "\n#{msg}"
           end
-        end,
+        end
     )
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false
@@ -60,7 +60,20 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
   config.action_mailer.delivery_method = :notify
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.logger =
+    Logger.new(
+      "log/mail.log",
+      formatter:
+        proc do |_, _, _, msg|
+          if msg =~ /quoted-printable/
+            message = Mail::Message.new(msg)
+            "\nTo: #{message.to}\n\n#{message.decoded}\n\n"
+          else
+            "\n#{msg}"
+          end
+        end,
+    )
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
       unlocks: "staff/unlocks"
     }
   )
+  devise_scope :staff do
+    get "/staff/sign_out", to: "staff/sessions#destroy"
+  end
 
   get "/start", to: "pages#start"
   get "/who", to: "reporting_as#new"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,12 +11,6 @@ Rails.application.routes.draw do
       unlocks: "staff/unlocks"
     }
   )
-  devise_scope :staff do
-    authenticate :staff do
-      # Mount engines that require staff authentication here
-      mount Sidekiq::Web, at: "sidekiq"
-    end
-  end
 
   get "/start", to: "pages#start"
   get "/who", to: "reporting_as#new"
@@ -47,6 +41,15 @@ Rails.application.routes.draw do
     mount FeatureFlags::Engine => "/features"
 
     root to: redirect("/support/eligibility_checks")
+
+    resources :staff, only: %i[index]
+
+    devise_scope :staff do
+      authenticate :staff do
+        # Mount engines that require staff authentication here
+        mount Sidekiq::Web, at: "sidekiq"
+      end
+    end
   end
 
   get "/accessibility", to: "static#accessibility"


### PR DESCRIPTION
### Context

We need somewhere we can invite staff users to access support.

### Changes proposed in this pull request

- Add the staff management page to support
- Add a sign out link in the support header to facilitate the sign in / sign out flow for staff users

### Guidance to review

Can be tested in a review app or locally by navigating to /support. The Staff page is linked in the header. You'll need either zero Staff records in the database or the `staff_http_basic_auth` feature flag on to access support with the basic auth credentials.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
