### PR TITLE
Referrals employer form - Add their QTS page

### DIFF
--- a/app/controllers/referrals/personal_details/qts_controller.rb
+++ b/app/controllers/referrals/personal_details/qts_controller.rb
@@ -1,0 +1,26 @@
+module Referrals
+  module PersonalDetails
+    class QtsController < ReferralsController
+      def edit
+        @personal_details_qts_form =
+          QtsForm.new(referral:, has_qts: referral.has_qts)
+      end
+
+      def update
+        @personal_details_qts_form = QtsForm.new(qts_params.merge(referral:))
+
+        if @personal_details_qts_form.save
+          # TODO: Redirect to personal details summary
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def qts_params
+        params.fetch(:referrals_personal_details_qts_form, {}).permit(:has_qts)
+      end
+    end
+  end
+end

--- a/app/controllers/referrals/personal_details/trn_controller.rb
+++ b/app/controllers/referrals/personal_details/trn_controller.rb
@@ -14,7 +14,7 @@ module Referrals
         @personal_details_trn_form = TrnForm.new(trn_params.merge(referral:))
 
         if @personal_details_trn_form.save
-          # TODO: Redirect to personal details confirm
+          redirect_to referrals_edit_personal_details_qts_path(referral)
         else
           render :edit
         end

--- a/app/forms/referrals/personal_details/qts_form.rb
+++ b/app/forms/referrals/personal_details/qts_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Referrals
+  module PersonalDetails
+    class QtsForm
+      include ActiveModel::Model
+
+      attr_accessor :referral, :has_qts
+
+      validates :has_qts, inclusion: { in: %w[yes no dont_know] }
+
+      def save
+        referral.update(has_qts:) if valid?
+      end
+    end
+  end
+end

--- a/app/forms/referrals/personal_details/trn_form.rb
+++ b/app/forms/referrals/personal_details/trn_form.rb
@@ -4,19 +4,18 @@ module Referrals
     class TrnForm
       include ActiveModel::Model
 
-      attr_accessor :trn_known, :referral
-      attr_reader :trn
+      attr_accessor :referral
+      attr_reader :trn, :trn_known
 
-      validates :trn_known, inclusion: { in: %w[true false] }
-      validates :trn,
-                presence: true,
-                length: {
-                  is: 7
-                },
-                if: -> { trn_known == "true" }
+      validates :trn_known, inclusion: { in: [true, false] }
+      validates :trn, presence: true, length: { is: 7 }, if: -> { trn_known }
 
       def trn=(value)
         @trn = value&.delete("^0-9")
+      end
+
+      def trn_known=(value)
+        @trn_known = ActiveModel::Type::Boolean.new.cast(value)
       end
 
       def save

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -13,6 +13,7 @@
 #  email_address    :string(256)
 #  email_known      :boolean
 #  first_name       :string
+#  has_qts          :string
 #  last_name        :string
 #  name_has_changed :string
 #  postcode         :string(11)

--- a/app/views/referrals/personal_details/qts/edit.html.erb
+++ b/app/views/referrals/personal_details/qts/edit.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, "#{'Error: ' if @personal_details_qts_form.errors.any?}Do they have qualified teacher status (QTS)?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: @personal_details_qts_form, url: referrals_update_personal_details_qts_path(@referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+      <div class="govuk-form-group">
+        <%= f.govuk_radio_buttons_fieldset(:has_qts, legend: { size: "xl", text: "Do they have qualified teacher status (QTS)?" }) do %>
+          <%= f.govuk_radio_button :has_qts, "yes", label: { text: "Yes, they have QTS" } %>
+          <%= f.govuk_radio_button :has_qts, "no", label: { text: "No, they do not have QTS" } %>
+          <%= f.govuk_radio_button :has_qts, "dont_know", label: { text: " I don’t know" } %>
+        <% end %>
+      </div>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/personal_details/trn/edit.html.erb
+++ b/app/views/referrals/personal_details/trn/edit.html.erb
@@ -11,11 +11,11 @@
           legend: { size: "xl", text: "Do you know their teacher reference number (TRN)?" },
           hint: { text: "A TRN is 7 digits long, for example 4567814."},
         ) do %>
-          <%= f.govuk_radio_button :trn_known, true, label: { text: "Yes" } do %>
+          <%= f.govuk_radio_button :trn_known, "true", label: { text: "Yes" } do %>
             <%= f.govuk_text_field :trn,
                 label: { text: "Teacher reference number", class: "govuk-label--s" } %>
           <% end %>
-          <%= f.govuk_radio_button :trn_known, false, label: { text: "No" } %>
+          <%= f.govuk_radio_button :trn_known, "false", label: { text: "No" } %>
         <% end %>
       </div>
       <%= f.govuk_submit "Save and continue" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,7 +68,7 @@ en:
             approximate_age:
               blank: Enter their approximate age
             age_known:
-              inclusion: Please indicate whether you know their date of birth or age
+              inclusion: Tell us if you know their date of birth or age
         "referrals/personal_details/name_form":
           attributes:
             first_name:
@@ -76,7 +76,7 @@ en:
             last_name:
               blank: Last name can't be blank
             name_has_changed:
-              inclusion: Please indicate whether their name has changed
+              inclusion: Tell us if you know their name has changed
             previous_name:
               blank: Previous name can't be blank
         "referrals/personal_details/trn_form":
@@ -86,6 +86,10 @@ en:
             trn:
               blank: Enter their TRN number
               wrong_length: Their TRN number should contain 7 digits
+        "referrals/personal_details/qts_form":
+          attributes:
+            has_qts:
+              inclusion: Tell us if you know whether they have QTS
         "referrals/contact_details/email_form":
           attributes:
             email_known:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,12 @@ Rails.application.routes.draw do
     put "/:id/personal-details/trn",
         to: "personal_details/trn#update",
         as: "update_personal_details_trn"
+    get "/:id/personal-details/qts",
+        to: "personal_details/qts#edit",
+        as: "edit_personal_details_qts"
+    put "/:id/personal-details/qts",
+        to: "personal_details/qts#update",
+        as: "update_personal_details_qts"
 
     get "/:id/contact-details/email",
         to: "contact_details/email#edit",

--- a/db/migrate/20221102174757_add_referrals_qts_field.rb
+++ b/db/migrate/20221102174757_add_referrals_qts_field.rb
@@ -1,0 +1,5 @@
+class AddReferralsQtsField < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrals, :has_qts, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,6 +53,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_03_124121) do
     t.string "town_or_city"
     t.string "postcode", limit: 11
     t.string "country"
+    t.string "has_qts"
   end
 
   create_table "referrers", force: :cascade do |t|

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -5,15 +5,16 @@
 #  id               :bigint           not null, primary key
 #  age_known        :string
 #  approximate_age  :string
-#  boolean          :string
 #  date_of_birth    :date
 #  email_address    :string(256)
-#  email_known      :string
+#  email_known      :boolean
 #  first_name       :string
+#  has_qts          :string
 #  last_name        :string
 #  name_has_changed :string
 #  previous_name    :string
-#  string           :string(256)
+#  trn              :string
+#  trn_known        :boolean
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #

--- a/spec/forms/referrals/personal_details/name_form_spec.rb
+++ b/spec/forms/referrals/personal_details/name_form_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Referrals::PersonalDetails::NameForm do
         expect(form.errors[:first_name]).to include "First name can't be blank"
         expect(form.errors[:last_name]).to include "Last name can't be blank"
         expect(form.errors[:name_has_changed]).to include(
-          "Please indicate whether their name has changed"
+          "Tell us if you know their name has changed"
         )
       end
 

--- a/spec/forms/referrals/personal_details/qts_form_spec.rb
+++ b/spec/forms/referrals/personal_details/qts_form_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Referrals::PersonalDetails::QtsForm, type: :model do
+  describe "#save" do
+    let(:referral) { Referral.new }
+    let(:has_qts) { "yes" }
+    subject(:save) { qts_form.save }
+
+    let(:qts_form) { described_class.new(referral:, has_qts:) }
+
+    context "with a valid value" do
+      it "saves the value on the referral" do
+        save
+        expect(referral.has_qts).to eq("yes")
+      end
+    end
+
+    context "with no values" do
+      let(:has_qts) { nil }
+      it "adds an error" do
+        save
+        expect(qts_form.errors[:has_qts]).to eq(
+          ["Tell us if you know whether they have QTS"]
+        )
+      end
+    end
+
+    context "with an invalid value" do
+      let(:has_qts) { "eh?" }
+      it "adds an error" do
+        save
+        expect(qts_form.errors[:has_qts]).to eq(
+          ["Tell us if you know whether they have QTS"]
+        )
+      end
+    end
+  end
+end

--- a/spec/forms/referrals/personal_details/trn_form_spec.rb
+++ b/spec/forms/referrals/personal_details/trn_form_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Referrals::PersonalDetails::TrnForm, type: :model do
   it do
-    is_expected.to validate_inclusion_of(:trn_known).in_array(%w[true false])
+    is_expected.to validate_inclusion_of(:trn_known).in_array([true, false])
   end
 
   describe "#save" do

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -12,6 +12,12 @@
 #  last_name        :string
 #  name_has_changed :string
 #  previous_name    :string
+#  has_qts          :string
+#  last_name        :string
+#  name_has_changed :string
+#  previous_name    :string
+#  trn              :string
+#  trn_known        :boolean
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -5,15 +5,27 @@ RSpec.feature "Personal details" do
   scenario "User adds personal details to a referral" do
     given_the_service_is_open
     and_the_employer_form_feature_is_active
-    and_i_am_making_a_referral
+    and_i_visit_a_referral
+    then_i_see_the_referral_summary
 
     when_i_edit_personal_details
+    and_i_am_asked_their_name
+    and_i_click_back
+    then_i_see_the_referral_summary
+
+    when_i_edit_personal_details
+    and_i_am_asked_their_name
     and_i_click_save_and_continue
     then_i_see_name_field_validation_errors
 
     when_i_fill_out_the_name_fields_and_save
     and_i_click_save_and_continue
-    then_i_am_asked_if_i_know_their_date_of_birth
+    then_i_am_asked_their_date_of_birth
+
+    when_i_click_back
+    and_i_am_asked_their_name
+    and_i_click_save_and_continue
+    then_i_am_asked_their_date_of_birth
 
     and_i_click_save_and_continue
     then_i_see_age_field_validation_errors
@@ -22,10 +34,21 @@ RSpec.feature "Personal details" do
     and_i_click_save_and_continue
     then_i_am_asked_if_i_know_their_trn
 
+    when_i_click_back
+    then_i_am_asked_their_date_of_birth
+
+    and_i_click_save_and_continue
+    then_i_am_asked_if_i_know_their_trn
+
     and_i_click_save_and_continue
     then_i_see_trn_field_validation_errors
 
     when_i_fill_out_their_trn
+    and_i_click_save_and_continue
+    then_i_am_asked_if_i_know_whether_they_have_qts
+
+    when_i_click_back
+    then_i_am_asked_if_i_know_their_trn
     and_i_click_save_and_continue
     then_i_am_asked_if_i_know_whether_they_have_qts
 
@@ -48,15 +71,28 @@ RSpec.feature "Personal details" do
     FeatureFlags::FeatureFlag.activate(:employer_form)
   end
 
-  def and_i_am_making_a_referral
+  def and_i_visit_a_referral
     @referral = Referral.create!
     visit edit_referral_path(@referral)
-
-    expect(page).to have_content("Your allegation of serious misconduct")
   end
 
   def when_i_edit_personal_details
     within(all(".app-task-list__section")[1]) { click_on "Personal details" }
+  end
+
+  def and_i_am_asked_their_name
+    expect(page).to have_content(
+      "What is the name of the person you’re referring?"
+    )
+  end
+
+  def when_i_click_back
+    click_on "Back"
+  end
+  alias_method :and_i_click_back, :when_i_click_back
+
+  def then_i_see_the_referral_summary
+    expect(page).to have_content("Your allegation of serious misconduct")
   end
 
   def then_i_see_name_field_validation_errors
@@ -75,7 +111,7 @@ RSpec.feature "Personal details" do
     click_on "Save and continue"
   end
 
-  def then_i_am_asked_if_i_know_their_date_of_birth
+  def then_i_am_asked_their_date_of_birth
     expect(page).to have_content("Do you know their age or date of birth?")
   end
 
@@ -113,9 +149,7 @@ RSpec.feature "Personal details" do
   end
 
   def then_i_see_qts_field_validation_errors
-    expect(page).to have_content(
-      "Tell us if you know whether they have QTS"
-    )
+    expect(page).to have_content("Tell us if you know whether they have QTS")
   end
 
   def when_i_fill_out_their_qts

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -27,6 +27,13 @@ RSpec.feature "Personal details" do
 
     when_i_fill_out_their_trn
     and_i_click_save_and_continue
+    then_i_am_asked_if_i_know_whether_they_have_qts
+
+    and_i_click_save_and_continue
+    then_i_see_qts_field_validation_errors
+
+    when_i_fill_out_their_qts
+    and_i_click_save_and_continue
 
     then_the_section_summary_displays_the_saved_personal_details
   end
@@ -74,7 +81,7 @@ RSpec.feature "Personal details" do
 
   def then_i_see_age_field_validation_errors
     expect(page).to have_content(
-      "Please indicate whether you know their date of birth or age"
+      "Tell us if you know their date of birth or age"
     )
   end
 
@@ -101,6 +108,20 @@ RSpec.feature "Personal details" do
     fill_in "Teacher reference number", with: "RP99/12345"
   end
 
+  def then_i_am_asked_if_i_know_whether_they_have_qts
+    expect(page).to have_content("Do they have qualified teacher status (QTS)?")
+  end
+
+  def then_i_see_qts_field_validation_errors
+    expect(page).to have_content(
+      "Tell us if you know whether they have QTS"
+    )
+  end
+
+  def when_i_fill_out_their_qts
+    choose "Yes", visible: false
+  end
+
   def then_the_section_summary_displays_the_saved_personal_details
     # TODO: This will assert the section summary page contents, not built yet
     @referral.reload
@@ -109,5 +130,7 @@ RSpec.feature "Personal details" do
     expect(@referral.previous_name).to eq("Jane Jones")
     expect(@referral.date_of_birth).to eq(Date.new(1990, 1, 17))
     expect(@referral.trn).to eq("9912345")
+    expect(@referral.trn_known).to eq(true)
+    expect(@referral.has_qts).to eq("yes")
   end
 end


### PR DESCRIPTION
### Context

When making a referral, we ask the referrer whether the person being referred has QTS.

### Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/93511/199769091-866b4e9b-2786-4221-80b0-e077ea31a909.png)

- Add `has_qts` field (is this a good name? - I'm not sure but it's a `yes / no / dont_know` string value in the db)
- Add form object and validation
- Add routes/actions/views for QTS form
- Adds additional system spec steps to test back links

### Guidance to review


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
