### PR TITLE
Added custom domain and StatusCake alert

### DIFF
--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -7,5 +7,6 @@
   "app_service_plan_sku": "S1",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
-  "resource_prefix": "s165d01-"
+  "resource_prefix": "s165d01-",
+  "domain": "dev.refer-serious-misconduct.education.gov.uk"
 }

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -7,5 +7,6 @@
   "app_service_plan_sku": "S1",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
-  "resource_prefix": "s165t01-"
+  "resource_prefix": "s165t01-",
+  "domain": "preprod.refer-serious-misconduct.education.gov.uk"
 }

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -10,5 +10,14 @@
   "resource_prefix": "s165p01-",
   "worker_count": 3,
   "postgres_flexible_server_sku": "GP_Standard_D2s_v3",
-  "enable_postgres_high_availability": true
+  "enable_postgres_high_availability": true,
+  "domain": "refer-serious-misconduct.education.gov.uk",
+  "statuscake_alerts": {
+    "rsm-prod": {
+      "website_name": "refer-serious-misconduct.education.gov.uk-prod",
+      "website_url": "https://refer-serious-misconduct.education.gov.uk/health",
+      "contact_group": [249142],
+      "confirmations": 2
+    }
+  }
 }

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -7,5 +7,6 @@
   "app_service_plan_sku": "S1",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
-  "resource_prefix": "s165t01-"
+  "resource_prefix": "s165t01-",
+  "domain": "test.refer-serious-misconduct.education.gov.uk"
 }


### PR DESCRIPTION
### Context

We require a StatusCake alert for production to know when the app has gone down.  We also need to block access to the default Azure hostname.

### Changes proposed in this pull request

Custom domain will block access to the default Azure domain from anywhere other than FrontDoor.

### Guidance to review

- Check values in workspace_variables files
- Cannot test deployment as this app only deploys main branch

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history

