### PR TITLE
Referrals employer form - Contact details / their email page

### DIFF
--- a/app/controllers/referrals/contact_details/email_controller.rb
+++ b/app/controllers/referrals/contact_details/email_controller.rb
@@ -1,0 +1,33 @@
+module Referrals
+  module ContactDetails
+    class EmailController < ReferralsController
+      def edit
+        @contact_details_email_form =
+          EmailForm.new(
+            email_known: referral.email_known,
+            email_address: referral.email_address
+          )
+      end
+
+      def update
+        @contact_details_email_form =
+          EmailForm.new(contact_details_email_form_params.merge(referral:))
+        if @contact_details_email_form.save
+          # TODO: Redirect to personal details telephone
+          redirect_to edit_referral_path(referral)
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def contact_details_email_form_params
+        params.require(:referrals_contact_details_email_form).permit(
+          :email_known,
+          :email_address
+        )
+      end
+    end
+  end
+end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -1,6 +1,7 @@
 class ReferralForm
   include Rails.application.routes.url_helpers
   include ActiveModel::Model
+  include Rails.application.routes.url_helpers
 
   attr_accessor :referral
 
@@ -61,7 +62,7 @@ class ReferralForm
         ),
         ReferralSectionItem.new(
           I18n.t("referral_form.contact_details"),
-          "#",
+          referrals_edit_contact_details_email_path(referral),
           :not_started_yet
         ),
         ReferralSectionItem.new(

--- a/app/forms/referrals/contact_details/email_form.rb
+++ b/app/forms/referrals/contact_details/email_form.rb
@@ -1,0 +1,29 @@
+module Referrals
+  module ContactDetails
+    class EmailForm
+      include ActiveModel::Model
+
+      attr_accessor :referral, :email_address
+      attr_reader :email_known
+
+      validates :referral, presence: true
+      validates :email_known, inclusion: { in: [true, false] }
+      validates :email_address,
+                presence: true,
+                valid_for_notify: true,
+                if: -> { email_known }
+
+      def email_known=(value)
+        @email_known = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save
+        return false unless valid?
+
+        referral.email_known = email_known
+        referral.email_address = email_known ? email_address : nil
+        referral.save
+      end
+    end
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -6,6 +6,8 @@
 #  age_known        :integer
 #  approximate_age  :string
 #  date_of_birth    :date
+#  email_address    :string(256)
+#  email_known      :boolean
 #  first_name       :string
 #  last_name        :string
 #  name_has_changed :string

--- a/app/views/referrals/contact_details/email/edit.html.erb
+++ b/app/views/referrals/contact_details/email/edit.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, "#{"Error: " if @contact_details_email_form.errors.any?}Do you know the personal email address of the person you are referring?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @contact_details_email_form, url: referrals_update_contact_details_email_url, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_radio_buttons_fieldset :email_known, legend: { size: "l", text: "Do you know the personal email address of the person you are referring?" }  do %>
+        <%= f.hidden_field :email_known %>
+        <%= f.govuk_radio_button :email_known, true, label: { text: "Yes" } do %>
+          <%= f.govuk_text_field :email_address, label: { text: "Email address" } %>
+        <% end %>
+        <%= f.govuk_radio_button :email_known, false, label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue", prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,11 @@ en:
               inclusion: Please indicate whether their name has changed
             previous_name:
               blank: Previous name can't be blank
+        "referrals/contact_details/email_form":
+          attributes:
+            email_address:
+              blank: The email address can't be blank
+              invalid: Enter an email address in the correct format, like name@example.com
 
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,13 @@ Rails.application.routes.draw do
     put "/:id/personal-details/name",
         to: "personal_details/name#update",
         as: "update_personal_details_name"
+
+    get "/:id/contact-details/email",
+        to: "contact_details/email#edit",
+        as: "edit_contact_details_email"
+    put "/:id/contact-details/email",
+        to: "contact_details/email#update",
+        as: "update_contact_details_email"
   end
 
   get "/performance", to: "performance#index"

--- a/db/migrate/20221026143109_add_teacher_contact_details_email_to_referrals.rb
+++ b/db/migrate/20221026143109_add_teacher_contact_details_email_to_referrals.rb
@@ -1,0 +1,8 @@
+class AddTeacherContactDetailsEmailToReferrals < ActiveRecord::Migration[7.0]
+  def change
+    change_table :referrals, bulk: true do |t|
+      t.string :email_known, :boolean
+      t.string :email_address, :string, limit: 256
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,6 +36,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_01_131509) do
   create_table "referrals", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "email_known"
+    t.string "email_address", limit: 256
     t.string "first_name"
     t.string "last_name"
     t.string "previous_name"

--- a/spec/forms/referrals/contact_details/email_form_spec.rb
+++ b/spec/forms/referrals/contact_details/email_form_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe Referrals::ContactDetails::EmailForm, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:referral) }
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    let(:referral) { Referral.new }
+    let(:form) { described_class.new(referral:, email_known:, email_address:) }
+    let(:email_known) { true }
+    let(:email_address) { "name@example.com" }
+
+    it { is_expected.to be_truthy }
+
+    context "when email_known is blank" do
+      let(:email_known) { "" }
+
+      it { is_expected.to be_falsy }
+    end
+
+    context "when email_address is blank" do
+      let(:email_address) { "" }
+
+      it { is_expected.to be_falsy }
+    end
+
+    context "when email_address is invalid" do
+      let(:email_address) { "name" }
+
+      it { is_expected.to be_falsy }
+    end
+
+    context "when email_known is false and email_address is blank" do
+      let(:email_known) { false }
+      let(:email_address) { "" }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:referral) { Referral.new }
+    let(:form) do
+      described_class.new(
+        referral:,
+        email_known: true,
+        email_address: "name@example.com"
+      )
+    end
+
+    it "saves the referral" do
+      save
+      expect(referral.email_known).to be_truthy
+      expect(referral.email_address).to eq("name@example.com")
+    end
+  end
+end

--- a/spec/system/referrals/user_adds_contact_details_email_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_email_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Contact details" do
+  scenario "User submits contact details for the referred person" do
+    given_the_service_is_open
+    and_the_employer_form_feature_is_active
+    and_i_have_an_existing_referral
+    when_i_visit_the_referral_summary
+    and_i_click_on_contact_details
+    then_i_see_the_personal_email_address_page
+
+    when_i_select_yes_without_email
+    and_i_press_continue
+    then_i_see_a_missing_email_error
+
+    when_i_select_yes_with_an_invalid_email
+    and_i_press_continue
+    then_i_see_an_invalid_email_error
+
+    when_i_select_yes_with_a_valid_email
+    and_i_press_continue
+    then_i_get_redirected_to_the_referral_summary
+
+    and_i_click_on_contact_details
+    when_i_select_no
+    and_i_press_continue
+    then_i_get_redirected_to_the_referral_summary
+  end
+
+  private
+
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_the_employer_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_i_have_an_existing_referral
+    @referral = Referral.create!
+  end
+
+  def when_i_visit_the_referral_summary
+    visit edit_referral_path(@referral)
+  end
+
+  def and_i_click_on_contact_details
+    click_link "Contact details"
+  end
+
+  def then_i_see_the_personal_email_address_page
+    expect(page).to have_current_path(
+      "/referrals/#{@referral.id}/contact-details/email"
+    )
+    expect(page).to have_title(
+      "Do you know the personal email address of the person you are referring?"
+    )
+    expect(page).to have_content(
+      "Do you know the personal email address of the person you are referring?"
+    )
+  end
+
+  def when_i_select_yes_without_email
+    choose "Yes", visible: false
+  end
+
+  def and_i_press_continue
+    click_on "Save and continue"
+  end
+
+  def then_i_see_a_missing_email_error
+    expect(page).to have_content("The email address can't be blank")
+  end
+
+  def when_i_select_yes_with_an_invalid_email
+    choose "Yes", visible: false
+    fill_in "Email address", with: "name"
+  end
+
+  def then_i_see_an_invalid_email_error
+    expect(page).to have_content(
+      "Enter an email address in the correct format, like name@example.com"
+    )
+  end
+
+  def when_i_select_yes_with_a_valid_email
+    choose "Yes", visible: false
+    fill_in "Email address", with: "name@example.com"
+  end
+
+  def then_i_get_redirected_to_the_referral_summary
+    expect(page).to have_current_path("/referrals/#{@referral.id}/edit")
+    expect(page).to have_content("Your allegation of serious misconduct")
+  end
+
+  def when_i_select_no
+    choose "No", visible: false
+  end
+end


### PR DESCRIPTION
### Context

When making a referral, the email of the person being referred needs to be specified.

https://teacher-misconduct.herokuapp.com/report/teacher-contact-details/email

https://trello.com/c/fF5VwXw5/861-contact-form-add-email-address-page

### Changes proposed in this pull request

Add the following page, accessible from the employer form hub:
<img width="742" alt="Screenshot 2022-10-28 at 15 06 44" src="https://user-images.githubusercontent.com/1636476/198635670-deb4d362-fe1a-4387-bf06-1d96947a1d6f.png">

* Update the routes
* Generate a migration for adding the email to the referrals table.
* Add the form, including validation 
* Link the form to the referral hub

### Guidance to review

To make merging easier, I have updated this PR to be more in-line with @steventux's #94 as I initially had a slightly different approach. One thing I didn't update was to create one from model for the "Contact details" journey. It seems like Steve 
created a [PersonalDetailsForm](https://github.com/DFE-Digital/refer-serious-misconduct/pull/94/files#diff-14e5071aa6cd1cb2cfaad4dc826c6400223159eaff193c2b0182d4d8f4eace21R2). I'd rather have a [model](https://github.com/DFE-Digital/refer-serious-misconduct/pull/97/files#diff-f24b6365d33f4c1eff916a217b38b5a75c2077b24eee898f64f0cfc293f4de12R2) for every form in the "Contact details" section.

### Checklist

- [X] Attach to Trello card
- [X] Rebased main
- [X] Cleaned commit history
- [X] Tested by running locally
