### PR TITLE
Referrals employer form - Contact details / their contact number page

### DIFF
--- a/app/controllers/referrals/contact_details/email_controller.rb
+++ b/app/controllers/referrals/contact_details/email_controller.rb
@@ -13,8 +13,7 @@ module Referrals
         @contact_details_email_form =
           EmailForm.new(contact_details_email_form_params.merge(referral:))
         if @contact_details_email_form.save
-          # TODO: Redirect to personal details telephone
-          redirect_to referrals_update_contact_details_address_path(referral)
+          redirect_to referrals_update_contact_details_telephone_path(referral)
         else
           render :edit
         end

--- a/app/controllers/referrals/contact_details/telephone_controller.rb
+++ b/app/controllers/referrals/contact_details/telephone_controller.rb
@@ -1,0 +1,34 @@
+module Referrals
+  module ContactDetails
+    class TelephoneController < ReferralsController
+      def edit
+        @contact_details_telephone_form =
+          TelephoneForm.new(
+            phone_known: referral.phone_known,
+            phone_number: referral.phone_number
+          )
+      end
+
+      def update
+        @contact_details_telephone_form =
+          TelephoneForm.new(
+            contact_details_telephone_form_params.merge(referral:)
+          )
+        if @contact_details_telephone_form.save
+          redirect_to referrals_update_contact_details_address_path(referral)
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def contact_details_telephone_form_params
+        params.require(:referrals_contact_details_telephone_form).permit(
+          :phone_known,
+          :phone_number
+        )
+      end
+    end
+  end
+end

--- a/app/forms/referrals/contact_details/telephone_form.rb
+++ b/app/forms/referrals/contact_details/telephone_form.rb
@@ -1,0 +1,31 @@
+module Referrals
+  module ContactDetails
+    class TelephoneForm
+      include ActiveModel::Model
+
+      attr_accessor :referral, :phone_number
+      attr_reader :phone_known
+
+      validates :referral, presence: true
+      validates :phone_known, inclusion: { in: [true, false] }
+      validates :phone_number, presence: true, if: -> { phone_known }
+      validates :phone_number,
+                format: {
+                  with: /\A(\+44\s?)?(?:\d\s?){10,11}\z/
+                },
+                if: -> { phone_known && phone_number.present? }
+
+      def phone_known=(value)
+        @phone_known = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save
+        return false unless valid?
+
+        referral.phone_known = phone_known
+        referral.phone_number = phone_known ? phone_number : nil
+        referral.save
+      end
+    end
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -16,6 +16,8 @@
 #  has_qts          :string
 #  last_name        :string
 #  name_has_changed :string
+#  phone_known      :boolean
+#  phone_number     :string
 #  postcode         :string(11)
 #  previous_name    :string
 #  town_or_city     :string

--- a/app/views/referrals/contact_details/telephone/edit.html.erb
+++ b/app/views/referrals/contact_details/telephone/edit.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, "#{"Error: " if @contact_details_telephone_form.errors.any?}Do you know their main contact number?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @contact_details_telephone_form, url: referrals_update_contact_details_telephone_url, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_radio_buttons_fieldset :phone_known, legend: { size: "xl", text: "Do you know their main contact number?" }  do %>
+        <%= f.hidden_field :phone_known %>
+        <%= f.govuk_radio_button :phone_known, true, label: { text: "Yes" } do %>
+          <%= f.govuk_text_field :phone_number, label: { text: "Contact number" } %>
+        <% end %>
+        <%= f.govuk_radio_button :phone_known, false, label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue", prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,13 @@ en:
             email_address:
               blank: Enter their email address
               invalid: Enter an email address in the correct format, like name@example.com
+        "referrals/contact_details/telephone_form":
+          attributes:
+            phone_known:
+              inclusion: Tell us if you know their main contact number
+            phone_number:
+              blank: Enter their contact number
+              invalid: Enter a valid mobile number, like 07700 900 982 or +44 7700 900 982
         "referrals/contact_details/address_form":
           attributes:
             address_known:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,12 @@ Rails.application.routes.draw do
     put "/:id/contact-details/email",
         to: "contact_details/email#update",
         as: "update_contact_details_email"
+    get "/:id/contact-details/telephone",
+        to: "contact_details/telephone#edit",
+        as: "edit_contact_details_telephone"
+    put "/:id/contact-details/telephone",
+        to: "contact_details/telephone#update",
+        as: "update_contact_details_telephone"
     get "/:id/contact-details/address",
         to: "contact_details/address#edit",
         as: "edit_contact_details_address"

--- a/db/migrate/20221104124508_add_contact_details_telephone_to_referrals.rb
+++ b/db/migrate/20221104124508_add_contact_details_telephone_to_referrals.rb
@@ -1,4 +1,4 @@
-class AddTeacherContactDetailsTelephoneToReferrals < ActiveRecord::Migration[7.0]
+class AddContactDetailsTelephoneToReferrals < ActiveRecord::Migration[7.0]
   def change
     change_table :referrals, bulk: true do |t|
       t.boolean :phone_known

--- a/db/migrate/20221104124508_add_teacher_contact_details_telephone_to_referrals.rb
+++ b/db/migrate/20221104124508_add_teacher_contact_details_telephone_to_referrals.rb
@@ -1,0 +1,8 @@
+class AddTeacherContactDetailsTelephoneToReferrals < ActiveRecord::Migration[7.0]
+  def change
+    change_table :referrals, bulk: true do |t|
+      t.boolean :phone_known
+      t.string :phone_number
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_03_124121) do
+ActiveRecord::Schema[7.0].define(version: 20_221_104_124_508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,6 +54,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_03_124121) do
     t.string "postcode", limit: 11
     t.string "country"
     t.string "has_qts"
+    t.boolean "phone_known"
+    t.string "phone_number"
   end
 
   create_table "referrers", force: :cascade do |t|

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -3,8 +3,12 @@
 # Table name: referrals
 #
 #  id               :bigint           not null, primary key
+#  address_known    :age_known
+#  address_line_1   :string
+#  address_line_2   :string
 #  age_known        :string
 #  approximate_age  :string
+#  country          :string
 #  date_of_birth    :date
 #  email_address    :string(256)
 #  email_known      :boolean
@@ -12,7 +16,11 @@
 #  has_qts          :string
 #  last_name        :string
 #  name_has_changed :string
+#  phone_known      :boolean
+#  phone_number     :string
+#  postcode         :string(11)
 #  previous_name    :string
+#  town_or_city     :string
 #  trn              :string
 #  trn_known        :boolean
 #  created_at       :datetime         not null

--- a/spec/forms/referrals/contact_details/address_form_spec.rb
+++ b/spec/forms/referrals/contact_details/address_form_spec.rb
@@ -90,27 +90,31 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
   describe "#save" do
     subject(:save) { form.save }
 
-    it "saves the referral" do
-      save
-      expect(referral.address_known).to be_truthy
-      expect(referral.address_line_1).to eq("1428 Elm Street")
-      expect(referral.address_line_2).to eq("Sunset Boulevard")
-      expect(referral.town_or_city).to eq("London")
-      expect(referral.postcode).to eq("NW1 4NP")
-      expect(referral.country).to eq("United Kingdom")
+    before { save }
+
+    it "saves address_known and the address field values" do
+      aggregate_failures "testing referral address fields" do
+        expect(referral.address_known).to be_truthy
+        expect(referral.address_line_1).to eq("1428 Elm Street")
+        expect(referral.address_line_2).to eq("Sunset Boulevard")
+        expect(referral.town_or_city).to eq("London")
+        expect(referral.postcode).to eq("NW1 4NP")
+        expect(referral.country).to eq("United Kingdom")
+      end
     end
 
     context "when the address is not known" do
       let(:address_known) { false }
 
-      it "saves the address_known and sets the address fields as nil" do
-        save
-        expect(referral.address_known).to be_falsy
-        expect(referral.address_line_1).to be_nil
-        expect(referral.address_line_2).to be_nil
-        expect(referral.town_or_city).to be_nil
-        expect(referral.postcode).to be_nil
-        expect(referral.country).to be_nil
+      it "saves address_known and sets the address fields as nil" do
+        aggregate_failures "testing referral address fields" do
+          expect(referral.address_known).to be_falsy
+          expect(referral.address_line_1).to be_nil
+          expect(referral.address_line_2).to be_nil
+          expect(referral.town_or_city).to be_nil
+          expect(referral.postcode).to be_nil
+          expect(referral.country).to be_nil
+        end
       end
     end
   end

--- a/spec/forms/referrals/contact_details/address_form_spec.rb
+++ b/spec/forms/referrals/contact_details/address_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
 
     it { is_expected.to be_truthy }
 
-    before { form.save }
+    before { valid }
 
     context "when address_known is blank" do
       let(:address_known) { "" }
@@ -92,29 +92,55 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
 
     before { save }
 
-    it "saves address_known and the address field values" do
-      aggregate_failures "testing referral address fields" do
-        expect(referral.address_known).to be_truthy
-        expect(referral.address_line_1).to eq("1428 Elm Street")
-        expect(referral.address_line_2).to eq("Sunset Boulevard")
-        expect(referral.town_or_city).to eq("London")
-        expect(referral.postcode).to eq("NW1 4NP")
-        expect(referral.country).to eq("United Kingdom")
-      end
+    it "saves address_known" do
+      expect(referral.address_known).to be_truthy
+    end
+
+    it "saves address_line_1" do
+      expect(referral.address_line_1).to eq("1428 Elm Street")
+    end
+
+    it "saves address_line_2" do
+      expect(referral.address_line_2).to eq("Sunset Boulevard")
+    end
+
+    it "saves town_or_city" do
+      expect(referral.town_or_city).to eq("London")
+    end
+
+    it "saves postcode" do
+      expect(referral.postcode).to eq("NW1 4NP")
+    end
+
+    it "saves country" do
+      expect(referral.country).to eq("United Kingdom")
     end
 
     context "when the address is not known" do
       let(:address_known) { false }
 
-      it "saves address_known and sets the address fields as nil" do
-        aggregate_failures "testing referral address fields" do
-          expect(referral.address_known).to be_falsy
-          expect(referral.address_line_1).to be_nil
-          expect(referral.address_line_2).to be_nil
-          expect(referral.town_or_city).to be_nil
-          expect(referral.postcode).to be_nil
-          expect(referral.country).to be_nil
-        end
+      it "sets the address_known to false" do
+        expect(referral.address_known).to be_falsy
+      end
+
+      it "sets the address_line_1 to nil" do
+        expect(referral.address_line_1).to be_nil
+      end
+
+      it "sets the address_line_2 to nil" do
+        expect(referral.address_line_2).to be_nil
+      end
+
+      it "sets the town_or_city to nil" do
+        expect(referral.town_or_city).to be_nil
+      end
+
+      it "sets the postcode to nil" do
+        expect(referral.postcode).to be_nil
+      end
+
+      it "sets the country to nil" do
+        expect(referral.country).to be_nil
       end
     end
   end

--- a/spec/forms/referrals/contact_details/email_form_spec.rb
+++ b/spec/forms/referrals/contact_details/email_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Referrals::ContactDetails::EmailForm, type: :model do
 
     it { is_expected.to be_truthy }
 
-    before { form.save }
+    before { valid }
 
     context "when email_known is blank" do
       let(:email_known) { "" }

--- a/spec/forms/referrals/contact_details/email_form_spec.rb
+++ b/spec/forms/referrals/contact_details/email_form_spec.rb
@@ -64,18 +64,24 @@ RSpec.describe Referrals::ContactDetails::EmailForm, type: :model do
   describe "#save" do
     subject(:save) { form.save }
 
-    it "saves the referral" do
-      save
+    before { save }
+
+    it "saves email_known" do
       expect(referral.email_known).to be_truthy
+    end
+
+    it "saves email_address" do
       expect(referral.email_address).to eq("name@example.com")
     end
 
     context "when the email is not known" do
       let(:email_known) { false }
 
-      it "saves the email_known and sets the email as nil" do
-        save
+      it "saves email_known" do
         expect(referral.email_known).to be_falsy
+      end
+
+      it "sets email_address as nil" do
         expect(referral.email_address).to be_nil
       end
     end

--- a/spec/forms/referrals/contact_details/telephone_form_spec.rb
+++ b/spec/forms/referrals/contact_details/telephone_form_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe Referrals::ContactDetails::TelephoneForm, type: :model do
+  let(:referral) { Referral.new }
+  let(:form) { described_class.new(referral:, phone_known:, phone_number:) }
+  let(:phone_known) { true }
+  let(:phone_number) { "07700 900 982" }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:referral) }
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    it { is_expected.to be_truthy }
+
+    before { form.save }
+
+    context "when phone_known is blank" do
+      let(:phone_known) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:phone_known]).to eq(
+          ["Tell us if you know their main contact number"]
+        )
+      end
+    end
+
+    context "when phone_number is blank" do
+      let(:phone_number) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:phone_number]).to eq(["Enter their contact number"])
+      end
+    end
+
+    context "when phone_number is invalid" do
+      let(:phone_number) { "name" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:phone_number]).to eq(
+          [
+            "Enter a valid mobile number, like 07700 900 982 or +44 7700 900 982"
+          ]
+        )
+      end
+    end
+
+    context "when phone_known is false and phone_number is blank" do
+      let(:phone_known) { false }
+      let(:phone_number) { "" }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    it "saves the referral" do
+      save
+      expect(referral.phone_known).to be_truthy
+      expect(referral.phone_number).to eq("07700 900 982")
+    end
+
+    context "when the phone number is not known" do
+      let(:phone_known) { false }
+
+      it "saves the phone_known and sets the phone number as nil" do
+        save
+        expect(referral.phone_known).to be_falsy
+        expect(referral.phone_number).to be_nil
+      end
+    end
+  end
+end

--- a/spec/forms/referrals/contact_details/telephone_form_spec.rb
+++ b/spec/forms/referrals/contact_details/telephone_form_spec.rb
@@ -64,18 +64,24 @@ RSpec.describe Referrals::ContactDetails::TelephoneForm, type: :model do
   describe "#save" do
     subject(:save) { form.save }
 
-    it "saves the referral" do
-      save
+    before { save }
+
+    it "saves phone_known" do
       expect(referral.phone_known).to be_truthy
+    end
+
+    it "saves phone_number" do
       expect(referral.phone_number).to eq("07700 900 982")
     end
 
     context "when the phone number is not known" do
       let(:phone_known) { false }
 
-      it "saves the phone_known and sets the phone number as nil" do
-        save
+      it "saves phone_known" do
         expect(referral.phone_known).to be_falsy
+      end
+
+      it "sets phone_number as nil" do
         expect(referral.phone_number).to be_nil
       end
     end

--- a/spec/forms/referrals/contact_details/telephone_form_spec.rb
+++ b/spec/forms/referrals/contact_details/telephone_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Referrals::ContactDetails::TelephoneForm, type: :model do
 
     it { is_expected.to be_truthy }
 
-    before { form.save }
+    before { valid }
 
     context "when phone_known is blank" do
       let(:phone_known) { "" }

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -3,19 +3,27 @@
 # Table name: referrals
 #
 #  id               :bigint           not null, primary key
+#  address_known    :boolean
+#  address_line_1   :string
+#  address_line_2   :string
 #  age_known        :string
 #  approximate_age  :string
+#  country          :string
 #  date_of_birth    :date
 #  email_address    :string(256)
 #  email_known      :boolean
 #  first_name       :string
 #  last_name        :string
 #  name_has_changed :string
+#  phone_known      :boolean
+#  phone_number     :string
+#  postcode         :string(11)
 #  previous_name    :string
 #  has_qts          :string
 #  last_name        :string
 #  name_has_changed :string
 #  previous_name    :string
+#  town_or_city     :string
 #  trn              :string
 #  trn_known        :boolean
 #  created_at       :datetime         not null

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -8,8 +8,11 @@ RSpec.feature "Contact details" do
     and_i_have_an_existing_referral
     when_i_visit_the_referral_summary
     and_i_click_on_contact_details
+
+    # Do you know the personal email address
     then_i_see_the_personal_email_address_page
 
+    # Email address known
     when_i_select_yes
     and_i_press_continue
     then_i_see_a_missing_email_error
@@ -20,13 +23,38 @@ RSpec.feature "Contact details" do
 
     when_i_select_yes_with_a_valid_email
     and_i_press_continue
-    then_i_see_the_home_address_page
+    then_i_see_the_contact_number_page
 
+    # Email address unknown
     when_i_go_back
     when_i_select_no
     and_i_press_continue
+
+    # Do you know their main contact number
+    then_i_see_the_contact_number_page
+
+    # Phone number known
+    when_i_select_yes
+    and_i_press_continue
+    then_i_see_a_missing_phone_number_error
+
+    when_i_select_yes_with_an_invalid_phone_number
+    and_i_press_continue
+    then_i_see_an_invalid_phone_number_error
+
+    when_i_select_yes_with_a_valid_phone_number
+    and_i_press_continue
     then_i_see_the_home_address_page
 
+    # Phone number unknown
+    when_i_go_back
+    when_i_select_no
+    and_i_press_continue
+
+    # Do you know their home address?
+    then_i_see_the_home_address_page
+
+    # Address known
     when_i_select_yes
     and_i_press_continue
     then_i_see_a_missing_address_fields_error
@@ -41,6 +69,9 @@ RSpec.feature "Contact details" do
 
     and_i_click_on_contact_details
     and_i_press_continue # skip the email page
+    and_i_press_continue # skip the telephone page
+
+    # Address unknown
     when_i_select_no
     and_i_press_continue
     then_i_get_redirected_to_the_referral_summary
@@ -84,6 +115,14 @@ RSpec.feature "Contact details" do
     )
   end
 
+  def then_i_see_the_contact_number_page
+    expect(page).to have_current_path(
+      "/referrals/#{@referral.id}/contact-details/telephone"
+    )
+    expect(page).to have_title("Do you know their main contact number?")
+    expect(page).to have_content("Do you know their main contact number?")
+  end
+
   def then_i_see_the_home_address_page
     expect(page).to have_current_path(
       "/referrals/#{@referral.id}/contact-details/address"
@@ -118,6 +157,26 @@ RSpec.feature "Contact details" do
   def when_i_select_yes_with_a_valid_email
     when_i_select_yes
     fill_in "Email address", with: "name@example.com"
+  end
+
+  def then_i_see_a_missing_phone_number_error
+    expect(page).to have_content("Enter their contact number")
+  end
+
+  def when_i_select_yes_with_an_invalid_phone_number
+    when_i_select_yes
+    fill_in "Contact number", with: "1234"
+  end
+
+  def then_i_see_an_invalid_phone_number_error
+    expect(page).to have_content(
+      "Enter a valid mobile number, like 07700 900 982 or +44 7700 900 982"
+    )
+  end
+
+  def when_i_select_yes_with_a_valid_phone_number
+    when_i_select_yes
+    fill_in "Contact number", with: "07700 900 982"
   end
 
   def then_i_get_redirected_to_the_referral_summary


### PR DESCRIPTION
### Context

When making a referral, the contact number of the person being referred needs to be specified.

https://teacher-misconduct.herokuapp.com/report/teacher-contact-details/telephone
The prototype was updated to have the question: **Do you know their main contact number?** with only one input field. 

https://trello.com/c/Pvt5esiS/938-contact-form-add-phone-number-page

### Changes proposed in this pull request

Add the following page, that comes after the email address question:
<img width="670" alt="Screenshot 2022-11-04 at 14 36 12" src="https://user-images.githubusercontent.com/1636476/200001746-ca0256c3-4fda-4952-b74b-6625cf3f82f7.png">

<img width="734" alt="Screenshot 2022-11-04 at 14 35 59" src="https://user-images.githubusercontent.com/1636476/200001612-614134f6-e441-4cbb-8b78-91f6e0fd10a9.png">


* Update the routes
* Generate a migration for adding the phone number to the referrals table.
* Add the form, including validation 
* Link the form to the email question page and the address page

### Checklist

- [X] Attach to Trello card
- [X] Rebased main
- [X] Cleaned commit history
- [X] Tested by running locally