### PR TITLE
Added Check Service Principal workflow

### DIFF
--- a/.github/workflows/check_sp.yml
+++ b/.github/workflows/check_sp.yml
@@ -1,0 +1,71 @@
+name: Check Service Principal
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "35 6 * * *"
+
+jobs:
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.select-tests.outputs.tests }}
+    steps:
+      - name: Select Tests
+        id: select-tests
+        run: |
+          d="{'environment':'dev', 'principal': 's165d01-rsm-keyvault-readonly-access'}"
+          t="{'environment':'test', 'principal': 's165t01-rsm-keyvault-readonly-access'}"
+          p="{'environment':'production', 'principal': 's165p01-rsm-keyvault-readonly-access'}"
+          tests="{ 'data':[ ${d},  ${t},  ${p} ]}"
+          echo "tests=${tests}" >> $GITHUB_OUTPUT
+  check_expires:
+    name: ${{matrix.data.environment}}/${{ matrix.data.principal }}
+    needs: set-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.set-matrix.outputs.tests) }}
+    environment:
+      name: ${{ matrix.data.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check ${{ steps.serviceprincipal.outputs.name }}
+        uses: DFE-Digital/github-actions/CheckServicePrincipal@master
+        id: pwsh_check_expire
+        with:
+          AzureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
+          ServicePrincipal: ${{ matrix.data.principal }}
+          ExpiresWithinDays: 30
+
+      - name: Processing
+        run: echo "${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application}} expires in ${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.ExpiresDays}} days"
+
+      - name: Check out the repo
+        if: fromJson(steps.pwsh_check_expire.outputs.json_data).data.Alert
+        uses: actions/checkout@v3
+
+      - uses: Azure/login@v1
+        if: fromJson(steps.pwsh_check_expire.outputs.json_data).data.Alert
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        if: fromJson(steps.pwsh_check_expire.outputs.json_data).data.Alert
+        id: keyvault-yaml-secret
+        with:
+          keyvault: ${{ secrets.KEY_VAULT}}
+          secret: MONITORING
+          key: SLACK_WEBHOOK
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Slack Notification
+        if: fromJson(steps.pwsh_check_expire.outputs.json_data).data.Alert
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_COLOR: "#ff0000"
+          SLACK_TITLE: ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application }} ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Name }}
+          SLACK_MESSAGE: |
+            The Service Principal ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application }}
+            key ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Name }} is due to expire in ${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.ExpiresDays}} days
+            Please follow the process in https://dfe-technical-guidance.london.cloudapps.digital/how-to/security/managing-secrets/#access-key-expiration to renew.
+            SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context

Workflows depend on service principals with time limited secrets, we need to check for their expiry.

### Changes proposed in this pull request

This will check the expiry date of service principals and post an alert on Slack if they expire in less than 30 days.

### Guidance to review

Check logs for test run [here](https://github.com/DFE-Digital/refer-serious-misconduct/actions/runs/3369830283).

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history

