### PR TITLE
Fix incorrect fields in the referrals table

### DIFF
--- a/db/migrate/20221026143109_add_teacher_contact_details_email_to_referrals.rb
+++ b/db/migrate/20221026143109_add_teacher_contact_details_email_to_referrals.rb
@@ -1,8 +1,8 @@
 class AddTeacherContactDetailsEmailToReferrals < ActiveRecord::Migration[7.0]
   def change
     change_table :referrals, bulk: true do |t|
-      t.string :email_known, :boolean
-      t.string :email_address, :string, limit: 256
+      t.boolean :email_known
+      t.string :email_address, limit: 256
     end
   end
 end

--- a/db/migrate/20221103120049_fix_referrals_table.rb
+++ b/db/migrate/20221103120049_fix_referrals_table.rb
@@ -1,0 +1,20 @@
+# TODO: Delete this file at some point, when all databases in use have migrated
+# Also potentially move the `email_known` field before the email_address in `schema.db`
+# as postgres doesn't support ordering in migrations
+
+class FixReferralsTable < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      change_table :referrals do |t|
+        dir.up do
+          t.remove :email_known, if_exists: true
+          t.boolean :email_known, if_not_exists: true
+          t.remove :boolean, if_exists: true
+          t.remove :string, if_exists: true
+        end
+
+        dir.down { t.boolean :email_known }
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_02_132623) do
+ActiveRecord::Schema[7.0].define(version: 20_221_103_120_049) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,7 +36,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_02_132623) do
   create_table "referrals", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "email_known"
     t.string "email_address", limit: 256
     t.string "first_name"
     t.string "last_name"
@@ -45,6 +44,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_02_132623) do
     t.date "date_of_birth"
     t.string "age_known"
     t.string "approximate_age"
+    t.boolean "email_known"
   end
 
   create_table "referrers", force: :cascade do |t|


### PR DESCRIPTION
### Context
A broken migration created some unnecessary fields in the database. 

### Changes proposed in this pull request
The migration will change the data type of the `email_known` field from `string` to `boolean`  and remove two others fields (`string` and `boolean`). One factory was also annotated on migration.

### Guidance to review
I had to format the migration in a certain way to avoid the rubocop lint errors.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
