### PR TITLE
Replace 'report' with 'refer' throughout the screener

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Refer serious misconduct by a teacher
 
-A service that allows people to report a teacher for serious misconduct.
+A service that allows people to refer a teacher for serious misconduct.
 
 ## Dependencies
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,19 +2,23 @@ module ApplicationHelper
   def link_to_referral_form_for(reporting_as = "public")
     link = {
       employer: {
-        title: "Teacher misconduct referral form for use by employers",
+        title:
+          "download and print the teacher misconduct form for use by employers (opens in a new tab)",
         url:
           "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1105692/Teacher_Misconduct_Referral_Form_for__Employers__8_.docx"
       },
       public: {
         title:
-          "Teacher misconduct referral form for use by members of the public",
+          "download and print the teacher misconduct form for use by members of the public (opens in a new tab)",
         url:
           "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1105693/Teacher_misconduct_referral_form_for_members_of_the_public.docx"
       }
     }.with_indifferent_access
 
-    link_to link[reporting_as][:title], link[reporting_as][:url]
+    link_to link[reporting_as][:title],
+            link[reporting_as][:url],
+            target: "_blank",
+            rel: "noopener"
   end
 
   def current_namespace

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -16,7 +16,7 @@ class EligibilityCheck < ApplicationRecord
   validates :reporting_as, presence: true
 
   def is_teacher?
-    %w[yes not_sure].include?(is_teacher)
+    %w[yes].include?(is_teacher)
   end
 
   def reporting_as_employer?

--- a/app/views/is_teacher/new.html.erb
+++ b/app/views/is_teacher/new.html.erb
@@ -9,11 +9,7 @@
         <%= f.hidden_field :is_teacher %>
         <%= f.govuk_radio_button :is_teacher, "yes", label: { text: "Yes" } %>
         <%= f.govuk_radio_button :is_teacher, "no", label: { text: "No" } %>
-        <%= f.govuk_radio_button :is_teacher, "not_sure", label: { text: "I’m not sure" } do %>
-          <p class="govuk_body">
-            If you’re not sure, please continue to report your allegation and the Teaching Regulation Agency will assess it.
-          </p>
-        <% end %>
+        <%= f.govuk_radio_button :is_teacher, "not_sure", label: { text: "I’m not sure" } %>
       <% end %>
       <%= f.govuk_submit prevent_double_click: false %>
     <% end %>

--- a/app/views/pages/complete.html.erb
+++ b/app/views/pages/complete.html.erb
@@ -1,31 +1,25 @@
-<% content_for :page_title, 'You need to complete a referral form' %>
+<% content_for :page_title, 'You can also refer serious misconduct offline' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You need to complete a referral form</h1>
+    <h1 class="govuk-heading-xl">You can also refer serious misconduct offline</h1>
 
     <p class="govuk_body">
-      Based on what you've told us, you need to fill out the teacher misconduct
-      referral form for use by <%= @eligibility_check.reporting_as_employer? ? "employers" : "members of the public" %>.
+      You can <%= link_to_referral_form_for(@eligibility_check.reporting_as) %>.
     </p>
 
-    <h2 class="govuk-heading-m">What you need to do next</h2>
+    <p class="govuk_body">You should use the guidance within the form to help you fill it out.</p>
 
-    <p class="govuk_body">Download the referral form:</p>
+    <h2 class="govuk-heading-m">What happens next</h2>
 
-    <p class="govuk_body">
-      <%= link_to_referral_form_for(@eligibility_check.reporting_as) %>
-    </p>
-    <p class="govuk_body">
-      Fill out the form, and email it to:<br><%= mail_to t('service.email') %>
-    </p>
+    <p class="govuk_body">If you need more information about making a referral, you can contact TRA.</p>
 
-    <h2 class="govuk-heading-m">Contacting TRA about this report</h2>
+    <h4 class="govuk-heading-s">Telephone</h4>
+    <p class="govuk_body">Call 020 7593 5393<br>Monday to Friday, 9am to 5pm (except Mondays and Fridays)</p>
+    <p class="govuk_body"><a href="https://www.gov.uk/call-charges">Find out about call charges</a>.</p>
 
-    <p class="govuk_body">
-      Call <%= t('service.phone') %> or email:<br>
-      <%= mail_to t('service.email') %>
-    </p>
-    <p class="govuk_body">Monday to Friday, 9am to 5pm (except public holidays)</p>
+    <h4 class="govuk-heading-s">Email</h4>
+    <p class="govuk_body"><%= mail_to t('service.email') %></p>
+    <p class="govuk_body">We aim to respond within 3 working days.</p>
   </div>
 </div>

--- a/app/views/pages/no_jurisdiction_unsupervised.html.erb
+++ b/app/views/pages/no_jurisdiction_unsupervised.html.erb
@@ -4,12 +4,25 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">You need to report this misconduct somewhere else</h1>
-    <p class="govuk_body">You can refer misconduct in Wales, Scotland or Northern&nbsp;Ireland by contacting:</p>
+    <h2 class="govuk-heading-m">Why you can’t refer them using this service</h2>
+    <p class="govuk_body">
+      The Teaching Regulation Agency (TRA) will only consider cases of serious misconduct by teachers who are, or have been, employed or engaged at:
+    </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>the <a rel="external" href="http://www.ewc.wales/">Education Workforce Council for Wales</a></li>
-      <li>the <a rel="external" href="http://www.gtcs.org.uk/fitness-to-teach/process/referral.aspx">General Teaching Council for Scotland</a></li>
-      <li>the <a rel="external" href="https://gtcni.org.uk/regulation/making-a-referral">General Teaching Council for Northern Ireland</a></li>
+      <li>a school in England</li>
+      <li>a sixth form college in England</li>
+      <li>relevant youth accommodation in England</li>
+      <li>a children’s home in England</li>
+      <li>a 16 to 19 Academy</li>
     </ul>
+
+    <p class="govuk_body">
+      TRA will not usually consider cases relating to teaching assistants, higher level teaching assistants or other support staff.
+    </p>
+    <h2 class="govuk-heading-m">Reporting someone who is not a teacher</h2>
+    <p class="govuk_body">
+      You should <a href="https://www.gov.uk/report-teacher-misconduct">make an informal complaint</a> to start with. If you’re not happy with the response, you should [not sure where we direct people here].
+    </p>
   </div>
 </div>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -25,21 +25,21 @@
       Cases of less serious misconduct, and all cases of incompetence, should be dealt with by employers.
     </p>
 
-    <h2 class="govuk-heading-m">What happens when you submit a report</h2>
+    <h2 class="govuk-heading-m">What happens when you make a referral</h2>
     <p class="govuk_body">
-      See the <%= link_to "step-by-step guide", "#" %> to find out what happens once you submit a report.
+      See the <%= link_to "step-by-step guide", "#" %> to find out what happens once you make a referral.
     </p>
 
-    <h2 class="govuk-heading-m">How long it will take to prepare your report</h2>
+    <h2 class="govuk-heading-m">How long it will take to prepare your referral</h2>
     <p class="govuk_body">
-      You should allow an hour or more to complete your report. The time it will take depends on the case. It will be faster if you’ve prepared the evidence.
+      You should allow an hour or more to complete your referral. The time it will take depends on the case. It will be faster if you’ve prepared the evidence.
     </p>
 
     <%= govuk_start_button(text: 'Start now', href: who_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
 
     <h2 class="govuk-heading-m">When to use a different form</h2>
     <p class="govuk_body">
-      If you want to report multiple teachers at once, you need to <%= link_to "complete a different form", "#" %>
+      If you want to refer multiple teachers at once, you need to <%= link_to "complete a different form", "#" %>
     </p>
   </div>
 

--- a/app/views/unsupervised_teaching/new.html.erb
+++ b/app/views/unsupervised_teaching/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @unsupervised_teaching_form.errors.any?}You can refer someone who does unsupervised teaching work" %>
+<% content_for :back_link_url, url_for(:back) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/eligibility_screener_spec.rb
+++ b/spec/system/eligibility_screener_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe "Eligibility screener", type: :system do
     when_i_press_continue
     then_i_see_the_unsupervised_teaching_page
 
+    when_i_go_back
+    when_i_choose_not_sure
+    when_i_press_continue
+    then_i_see_the_unsupervised_teaching_page
+
     when_i_press_continue
     then_i_see_a_validation_error
     when_i_choose_not_sure
@@ -89,9 +94,11 @@ RSpec.describe "Eligibility screener", type: :system do
   def then_i_see_the_completion_page
     expect(page).to have_current_path("/complete")
     expect(page).to have_title(
-      "You need to complete a referral form - Refer serious misconduct by a teacher"
+      "You can also refer serious misconduct offline - Refer serious misconduct by a teacher"
     )
-    expect(page).to have_content("You need to complete a referral form")
+    expect(page).to have_content(
+      "You can also refer serious misconduct offline"
+    )
   end
 
   def then_i_see_the_employer_or_public_question


### PR DESCRIPTION
The designs updated recently to replace the word 'report' with the more
consistent 'refer'.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
