### PR TITLE
Remove `name_has_changed` enum from referrals

### DIFF
--- a/app/forms/referrals/personal_details/name_form.rb
+++ b/app/forms/referrals/personal_details/name_form.rb
@@ -10,6 +10,7 @@ module Referrals
                     :referral
 
       validates :first_name, :last_name, presence: true
+      validates :name_has_changed, inclusion: { in: %w[yes no dont_know] }
       validates :previous_name,
                 presence: true,
                 if: -> { name_has_changed == "yes" }

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -3,13 +3,15 @@
 # Table name: referrals
 #
 #  id               :bigint           not null, primary key
+#  age_known        :integer
+#  approximate_age  :string
+#  date_of_birth    :date
 #  first_name       :string
 #  last_name        :string
-#  name_has_changed :integer
+#  name_has_changed :string
 #  previous_name    :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #
 class Referral < ApplicationRecord
-  enum :name_has_changed, { yes: 0, no: 1, dont_know: 2 }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,8 @@ en:
               blank: First name can't be blank
             last_name:
               blank: Last name can't be blank
+            name_has_changed:
+              inclusion: Please indicate whether their name has changed
             previous_name:
               blank: Previous name can't be blank
 

--- a/db/migrate/20221101131509_change_referrals_name_has_changed_column_type.rb
+++ b/db/migrate/20221101131509_change_referrals_name_has_changed_column_type.rb
@@ -1,0 +1,5 @@
+class ChangeReferralsNameHasChangedColumnType < ActiveRecord::Migration[7.0]
+  def up
+    change_column :referrals, :name_has_changed, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_26_155534) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_01_131509) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,7 +39,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_26_155534) do
     t.string "first_name"
     t.string "last_name"
     t.string "previous_name"
-    t.integer "name_has_changed"
+    t.string "name_has_changed"
   end
 
   create_table "staff", force: :cascade do |t|

--- a/spec/forms/referrals/personal_details/name_form_spec.rb
+++ b/spec/forms/referrals/personal_details/name_form_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Referrals::PersonalDetails::NameForm do
     context "with invalid values" do
       let(:first_name) { "" }
       let(:last_name) { "" }
-      let(:name_has_changed) { "yes" }
+      let(:name_has_changed) { "" }
       let(:previous_name) { "" }
 
       it "fails form validation" do
@@ -40,6 +40,14 @@ RSpec.describe Referrals::PersonalDetails::NameForm do
 
         expect(form.errors[:first_name]).to include "First name can't be blank"
         expect(form.errors[:last_name]).to include "Last name can't be blank"
+        expect(form.errors[:name_has_changed]).to include(
+          "Please indicate whether their name has changed"
+        )
+      end
+
+      it "validates previous name conditionally" do
+        form.name_has_changed = "yes"
+        form.save
         expect(
           form.errors[:previous_name]
         ).to include "Previous name can't be blank"


### PR DESCRIPTION
### Context

Adding an `ApplicationRecord.enum` provides a lot of unnecessary Rails magic which was unintentional in the original PR.

### Changes proposed in this pull request

Make `Referral#name_has_changed` a text/string field, the values are validated by `NameForm`.

### Guidance to review



### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
