### PR TITLE
[WIP] Add OTP-based User auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "pg", "~> 1.4"
 gem "propshaft"
 gem "puma", "~> 5.0"
 gem "rails", "~> 7.0.3"
+gem "rotp"
 gem "sidekiq"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "view_component"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,7 @@ GEM
       nokogiri
     rexml (3.2.5)
     rladr (1.2.0)
+    rotp (6.2.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -404,6 +405,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.3)
   rladr
+  rotp
   rspec
   rspec-rails
   rubocop-govuk

--- a/app/controllers/reporting_as_controller.rb
+++ b/app/controllers/reporting_as_controller.rb
@@ -1,6 +1,9 @@
 class ReportingAsController < ApplicationController
   include EnforceQuestionOrder
 
+  # TODO: remove this, for demo only
+  before_action :authenticate_user!, only: [:new]
+
   def new
     @reporting_as_form = ReportingAsForm.new(eligibility_check:)
   end

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -5,6 +5,13 @@ class Users::OtpController < DeviseController
 
   def new
     self.resource = resource_class.find(params[:id])
+
+    ### TODO - remove these lines, for testing/debugging only
+    if HostingEnvironment.test_environment?
+      otp_generator = ROTP::HOTP.new(resource.secret_key)
+      @derived_otp = otp_generator.at(0)
+    end
+    ###
   end
 
   def create

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -1,0 +1,34 @@
+class Users::OtpController < DeviseController
+  prepend_before_action :require_no_authentication, only: [:new, :create]
+  prepend_before_action :allow_params_authentication!, only: :create
+  prepend_before_action(only: [:create]) { request.env["devise.skip_timeout"] = true }
+
+  def new
+    self.resource = resource_class.find(params[:id])
+  end
+
+  def create
+    self.resource = warden.authenticate!(auth_options)
+    set_flash_message!(:notice, :signed_in)
+    sign_in(resource_name, resource)
+    yield resource if block_given?
+    redirect_to after_sign_in_path_for(resource)
+  end
+
+  protected
+
+  def auth_options
+    mapping = Devise.mappings[resource_name]
+    { scope: resource_name, recall: "#{mapping.path.pluralize}/sessions#new" }
+  end
+
+  def translation_scope
+    "devise.sessions"
+  end
+
+  private
+
+  def after_sign_in_path_for(_resource)
+    root_path
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+class Users::SessionsController < Devise::SessionsController
+  def create
+    self.resource = resource_class.find_or_initialize_by(sign_in_params)
+
+    if resource.save
+      # generate secret and otp
+      secret_key = ROTP::Base32.random
+      otp = ROTP::HOTP.new(secret_key).at(0)
+
+      # save 32-bit key to model
+      resource.update(secret_key:)
+
+      # TODO: send otp via email
+
+      # redirect to OTP controller
+      redirect_to new_user_otp_path(id: resource.id)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def sign_in_params
+    resource_params.permit(:email)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,6 +52,18 @@ module ApplicationHelper
           )
         end
       end
+
+      if current_user
+        header.navigation_item(
+          href: main_app.users_sign_out_path,
+          text: "Sign out"
+        )
+      else
+        header.navigation_item(
+          href: main_app.new_user_session_path,
+          text: "Sign in"
+        )
+      end
     end
   end
 end

--- a/app/lib/otp_authenticatable.rb
+++ b/app/lib/otp_authenticatable.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "devise"
+require "devise/strategies/authenticatable"
+
+class OtpAuthenticatable < Devise::Strategies::Authenticatable
+  #undef :password
+  #undef :password=
+
+  attr_accessor :otp, :email
+
+  def valid_for_http_auth?
+    super && http_auth_hash[:otp].present?
+  end
+
+  def valid_for_params_auth?
+    super && params_auth_hash[:otp].present?
+  end
+
+  def authenticate!
+    resource = mapping.to.find_by(email:)
+    unless resource && resource.secret_key.present?
+      fail(:otp_invalid)
+      return
+    end
+
+    # TODO: handle expired OTPs
+
+    otp_generator = ROTP::HOTP.new(resource.secret_key)
+    derived_otp = otp_generator.at(0)
+
+    unless derived_otp == otp
+      fail(:otp_invalid)
+      return
+    end
+
+    if validate(resource)
+      remember_me(resource)
+      resource.after_otp_authentication
+      success!(resource)
+    else
+      fail(:otp_invalid)
+    end
+  end
+
+  private
+
+  # Sets the authentication hash and the token from params_auth_hash or http_auth_hash.
+  def with_authentication_hash(auth_type, auth_values)
+    self.authentication_hash = {}
+    self.authentication_type = auth_type
+    self.email = auth_values[:email]
+    self.otp = auth_values[:otp]
+
+    parse_authentication_key_values(auth_values, authentication_keys) &&
+      parse_authentication_key_values(request_values, request_keys)
+  end
+end
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,18 @@
 #
 class User < ApplicationRecord
   devise :validatable, :trackable
+
+  attr_reader :otp
+
+  def password_required?
+    false
+  end
+
+  def password
+    nil
+  end
+
+  def after_otp_authentication
+    update(secret_key: nil)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                  :bigint           not null, primary key
+#  current_sign_in_at  :datetime
+#  current_sign_in_ip  :string
+#  email               :string           default(""), not null
+#  last_sign_in_at     :datetime
+#  last_sign_in_ip     :string
+#  remember_created_at :datetime
+#  secret_key          :string
+#  sign_in_count       :integer          default(0), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email  (email) UNIQUE
+#
+class User < ApplicationRecord
+  devise :validatable, :trackable
+end

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -3,6 +3,7 @@
     <h1 class="govuk-heading-xl">
       <%= t('service.name') %>
     </h1>
+    <h2>Signed in as: <%= current_user.present? ? current_user.email : 'no one' %></h2>
   </div>
 </div>
 

--- a/app/views/users/otp/new.html.erb
+++ b/app/views/users/otp/new.html.erb
@@ -1,0 +1,15 @@
+<h1 class="govuk-heading-l">Log in</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= "Debug - expected OTP: #{@derived_otp}" %>
+    <%= form_for(resource, as: resource_name, url: user_otp_path, method: :post) do |f| %>
+      <%= f.hidden_field :email, value: resource.email %>
+      <p><%= resource.email %></p>
+
+      <%= f.govuk_text_field :otp %>
+
+      <%= f.govuk_submit "Sign in" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,0 +1,11 @@
+<h1 class="govuk-heading-l">Sign in</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(resource, as: resource_name, url: user_session_path, method: :post) do |f| %>
+      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+
+      <%= f.govuk_submit "Send code" %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -330,6 +330,9 @@ Devise.setup do |config|
   config.warden do |manager|
     manager.strategies.add(:staff_http_basic_auth, StaffHttpBasicAuthStrategy)
     manager.default_strategies(scope: :staff).unshift :staff_http_basic_auth
+
+    manager.strategies.add(:otp_authenticatable, OtpAuthenticatable)
+    manager.default_strategies(scope: :user).unshift(:otp_authenticatable)
   end
 
   # ==> Mountable engine configurations

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -16,6 +16,8 @@ en:
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
+      user:
+        otp_invalid: "Invalid code"
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,16 @@ Rails.application.routes.draw do
     get "/staff/sign_out", to: "staff/sessions#destroy"
   end
 
-  get "_sha", to: ->(_) { [200, {}, [ENV.fetch("GIT_SHA", "")]] }
+  devise_for(:user)
+  devise_scope :user do
+    get '/users/session/new', to: "users/sessions#new", as: "new_user_session"
+    post '/users/session', to: "users/sessions#create", as: "user_session"
+    get '/users/otp/new', to: "users/otp#new", as: "new_user_otp"
+    post '/users/otp', to: "users/otp#create", as: "user_otp"
+
+    get "/users/sign_out", to: "users/sessions#destroy"
+  end
+
   get "/start", to: "pages#start"
   get "/who", to: "reporting_as#new"
   post "/who", to: "reporting_as#create"
@@ -94,4 +103,6 @@ Rails.application.routes.draw do
     get "/429", to: "errors#too_many_requests"
     get "/500", to: "errors#internal_server_error"
   end
+
+  get "_sha", to: ->(_) { [200, {}, [ENV.fetch("GIT_SHA", "")]] }
 end

--- a/db/migrate/20221028153803_devise_create_users.rb
+++ b/db/migrate/20221028153803_devise_create_users.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email,                unique: true
+  end
+end

--- a/db/migrate/20221101110008_add_secret_key_to_users.rb
+++ b/db/migrate/20221101110008_add_secret_key_to_users.rb
@@ -1,0 +1,5 @@
+class AddSecretKeyToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :secret_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,4 +84,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_01_131509) do
     t.index ["unlock_token"], name: "index_staff_on_unlock_token", unique: true
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "secret_key"
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                  :bigint           not null, primary key
+#  current_sign_in_at  :datetime
+#  current_sign_in_ip  :string
+#  email               :string           default(""), not null
+#  last_sign_in_at     :datetime
+#  last_sign_in_ip     :string
+#  remember_created_at :datetime
+#  secret_key          :string
+#  sign_in_count       :integer          default(0), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email  (email) UNIQUE
+#
+FactoryBot.define do
+  factory :user do
+    
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                  :bigint           not null, primary key
+#  current_sign_in_at  :datetime
+#  current_sign_in_ip  :string
+#  email               :string           default(""), not null
+#  last_sign_in_at     :datetime
+#  last_sign_in_ip     :string
+#  remember_created_at :datetime
+#  secret_key          :string
+#  sign_in_count       :integer          default(0), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email  (email) UNIQUE
+#
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### Context

Raising this WIP PR for early feedback from the dev team.

### Changes proposed in this pull request

This PR implements a bare-bones OTP-based auth flow, using HMAC-based One Time Passwords (HOTPs). See the guidance section below for recommended testing steps.

These are yet to be implemented:

- Expiring OTPs
- Limiting the number of attempts 
- Staying on the OTP screen on failed auth, rather than returning to the email prompt
- Moving the Devise-shaped methods on the User model into a model Concern (similarly to the devise-passwordless gem)

I also have a question I'd like some input on:

The [HOTP RFC](https://datatracker.ietf.org/doc/html/rfc4226) describes a process of using an incrementing counter to generate successive OTPs from a fixed secret key. This implementation is slightly different. Here, a new key is generated whenever a new OTP is required by the user, and there is no moving counter element. It means a simpler implementation, but I'm not sure what the implications are for security. If we complement the approach here with expiry and a limit on the number of guesses, is that sufficiently secure?

### Guidance to review

- Commits provide a decent summary of the various parts needed to get this working
- 'Sign in' link is in the header
- There's no mailer code yet, so the email you provide can be arbitrary
- To assist manual testing, the OTP entry screen will render the expected OTP
- The `/why` route sits behind a user auth check for the purposes of this PR — you should only be able to access it once signed in
- The 'Sign out' link in the header should behave as expected (can use the `/why` route to test).

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
