### PR TITLE
Referrals employer form - Contact details / their address page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "puma", "~> 5.0"
 gem "rails", "~> 7.0.3"
 gem "sidekiq"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
+gem "uk_postcode"
 
 group :development, :test do
   gem "dotenv-rails", "~> 2.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,6 +353,7 @@ GEM
     timeout (0.3.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
+    uk_postcode (2.1.8)
     unicode-display_width (2.3.0)
     view_component (2.74.1)
       activesupport (>= 5.0.0, < 8.0)
@@ -414,6 +415,7 @@ DEPENDENCIES
   syntax_tree-haml
   syntax_tree-rbs
   tzinfo-data
+  uk_postcode
   web-console
 
 RUBY VERSION

--- a/app/controllers/referrals/contact_details/address_controller.rb
+++ b/app/controllers/referrals/contact_details/address_controller.rb
@@ -1,0 +1,41 @@
+module Referrals
+  module ContactDetails
+    class AddressController < ReferralsController
+      def edit
+        @contact_details_address_form =
+          AddressForm.new(
+            address_known: referral.address_known,
+            address_line_1: referral.address_line_1,
+            address_line_2: referral.address_line_2,
+            town_or_city: referral.town_or_city,
+            postcode: referral.postcode,
+            country: referral.country
+          )
+      end
+
+      def update
+        @contact_details_address_form =
+          AddressForm.new(contact_details_address_form_params.merge(referral:))
+        if @contact_details_address_form.save
+          # TODO: Redirect to check answers page
+          redirect_to edit_referral_path(referral)
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def contact_details_address_form_params
+        params.require(:referrals_contact_details_address_form).permit(
+          :address_known,
+          :address_line_1,
+          :address_line_2,
+          :town_or_city,
+          :postcode,
+          :country
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/referrals/contact_details/email_controller.rb
+++ b/app/controllers/referrals/contact_details/email_controller.rb
@@ -14,7 +14,7 @@ module Referrals
           EmailForm.new(contact_details_email_form_params.merge(referral:))
         if @contact_details_email_form.save
           # TODO: Redirect to personal details telephone
-          redirect_to edit_referral_path(referral)
+          redirect_to referrals_update_contact_details_address_path(referral)
         else
           render :edit
         end

--- a/app/forms/referrals/contact_details/address_form.rb
+++ b/app/forms/referrals/contact_details/address_form.rb
@@ -1,0 +1,60 @@
+module Referrals
+  module ContactDetails
+    class AddressForm
+      include ActiveModel::Model
+
+      attr_accessor :referral,
+                    :address_line_1,
+                    :address_line_2,
+                    :town_or_city,
+                    :postcode,
+                    :country
+      attr_reader :address_known
+
+      validates :referral, presence: true
+      validates :address_known, inclusion: { in: [true, false] }
+      validates :address_line_1,
+                :town_or_city,
+                :postcode,
+                presence: true,
+                if: -> { address_known }
+      validate :postcode_is_valid, if: -> { postcode.present? && address_known }
+
+      def address_known=(value)
+        @address_known = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save
+        return false unless valid?
+
+        address_attrs = {
+          address_known:,
+          address_line_1: nil,
+          address_line_2: nil,
+          town_or_city: nil,
+          postcode: nil,
+          country: nil
+        }
+
+        if address_known
+          address_attrs.merge!(
+            address_line_1:,
+            address_line_2:,
+            town_or_city:,
+            postcode:,
+            country:
+          )
+        end
+        referral.update(address_attrs)
+      end
+
+      private
+
+      def postcode_is_valid
+        unless UKPostcode.parse(postcode).full_valid?
+          errors.add(:postcode, :invalid)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/referrals/contact_details/email_form.rb
+++ b/app/forms/referrals/contact_details/email_form.rb
@@ -8,10 +8,10 @@ module Referrals
 
       validates :referral, presence: true
       validates :email_known, inclusion: { in: [true, false] }
+      validates :email_address, presence: true, if: -> { email_known }
       validates :email_address,
-                presence: true,
                 valid_for_notify: true,
-                if: -> { email_known }
+                if: -> { email_known && email_address.present? }
 
       def email_known=(value)
         @email_known = ActiveModel::Type::Boolean.new.cast(value)

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -3,15 +3,21 @@
 # Table name: referrals
 #
 #  id               :bigint           not null, primary key
+#  address_known    :boolean
+#  address_line_1   :string
+#  address_line_2   :string
 #  age_known        :string
 #  approximate_age  :string
+#  country          :string
 #  date_of_birth    :date
 #  email_address    :string(256)
 #  email_known      :boolean
 #  first_name       :string
 #  last_name        :string
 #  name_has_changed :string
+#  postcode         :string(11)
 #  previous_name    :string
+#  town_or_city     :string
 #  trn              :string
 #  trn_known        :boolean
 #  created_at       :datetime         not null

--- a/app/views/referrals/contact_details/address/edit.html.erb
+++ b/app/views/referrals/contact_details/address/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, "#{"Error: " if @contact_details_address_form.errors.any?}Do you know their home address?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @contact_details_address_form, url: referrals_update_contact_details_address_url, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_radio_buttons_fieldset :address_known, legend: { size: "xl", text: "Do you know their home address?" }  do %>
+        <%= f.hidden_field :address_known %>
+        <%= f.govuk_radio_button :address_known, true, label: { text: "Yes" } do %>
+          <%= f.govuk_fieldset legend: { text: "What is their address?" } do %>
+            <%= f.govuk_text_field :address_line_1, label: { text: "Address line 1" } %>
+            <%= f.govuk_text_field :address_line_2, label: { text: "Address line 2 (optional)" } %>
+            <%= f.govuk_text_field :town_or_city, label: { text: "Town or city" } %>
+            <%= f.govuk_text_field :postcode, label: { text: "Postcode" } %>
+            <%= f.govuk_text_field :country, label: { text: "Country (optional)" } %>
+          <% end %>
+        <% end %>
+        <%= f.govuk_radio_button :address_known, false, label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue", prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,9 +88,22 @@ en:
               wrong_length: Their TRN number should contain 7 digits
         "referrals/contact_details/email_form":
           attributes:
+            email_known:
+              inclusion: Tell us if you know their email address
             email_address:
-              blank: The email address can't be blank
+              blank: Enter their email address
               invalid: Enter an email address in the correct format, like name@example.com
+        "referrals/contact_details/address_form":
+          attributes:
+            address_known:
+              inclusion: Tell us if you know their home address
+            address_line_1:
+              blank: Enter the first line of their address
+            town_or_city:
+              blank: Enter their town or city
+            postcode:
+              blank: Enter their postcode
+              invalid: Enter a real postcode
         "referrals/referrer_name_form":
           attributes:
             name:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,12 @@ Rails.application.routes.draw do
     put "/:id/contact-details/email",
         to: "contact_details/email#update",
         as: "update_contact_details_email"
+    get "/:id/contact-details/address",
+        to: "contact_details/address#edit",
+        as: "edit_contact_details_address"
+    put "/:id/contact-details/address",
+        to: "contact_details/address#update",
+        as: "update_contact_details_address"
   end
 
   get "/performance", to: "performance#index"

--- a/db/migrate/20221102204802_add_teacher_contact_details_address_to_referrals.rb
+++ b/db/migrate/20221102204802_add_teacher_contact_details_address_to_referrals.rb
@@ -1,0 +1,12 @@
+class AddTeacherContactDetailsAddressToReferrals < ActiveRecord::Migration[7.0]
+  def change
+    change_table :referrals, bulk: true do |t|
+      t.boolean :address_known
+      t.string :address_line_1
+      t.string :address_line_2
+      t.string :town_or_city
+      t.string :postcode, limit: 11
+      t.string :country
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,6 +47,12 @@ ActiveRecord::Schema[7.0].define(version: 20_221_103_120_049) do
     t.boolean "email_known"
     t.string "trn"
     t.boolean "trn_known"
+    t.boolean "address_known"
+    t.string "address_line_1"
+    t.string "address_line_2"
+    t.string "town_or_city"
+    t.string "postcode", limit: 11
+    t.string "country"
   end
 
   create_table "referrers", force: :cascade do |t|

--- a/spec/forms/referrals/contact_details/address_form_spec.rb
+++ b/spec/forms/referrals/contact_details/address_form_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
+  let(:referral) { Referral.new }
+  let(:form) do
+    described_class.new(
+      referral:,
+      address_known:,
+      address_line_1:,
+      address_line_2:,
+      town_or_city:,
+      postcode:,
+      country:
+    )
+  end
+
+  let(:address_known) { true }
+  let(:address_line_1) { "1428 Elm Street" }
+  let(:address_line_2) { "Sunset Boulevard" }
+  let(:town_or_city) { "London" }
+  let(:postcode) { "NW1 4NP" }
+  let(:country) { "United Kingdom" }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:referral) }
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    it { is_expected.to be_truthy }
+
+    before { form.save }
+
+    context "when address_known is blank" do
+      let(:address_known) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:address_known]).to eq(
+          ["Tell us if you know their home address"]
+        )
+      end
+    end
+
+    context "when address_line_1 is blank" do
+      let(:address_line_1) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:address_line_1]).to eq(
+          ["Enter the first line of their address"]
+        )
+      end
+    end
+
+    context "when town_or_city is blank" do
+      let(:town_or_city) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:town_or_city]).to eq(["Enter their town or city"])
+      end
+    end
+
+    context "when postcode is blank" do
+      let(:postcode) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:postcode]).to eq(["Enter their postcode"])
+      end
+    end
+
+    context "when postcode is invalid" do
+      let(:postcode) { "Postcode" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:postcode]).to eq(["Enter a real postcode"])
+      end
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    it "saves the referral" do
+      save
+      expect(referral.address_known).to be_truthy
+      expect(referral.address_line_1).to eq("1428 Elm Street")
+      expect(referral.address_line_2).to eq("Sunset Boulevard")
+      expect(referral.town_or_city).to eq("London")
+      expect(referral.postcode).to eq("NW1 4NP")
+      expect(referral.country).to eq("United Kingdom")
+    end
+
+    context "when the address is not known" do
+      let(:address_known) { false }
+
+      it "saves the address_known and sets the address fields as nil" do
+        save
+        expect(referral.address_known).to be_falsy
+        expect(referral.address_line_1).to be_nil
+        expect(referral.address_line_2).to be_nil
+        expect(referral.town_or_city).to be_nil
+        expect(referral.postcode).to be_nil
+        expect(referral.country).to be_nil
+      end
+    end
+  end
+end

--- a/spec/system/referrals/user_adds_contact_details_email_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_email_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Contact details" do
     and_i_click_on_contact_details
     then_i_see_the_personal_email_address_page
 
-    when_i_select_yes_without_email
+    when_i_select_yes
     and_i_press_continue
     then_i_see_a_missing_email_error
 
@@ -20,9 +20,27 @@ RSpec.feature "Contact details" do
 
     when_i_select_yes_with_a_valid_email
     and_i_press_continue
+    then_i_see_the_home_address_page
+
+    when_i_go_back
+    when_i_select_no
+    and_i_press_continue
+    then_i_see_the_home_address_page
+
+    when_i_select_yes
+    and_i_press_continue
+    then_i_see_a_missing_address_fields_error
+
+    when_i_fill_in_an_incorrect_postcode
+    and_i_press_continue
+    then_i_see_a_invalid_postcode_error
+
+    when_i_fill_in_the_address_details
+    and_i_press_continue
     then_i_get_redirected_to_the_referral_summary
 
     and_i_click_on_contact_details
+    and_i_press_continue # skip the email page
     when_i_select_no
     and_i_press_continue
     then_i_get_redirected_to_the_referral_summary
@@ -50,6 +68,10 @@ RSpec.feature "Contact details" do
     click_link "Contact details"
   end
 
+  def when_i_go_back
+    click_link "Back"
+  end
+
   def then_i_see_the_personal_email_address_page
     expect(page).to have_current_path(
       "/referrals/#{@referral.id}/contact-details/email"
@@ -62,7 +84,15 @@ RSpec.feature "Contact details" do
     )
   end
 
-  def when_i_select_yes_without_email
+  def then_i_see_the_home_address_page
+    expect(page).to have_current_path(
+      "/referrals/#{@referral.id}/contact-details/address"
+    )
+    expect(page).to have_title("Do you know their home address?")
+    expect(page).to have_content("Do you know their home address?")
+  end
+
+  def when_i_select_yes
     choose "Yes", visible: false
   end
 
@@ -71,11 +101,11 @@ RSpec.feature "Contact details" do
   end
 
   def then_i_see_a_missing_email_error
-    expect(page).to have_content("The email address can't be blank")
+    expect(page).to have_content("Enter their email address")
   end
 
   def when_i_select_yes_with_an_invalid_email
-    choose "Yes", visible: false
+    when_i_select_yes
     fill_in "Email address", with: "name"
   end
 
@@ -86,7 +116,7 @@ RSpec.feature "Contact details" do
   end
 
   def when_i_select_yes_with_a_valid_email
-    choose "Yes", visible: false
+    when_i_select_yes
     fill_in "Email address", with: "name@example.com"
   end
 
@@ -97,5 +127,25 @@ RSpec.feature "Contact details" do
 
   def when_i_select_no
     choose "No", visible: false
+  end
+
+  def then_i_see_a_missing_address_fields_error
+    expect(page).to have_content("Enter the first line of their address")
+    expect(page).to have_content("Enter their town or city")
+    expect(page).to have_content("Enter their postcode")
+  end
+
+  def when_i_fill_in_an_incorrect_postcode
+    fill_in "Postcode", with: "postcode"
+  end
+
+  def then_i_see_a_invalid_postcode_error
+    expect(page).to have_content("Enter a real postcode")
+  end
+
+  def when_i_fill_in_the_address_details
+    fill_in "Address line 1", with: "1428 Elm Street"
+    fill_in "Town or city", with: "London"
+    fill_in "Postcode", with: "NW1 4NP"
   end
 end


### PR DESCRIPTION
### Context

When making a referral, the address of the person being referred needs to be specified.

https://teacher-misconduct.herokuapp.com/report/teacher-contact-details/address
https://trello.com/c/2sfOnWSi/872-contact-form-add-address-page

Add the following page, accessible from the employer form hub:
<img width="710" alt="Screenshot 2022-11-03 at 11 24 18" src="https://user-images.githubusercontent.com/1636476/199708943-f111f2a4-8442-4aa0-864a-b9fa60a6e4d5.png">

<img width="718" alt="Screenshot 2022-11-03 at 11 24 42" src="https://user-images.githubusercontent.com/1636476/199708970-4c600477-4232-4c23-be70-e4687f6bb36a.png">

* Update the routes
* Generate a migration for adding the address fields to the referrals table.
* Add the form, including validation 
* Link the form to the email question page

### Checklist

- [X] Attach to Trello card
- [X] Rebased main
- [X] Cleaned commit history
- [X] Tested by running locally
