### PR TITLE
Fix prod deployment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,6 +23,7 @@ jobs:
       image_name_tag: ${{ steps.build_image.outputs.ghcr_image_name_tag }}
     steps:
       - uses: actions/checkout@v3
+
       - uses: ./.github/actions/build-image
         id: build_image
         with:
@@ -30,7 +31,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
 
-  deploy_nonprod:
+  deploy:
     name: Deploy to ${{ matrix.environment }} environment
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -39,7 +40,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: [dev, test, preprod]
+        environment: [dev, test, preprod, production]
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy.outputs.environment_url }}
@@ -56,31 +57,10 @@ jobs:
           image_name_tag: ${{ needs.build_image.outputs.image_name_tag }}
           image_tag: ${{ github.sha }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
       - uses: ./.github/actions/smoke-test
+        if: ${{ matrix.environment }} != 'production'
         id: smoke-test
         with:
           environment: ${{ matrix.environment }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-
-  deploy_production:
-    name: Deploy to production environment
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    environment:
-      name: production
-      url: ${{ steps.deploy.outputs.environment_url }}
-    concurrency: deploy_production
-    needs: [deploy_nonprod]
-
-    outputs:
-      environment_url: ${{ steps.deploy.outputs.environment_url }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ./.github/actions/deploy-environment
-        id: deploy
-        with:
-          environment_name: production
-          image_tag: ${{ github.sha }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,4 @@
 * @DFE-Digital/refer-serious-misconduct
+/.github/ @DFE-Digital/teacher-services-infrastructure @DFE-Digital/refer-serious-misconduct
+/terraform/ @DFE-Digital/teacher-services-infrastructure @DFE-Digital/refer-serious-misconduct
+Makefile @DFE-Digital/teacher-services-infrastructure @DFE-Digital/refer-serious-misconduct


### PR DESCRIPTION
### Context

The deploy to production job is defined separately, changes were not applied to it that were made to the deploy to non-production job so it failed.

### Changes proposed in this pull request

- Refactor deploy jobs as a single job and add condition to smoke test step
- Added teacher-services-infrastructure to CODEOWNERS

### Guidance to review

- The only way to test this is to modify the workflow so the branch is deployed, at present we only deploy `main`.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history

