### PR TITLE
Add a performance dashboard

### DIFF
--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -1,0 +1,80 @@
+.app-card {
+  background-color: govuk-colour("light-grey");
+  display: block;
+  padding: govuk-spacing(2);
+  text-decoration: none;
+  @include govuk-font($size: 19);
+
+  @include govuk-media-query($from: desktop) {
+    padding: govuk-spacing(4);
+  }
+}
+
+.app-card--blue {
+  background: govuk-colour("blue");
+  color: govuk-colour("white");
+}
+
+.app-card--grey {
+  color: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
+  background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90);
+}
+
+.app-card--purple {
+  color: govuk-shade(govuk-colour("purple"), 20);
+  background: govuk-tint(govuk-colour("purple"), 80);
+}
+
+.app-card--turquoise {
+  color: govuk-shade(govuk-colour("turquoise"), 60);
+  background: govuk-tint(govuk-colour("turquoise"), 70);
+}
+
+.app-card--light-blue {
+  color: govuk-shade(govuk-colour("blue"), 30);
+  background: govuk-tint(govuk-colour("blue"), 80);
+}
+
+.app-card--yellow {
+  color: govuk-shade(govuk-colour("yellow"), 65);
+  background: govuk-tint(govuk-colour("yellow"), 75);
+}
+
+.app-card--orange {
+  color: govuk-shade(govuk-colour("orange"), 55);
+  background: govuk-tint(govuk-colour("orange"), 70);
+}
+
+.app-card--red {
+  color: govuk-shade(govuk-colour("red"), 30);
+  background: govuk-tint(govuk-colour("red"), 80);
+}
+
+.app-card--pink {
+  color: govuk-shade(govuk-colour("pink"), 40);
+  background: govuk-tint(govuk-colour("pink"), 80);
+}
+
+.app-card--green {
+  color: govuk-shade(govuk-colour("green"), 20);
+  background: govuk-tint(govuk-colour("green"), 80);
+}
+
+.app-card--red {
+  color: govuk-shade(govuk-colour("red"), 30);
+  background: govuk-tint(govuk-colour("red"), 80);
+}
+
+.app-card--white {
+  background-color: govuk-colour("white");
+}
+
+.app-card__count {
+  @include govuk-font($size: 80, $weight: bold);
+  display: block;
+}
+
+.app-card__secondary-count {
+  @include govuk-font($size: 48, $weight: bold);
+  display: block;
+}

--- a/app/assets/stylesheets/_performance-table.scss
+++ b/app/assets/stylesheets/_performance-table.scss
@@ -1,0 +1,24 @@
+.app-performance-table td {
+  @include govuk-font($size: false, $tabular: true);
+}
+
+.app-performance-table-total-row {
+  td,
+  th {
+    border-top: 2px solid $govuk-border-colour;
+    border-bottom: none;
+  }
+}
+
+.app-performance-table-column-divider {
+  border-right: 2px solid $govuk-border-colour;
+
+  + td,
+  + th {
+    padding-left: govuk-spacing(2);
+  }
+}
+
+.app-performance-table-date-column {
+  width: 25%;
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -3,7 +3,9 @@ $govuk-new-link-styles: true;
 $govuk-assets-path: "/";
 
 @import "govuk-frontend/govuk/all";
-@import "_task-list.scss";
+@import "_task-list";
+@import "_performance-table";
+@import "card";
 
 .app-govuk-related-navigation {
   @include govuk-text-colour;

--- a/app/components/eligibility_performance_table_component.rb
+++ b/app/components/eligibility_performance_table_component.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+class EligibilityPerformanceTableComponent < ViewComponent::Base
+  include PerformanceTableHelpers
+  include ActiveModel::Model
+
+  attr_accessor :grouped_request_counts, :since, :total_grouped_requests
+
+  def call
+    govuk_table(classes: "app-performance-table") do |table|
+      table.head do |head|
+        head.row do |row|
+          row.cell(
+            header: true,
+            text: "Date",
+            classes:
+              "app-performance-table-column-divider app-performance-table-date-column"
+          )
+          row.cell(header: true, text: "Complete")
+          row.cell(header: true, text: "Screened out")
+          row.cell(
+            header: true,
+            text: "Did not finish",
+            classes: "app-performance-table-column-divider"
+          )
+          row.cell(
+            header: true,
+            text: "Total",
+            classes: "govuk-!-padding-left-2"
+          )
+        end
+      end
+      table.body do |body|
+        grouped_request_counts.map do |period_label, counts|
+          body.row do |row|
+            row.cell(classes: "app-performance-table-column-divider") do
+              period_label
+            end
+            row.cell { number_with_percentage_cell(counts, :complete_count) }
+            row.cell do
+              number_with_percentage_cell(counts, :screened_out_count)
+            end
+            row.cell(classes: "app-performance-table-column-divider") do
+              number_with_percentage_cell(counts, :incomplete_count)
+            end
+            row.cell { "#{number_with_delimiter(counts[:total])} checks" }
+          end
+        end
+        body.row(classes: "app-performance-table-total-row") do |row|
+          row.cell(
+            header: true,
+            classes: "app-performance-table-column-divider"
+          ) { "Total (#{since})" }
+          row.cell do
+            number_with_percentage_cell(total_grouped_requests, :complete_count)
+          end
+          row.cell do
+            number_with_percentage_cell(
+              total_grouped_requests,
+              :screened_out_count
+            )
+          end
+          row.cell(classes: "app-performance-table-column-divider") do
+            number_with_percentage_cell(
+              total_grouped_requests,
+              :incomplete_count
+            )
+          end
+          row.cell do
+            "#{number_with_delimiter(total_grouped_requests[:total])} checks"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/performance_table_helpers.rb
+++ b/app/components/performance_table_helpers.rb
@@ -1,0 +1,24 @@
+module PerformanceTableHelpers
+  def count_to_percent(attributes, numerator_key)
+    if attributes[:total].zero?
+      ""
+    else
+      percentage =
+        number_to_percentage(
+          100 * attributes[numerator_key].fdiv(attributes[:total]),
+          precision: 0
+        )
+      "(#{percentage})"
+    end
+  end
+
+  def number_with_percentage_cell(counts, key, label: nil)
+    [
+      number_with_delimiter(counts[key]),
+      label&.pluralize(counts[key]),
+      '<span class="govuk-hint govuk-!-font-size-16">',
+      count_to_percent(counts, key),
+      "</span>"
+    ].compact.join(" ").html_safe
+  end
+end

--- a/app/components/tile_component.html.erb
+++ b/app/components/tile_component.html.erb
@@ -1,0 +1,4 @@
+<div class="app-card<%= colour == :default ? '' : " app-card--#{colour}" %>">
+  <span class="<%= count_class %>"><%= number_with_delimiter(count) %></span>
+  <%= label %>
+</div>

--- a/app/components/tile_component.rb
+++ b/app/components/tile_component.rb
@@ -1,0 +1,15 @@
+class TileComponent < ViewComponent::Base
+  attr_reader :count, :label, :colour
+
+  def initialize(count:, label:, colour: :default, size: :regular)
+    super
+    @count = count
+    @label = label
+    @colour = colour
+    @size = size
+  end
+
+  def count_class
+    @size == :regular ? "app-card__count" : "app-card__secondary-count"
+  end
+end

--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class PerformanceController < ApplicationController
+  def index
+    stats = PerformanceStats.new
+
+    @total_requests_by_day = stats.total_requests_by_day
+    @request_counts_by_day = stats.request_counts_by_day
+    @total_requests_by_month = stats.total_requests_by_month
+    @request_counts_by_month = stats.request_counts_by_month
+    @daily_percentiles = stats.daily_percentiles
+    @total_percentiles = stats.total_percentiles
+  end
+end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -15,6 +15,24 @@
 class EligibilityCheck < ApplicationRecord
   validates :reporting_as, presence: true
 
+  scope :complete, -> { where(serious_misconduct: "yes") }
+  scope :group_by_day, -> { group("date_trunc('day', created_at)") }
+  scope :incomplete,
+        -> {
+          where(is_teacher: nil)
+            .or(where.not(teaching_in_england: "no"))
+            .or(where.not(unsupervised_teaching: "no"))
+            .or(where.not(serious_misconduct: "no"))
+        }
+  scope :ineligible,
+        -> {
+          where(unsupervised_teaching: "no").or(
+            where(serious_misconduct: "no")
+          ).or(where(teaching_in_england: "no"))
+        }
+  scope :previous_7_days,
+        -> { where(created_at: 1.week.ago.beginning_of_day..) }
+
   def is_teacher?
     %w[yes].include?(is_teacher)
   end

--- a/app/models/performance_stats.rb
+++ b/app/models/performance_stats.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+class PerformanceStats
+  include ActionView::Helpers::NumberHelper
+
+  LAUNCH_DATE = Date.new(2022, 10, 1).beginning_of_day.freeze
+
+  def daily_percentiles
+    @daily_percentiles ||=
+      last_n_days.map do |day|
+        percentiles = percentiles_by_day[day] || [0, 0, 0]
+        date_string =
+          day == Time.zone.today ? "Today" : day.to_fs(:weekday_day_and_month)
+        [date_string] +
+          percentiles.map do |value|
+            ActiveSupport::Duration.build(value.to_i).inspect
+          end
+      end
+  end
+
+  def request_counts_by_day
+    @request_counts_by_day ||=
+      last_n_days.map do |day|
+        requests =
+          sparse_request_counts_by_day[day] ||
+            {
+              total: 0,
+              complete_count: 0,
+              screened_out_count: 0,
+              incomplete_count: 0
+            }
+        date_string =
+          day == Time.current ? "Today" : day.to_fs(:weekday_day_and_month)
+
+        [date_string, requests]
+      end
+  end
+
+  def request_counts_by_month
+    @request_counts_by_month ||=
+      sparse_request_counts_by_month.map do |month, counts|
+        [month.to_fs(:month_and_year), counts]
+      end
+  end
+
+  def total_percentiles
+    @total_percentiles ||=
+      begin
+        percentiles =
+          eligibility_checks
+            .unscope(:group)
+            .where(serious_misconduct: "yes")
+            .pick(
+              Arel.sql(
+                "percentile_disc(0.90) within group (order by (updated_at - created_at) asc) as percentile_90"
+              ),
+              Arel.sql(
+                "percentile_disc(0.75) within group (order by (updated_at - created_at) asc) as percentile_75"
+              ),
+              Arel.sql(
+                "percentile_disc(0.50) within group (order by (updated_at - created_at) asc) as percentile_50"
+              )
+            )
+
+        (percentiles || [0, 0, 0]).map do |value|
+          ActiveSupport::Duration.build(value.to_i).inspect
+        end
+      end
+  end
+
+  def total_requests_by_day
+    @total_requests_by_day ||=
+      %i[
+        total
+        complete_count
+        screened_out_count
+        incomplete_count
+      ].index_with do |key|
+        sparse_request_counts_by_day
+          .map(&:last)
+          .collect { |attr| attr[key] }
+          .reduce(&:+) || 0
+      end
+  end
+
+  def total_requests_by_month
+    @total_requests_by_month ||=
+      %i[
+        total
+        complete_count
+        screened_out_count
+        incomplete_count
+      ].index_with do |key|
+        sparse_request_counts_by_month
+          .map(&:last)
+          .collect { |attr| attr[key] }
+          .reduce(&:+) || 0
+      end
+  end
+
+  private
+
+  def arel_columns_for_request_counts
+    [
+      Arel.sql(
+        "sum(case when serious_misconduct = 'yes' then 1 else 0 end) as complete_count"
+      ),
+      Arel.sql(
+        "sum(case when serious_misconduct = 'no' or teaching_in_england = 'no' or " \
+          "unsupervised_teaching = 'no' then 1 else 0 end) as screened_out_count"
+      ),
+      Arel.sql(
+        "sum(case when (is_teacher is null or teaching_in_england is null or unsupervised_teaching is null or " \
+          "serious_misconduct is null) and (teaching_in_england <> 'no' or unsupervised_teaching <> 'no' " \
+          "or serious_misconduct <> 'no') then 1 else 0 end) as incomplete_count"
+      ),
+      Arel.sql("count(*) as total")
+    ]
+  end
+
+  def eligibility_checks
+    @eligibility_checks ||= EligibilityCheck.previous_7_days.group_by_day
+  end
+
+  def last_n_days
+    @last_n_days ||= (0..7).map { |n| n.days.ago.beginning_of_day.utc }
+  end
+
+  def percentiles_by_day
+    @percentiles_by_day ||=
+      eligibility_checks
+        .complete
+        .group("1")
+        .pluck(
+          Arel.sql("date_trunc('day', created_at) AS day"),
+          Arel.sql(
+            "percentile_disc(0.90) within group (order by (updated_at - created_at) asc) as percentile_90"
+          ),
+          Arel.sql(
+            "percentile_disc(0.75) within group (order by (updated_at - created_at) asc) as percentile_75"
+          ),
+          Arel.sql(
+            "percentile_disc(0.50) within group (order by (updated_at - created_at) asc) as percentile_50"
+          )
+        )
+        .each_with_object({}) { |row, hash| hash[row[0]] = row.slice(1, 3) }
+  end
+
+  def sparse_request_counts_by_day
+    @sparse_request_counts_by_day ||=
+      eligibility_checks
+        .select(
+          Arel.sql("date_trunc('day', created_at) AS day"),
+          *arel_columns_for_request_counts
+        )
+        .each_with_object({}) do |row, hash|
+          hash[row["day"]] = row.attributes.except("id", "day").symbolize_keys
+        end
+  end
+
+  def sparse_request_counts_by_month
+    @sparse_request_counts_by_month ||=
+      begin
+        start_date = [
+          LAUNCH_DATE,
+          12.months.ago.beginning_of_month.beginning_of_day
+        ].max
+
+        EligibilityCheck
+          .where(created_at: (start_date..))
+          .group("date_trunc('month', created_at)")
+          .select(
+            Arel.sql("date_trunc('month', created_at) AS month"),
+            *arel_columns_for_request_counts
+          )
+          .order(Arel.sql("date_trunc('month', created_at) desc"))
+          .each_with_object({}) do |row, hash|
+            hash[row["month"]] = row
+              .attributes
+              .except("id", "month")
+              .symbolize_keys
+          end
+      end
+  end
+end

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -1,0 +1,115 @@
+<% content_for :page_title, 'Performance dashboard' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">
+        <%= t('service.name') %>
+      </span>
+      Performance dashboard
+    </h1>
+  </div>
+</div>
+
+<h2 class="govuk-heading-m">Today and the previous 7 days</h2>
+
+<div class="govuk-!-margin-bottom-4">
+  <%= render TileComponent.new(
+    colour: :blue,
+    count: @total_requests_by_day[:total],
+    label: "checks today and the previous 7 days",
+  ) %>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-third">
+    <%= render TileComponent.new(
+      colour: :green,
+      count: number_to_percentage(
+        100 * @total_requests_by_day[:complete_count].fdiv(@total_requests_by_day[:total]),
+        precision: 0
+      ), 
+      label: [
+         "completed their checks",
+         "straight away",
+         "(#{number_with_delimiter(@total_requests_by_day[:complete_count])} out of #{number_with_delimiter(@total_requests_by_day[:total])})"
+      ].join("<br />").html_safe,
+    ) %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render TileComponent.new(
+                 count: number_to_percentage(100 * @total_requests_by_day[:incomplete_count].fdiv(@total_requests_by_day[:total]), precision: 0),
+                 label: [
+                    "did not complete their journey",
+                    "",
+                    "(#{number_with_delimiter(@total_requests_by_day[:incomplete_count])} out of #{number_with_delimiter(@total_requests_by_day[:total])})"
+                  ].join("<br />").html_safe,
+                 colour: :grey) %>
+  </div>
+</div>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-7">Eligibility checks by day</h2>
+
+<%= render EligibilityPerformanceTableComponent.new(grouped_request_counts: @request_counts_by_day, total_grouped_requests: @total_requests_by_day, since: "today and the previous 7 days") %>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-7">Eligibility checks by month</h2>
+
+<%= render EligibilityPerformanceTableComponent.new(grouped_request_counts: @request_counts_by_month, total_grouped_requests: @total_requests_by_month, since: "this month and the last 12 months") %>
+
+<div class="govuk-!-margin-top-7">
+  <%= govuk_table(classes: 'app-performance-table') do |table|
+      table.caption(size: 'm', text: "How quickly did users get their eligibility status (today and the previous 7 days)")
+
+      table.head do |head|
+        head.row do |row|
+          row.cell(header: true, text: 'Date')
+          row.cell(header: true) { '90% of users<br>got their eligibility status within'.html_safe }
+          row.cell(header: true) { '75% of users<br>got their eligibility status within'.html_safe }
+          row.cell(header: true) { '50% of users<br>got their eligibility status within'.html_safe }
+        end
+      end
+
+      table.body do |body|
+        @daily_percentiles.each do |data_row|
+          body.row do |row|
+            row.cell { data_row[0] }
+            row.cell { data_row[1] }
+            row.cell { data_row[2] }
+            row.cell { data_row[3] }
+          end
+        end
+
+        body.row(classes: 'app-performance-table-total-row') do |row|
+          row.cell(header: true) { 'Average (today and the last 7 days)' }
+          row.cell { @total_percentiles[0] }
+          row.cell { @total_percentiles[1] }
+          row.cell { @total_percentiles[2] }
+        end
+     end; end %>
+</div>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-7">About this service</h2>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-body govuk-!-margin-0">Visit this service</h2>
+    <p class="govuk-heading-m">
+      <%= govuk_link_to t('service.name'), start_path %>
+    </p>
+
+    <h2 class="govuk-body govuk-!-margin-0">Ministerial department:</h2>
+    <p class="govuk-heading-m">
+      Department for Education
+    </p>
+
+    <h2 class="govuk-body govuk-!-margin-0">User:</h2>
+    <p class="govuk-heading-m">
+      Individuals
+    </p>
+
+    <h2 class="govuk-body govuk-!-margin-0">Service costs paid by:</h2>
+    <p class="govuk-heading-m">
+      Department budget
+    </p>
+  </div>
+</div>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+Date::DATE_FORMATS[:long_ordinal_uk] = "%-d %B %Y"
+
+Time::DATE_FORMATS[:weekday_day_and_month] = "%A %-d %B"
+Date::DATE_FORMATS[:weekday_day_and_month] = "%A %-d %B"
+
+Time::DATE_FORMATS[:month_and_year] = "%B %Y"
+Date::DATE_FORMATS[:month_and_year] = "%B %Y"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,8 @@ Rails.application.routes.draw do
         as: "update_personal_details_name"
   end
 
+  get "/performance", to: "performance#index"
+
   namespace :support_interface, path: "/support" do
     mount FeatureFlags::Engine => "/features"
 

--- a/spec/factories/eligibility_checks.rb
+++ b/spec/factories/eligibility_checks.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :eligibility_check do
+    reporting_as { "employer" }
+
+    trait :complete do
+      is_teacher { "yes" }
+      teaching_in_england { "yes" }
+      serious_misconduct { "yes" }
+    end
+
+    trait :not_unsupervised do
+      is_teacher { "no" }
+      unsupervised_teaching { "no" }
+    end
+  end
+end

--- a/spec/models/performance_stats_spec.rb
+++ b/spec/models/performance_stats_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+RSpec.describe PerformanceStats, type: :model do
+  describe "#request_counts_by_day" do
+    subject(:request_counts_by_day) { performance_stats.request_counts_by_day }
+
+    let(:performance_stats) { described_class.new }
+
+    before do
+      create(:eligibility_check, :complete)
+      create(:eligibility_check, :not_unsupervised)
+      create(:eligibility_check)
+    end
+
+    it "returns the request counts for the last 8 days" do
+      expect(request_counts_by_day.size).to eq(8)
+    end
+
+    it "returns the correct number of requests for today" do
+      expect(request_counts_by_day.first).to eq(
+        [
+          Time.current.to_fs(:weekday_day_and_month),
+          {
+            complete_count: 1,
+            screened_out_count: 1,
+            incomplete_count: 1,
+            total: 3
+          }
+        ]
+      )
+    end
+
+    it "returns default values for days without a request" do
+      expect(request_counts_by_day.second).to eq(
+        [
+          1.day.ago.to_fs(:weekday_day_and_month),
+          {
+            complete_count: 0,
+            screened_out_count: 0,
+            incomplete_count: 0,
+            total: 0
+          }
+        ]
+      )
+    end
+  end
+
+  describe "#total_requests_by_day" do
+    subject(:total_requests_by_day) { performance_stats.total_requests_by_day }
+
+    let(:performance_stats) { described_class.new }
+
+    it "returns zero values by default" do
+      expect(total_requests_by_day).to eq(
+        {
+          complete_count: 0,
+          screened_out_count: 0,
+          incomplete_count: 0,
+          total: 0
+        }
+      )
+    end
+
+    context "when there have been checks" do
+      before do
+        create(:eligibility_check, :complete)
+        create(:eligibility_check, :not_unsupervised)
+        create(:eligibility_check)
+      end
+
+      it "returns the totals for the period" do
+        expect(total_requests_by_day).to eq(
+          {
+            complete_count: 1,
+            screened_out_count: 1,
+            incomplete_count: 1,
+            total: 3
+          }
+        )
+      end
+    end
+  end
+
+  describe "#total_requests_by_month" do
+    subject(:total_requests_by_month) do
+      performance_stats.total_requests_by_month
+    end
+
+    let(:performance_stats) { described_class.new }
+
+    it "returns zero values by default" do
+      expect(total_requests_by_month).to eq(
+        {
+          complete_count: 0,
+          screened_out_count: 0,
+          incomplete_count: 0,
+          total: 0
+        }
+      )
+    end
+
+    context "when there have been checks" do
+      before do
+        create(:eligibility_check, :complete)
+        create(:eligibility_check, :not_unsupervised)
+        create(:eligibility_check)
+      end
+
+      it "returns the totals for the period" do
+        expect(total_requests_by_month).to eq(
+          {
+            complete_count: 1,
+            screened_out_count: 1,
+            incomplete_count: 1,
+            total: 3
+          }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to provide a snapshot of how the service is being used.

The design and metrics for this page have been lifted from Find.

I assume we will iterate on this and display more appropriate metrics as
we have need.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1004" alt="Screenshot 2022-11-01 at 9 02 52 am" src="https://user-images.githubusercontent.com/3126/199198475-32fc3c13-cb73-4467-8709-312033cb01fa.png">
