### PR TITLE
Add basic implementation of OTP-based User sign in

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "pg", "~> 1.4"
 gem "propshaft"
 gem "puma", "~> 5.0"
 gem "rails", "~> 7.0.3"
+gem "rotp"
 gem "sidekiq"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "uk_postcode"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,7 @@ GEM
       nokogiri
     rexml (3.2.5)
     rladr (1.2.0)
+    rotp (6.2.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -405,6 +406,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.3)
   rladr
+  rotp
   rspec
   rspec-rails
   rubocop-govuk

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -5,6 +5,14 @@ class Users::OtpController < DeviseController
 
   def new
     self.resource = resource_class.find(params[:id])
+
+    # TODO: Remove this block once emailed OTPs are implemented
+    # For now this makes manual testing in test environments simpler
+    if HostingEnvironment.test_environment?
+      otp_generator = ROTP::HOTP.new(resource.secret_key)
+      @derived_otp = otp_generator.at(0)
+    end
+    ###
   end
 
   def create

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -1,7 +1,9 @@
 class Users::OtpController < DeviseController
-  prepend_before_action :require_no_authentication, only: [:new, :create]
+  prepend_before_action :require_no_authentication, only: %i[new create]
   prepend_before_action :allow_params_authentication!, only: :create
-  prepend_before_action(only: [:create]) { request.env["devise.skip_timeout"] = true }
+  prepend_before_action(only: [:create]) do
+    request.env["devise.skip_timeout"] = true
+  end
 
   def new
     self.resource = resource_class.find(params[:id])

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -1,0 +1,34 @@
+class Users::OtpController < DeviseController
+  prepend_before_action :require_no_authentication, only: [:new, :create]
+  prepend_before_action :allow_params_authentication!, only: :create
+  prepend_before_action(only: [:create]) { request.env["devise.skip_timeout"] = true }
+
+  def new
+    self.resource = resource_class.find(params[:id])
+  end
+
+  def create
+    self.resource = warden.authenticate!(auth_options)
+    set_flash_message!(:notice, :signed_in)
+    sign_in(resource_name, resource)
+    yield resource if block_given?
+    redirect_to after_sign_in_path_for(resource)
+  end
+
+  protected
+
+  def auth_options
+    mapping = Devise.mappings[resource_name]
+    { scope: resource_name, recall: "#{mapping.path.pluralize}/sessions#new" }
+  end
+
+  def translation_scope
+    "devise.sessions"
+  end
+
+  private
+
+  def after_sign_in_path_for(_resource)
+    root_path
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+class Users::SessionsController < Devise::SessionsController
+  def create
+    self.resource = resource_class.find_or_initialize_by(sign_in_params)
+
+    if resource.save
+      # generate secret and otp
+      secret_key = ROTP::Base32.random
+      # otp = ROTP::HOTP.new(secret_key).at(0)
+
+      # save 32-bit key to model
+      resource.update(secret_key:)
+
+      # TODO: send otp via email
+
+      # redirect to OTP controller
+      redirect_to new_user_otp_path(id: resource.id)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def sign_in_params
+    resource_params.permit(:email)
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,16 +3,9 @@ class Users::SessionsController < Devise::SessionsController
     self.resource = resource_class.find_or_initialize_by(sign_in_params)
 
     if resource.save
-      # generate secret and otp
       secret_key = ROTP::Base32.random
-      # otp = ROTP::HOTP.new(secret_key).at(0)
-
-      # save 32-bit key to model
       resource.update(secret_key:)
-
       # TODO: send otp via email
-
-      # redirect to OTP controller
       redirect_to new_user_otp_path(id: resource.id)
     else
       render :new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,6 +52,18 @@ module ApplicationHelper
           )
         end
       end
+
+      if current_user
+        header.navigation_item(
+          href: main_app.users_sign_out_path,
+          text: "Sign out"
+        )
+      else
+        header.navigation_item(
+          href: main_app.new_user_session_path,
+          text: "Sign in"
+        )
+      end
     end
   end
 end

--- a/app/lib/devise/models/otp_authenticatable.rb
+++ b/app/lib/devise/models/otp_authenticatable.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Devise::Models::OtpAuthenticatable
+  extend ActiveSupport::Concern
+
+  included do
+    attr_reader :otp
+  end
+
+  def password_required?
+    false
+  end
+
+  def password
+    nil
+  end
+
+  def after_otp_authentication
+    update(secret_key: nil)
+  end
+end
+

--- a/app/lib/devise/models/otp_authenticatable.rb
+++ b/app/lib/devise/models/otp_authenticatable.rb
@@ -3,9 +3,7 @@
 module Devise::Models::OtpAuthenticatable
   extend ActiveSupport::Concern
 
-  included do
-    attr_reader :otp
-  end
+  included { attr_reader :otp }
 
   def password_required?
     false
@@ -19,4 +17,3 @@ module Devise::Models::OtpAuthenticatable
     update(secret_key: nil)
   end
 end
-

--- a/app/lib/devise/otp_comparison.rb
+++ b/app/lib/devise/otp_comparison.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Devise::OtpComparison
+  def self.success?(resource, submitted_otp)
+    submitted_otp == derive_otp(resource.secret_key)
+  end
+
+  def self.derive_otp(key)
+    otp_generator = ROTP::HOTP.new(key)
+    otp_generator.at(0)
+  end
+end

--- a/app/lib/devise/strategies/otp_authenticatable.rb
+++ b/app/lib/devise/strategies/otp_authenticatable.rb
@@ -3,7 +3,7 @@
 require "devise"
 require "devise/strategies/authenticatable"
 
-class OtpAuthenticatable < Devise::Strategies::Authenticatable
+class Devise::Strategies::OtpAuthenticatable < Devise::Strategies::Authenticatable
   #undef :password
   #undef :password=
 
@@ -26,10 +26,7 @@ class OtpAuthenticatable < Devise::Strategies::Authenticatable
 
     # TODO: handle expired OTPs
 
-    otp_generator = ROTP::HOTP.new(resource.secret_key)
-    derived_otp = otp_generator.at(0)
-
-    unless derived_otp == otp
+    unless Devise::OtpComparison.success?(resource, otp)
       fail!(:otp_invalid)
       return
     end

--- a/app/lib/otp_authenticatable.rb
+++ b/app/lib/otp_authenticatable.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "devise"
+require "devise/strategies/authenticatable"
+
+class OtpAuthenticatable < Devise::Strategies::Authenticatable
+  #undef :password
+  #undef :password=
+
+  attr_accessor :otp, :email
+
+  def valid_for_http_auth?
+    super && http_auth_hash[:otp].present?
+  end
+
+  def valid_for_params_auth?
+    super && params_auth_hash[:otp].present?
+  end
+
+  def authenticate!
+    resource = mapping.to.find_by(email:)
+    unless resource && resource.secret_key.present?
+      fail!(:otp_invalid)
+      return
+    end
+
+    # TODO: handle expired OTPs
+
+    otp_generator = ROTP::HOTP.new(resource.secret_key)
+    derived_otp = otp_generator.at(0)
+
+    unless derived_otp == otp
+      fail!(:otp_invalid)
+      return
+    end
+
+    if validate(resource)
+      remember_me(resource)
+      resource.after_otp_authentication
+      success!(resource)
+    else
+      fail!(:otp_invalid)
+    end
+  end
+
+  private
+
+  # Sets the authentication hash and the otp from params_auth_hash or http_auth_hash.
+  def with_authentication_hash(auth_type, auth_values)
+    self.authentication_hash = {}
+    self.authentication_type = auth_type
+    self.email = auth_values[:email]
+    self.otp = auth_values[:otp]
+
+    parse_authentication_key_values(auth_values, authentication_keys) &&
+      parse_authentication_key_values(request_values, request_keys)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,18 +20,5 @@
 #
 class User < ApplicationRecord
   devise :validatable, :trackable
-
-  attr_reader :otp
-
-  def password_required?
-    false
-  end
-
-  def password
-    nil
-  end
-
-  def after_otp_authentication
-    update(secret_key: nil)
-  end
+  include Devise::Models::OtpAuthenticatable
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,18 @@
 #
 class User < ApplicationRecord
   devise :validatable, :trackable
+
+  attr_reader :otp
+
+  def password_required?
+    false
+  end
+
+  def password
+    nil
+  end
+
+  def after_otp_authentication
+    update(secret_key: nil)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                  :bigint           not null, primary key
+#  current_sign_in_at  :datetime
+#  current_sign_in_ip  :string
+#  email               :string           default(""), not null
+#  last_sign_in_at     :datetime
+#  last_sign_in_ip     :string
+#  remember_created_at :datetime
+#  secret_key          :string
+#  sign_in_count       :integer          default(0), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email  (email) UNIQUE
+#
+class User < ApplicationRecord
+  devise :validatable, :trackable
+end

--- a/app/views/users/otp/new.html.erb
+++ b/app/views/users/otp/new.html.erb
@@ -1,0 +1,15 @@
+<h1 class="govuk-heading-l">Log in</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= "Debug - expected OTP: #{@derived_otp}" %>
+    <%= form_for(resource, as: resource_name, url: user_otp_path, method: :post) do |f| %>
+      <%= f.hidden_field :email, value: resource.email %>
+      <p><%= resource.email %></p>
+
+      <%= f.govuk_text_field :otp %>
+
+      <%= f.govuk_submit "Sign in" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/otp/new.html.erb
+++ b/app/views/users/otp/new.html.erb
@@ -2,7 +2,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= "Debug - expected OTP: #{@derived_otp}" %>
+    <% if HostingEnvironment.test_environment? %>
+      <%= "Expected OTP: #{@derived_otp}" %>
+    <% end %>
+
     <%= form_for(resource, as: resource_name, url: user_otp_path, method: :post) do |f| %>
       <%= f.hidden_field :email, value: resource.email %>
       <p><%= resource.email %></p>

--- a/app/views/users/otp/new.html.erb
+++ b/app/views/users/otp/new.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-l">Log in</h1>
+<h1 class="govuk-heading-l">Confirm your email address</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -8,9 +8,9 @@
 
     <%= form_for(resource, as: resource_name, url: user_otp_path, method: :post) do |f| %>
       <%= f.hidden_field :email, value: resource.email %>
-      <p><%= resource.email %></p>
+      <h3><%= resource.email %></h3>
 
-      <%= f.govuk_text_field :otp %>
+      <%= f.govuk_text_field :otp, size: 'm', label: { text: "Enter your code" }, class: 'govuk-!-width-one-quarter' %>
 
       <%= f.govuk_submit "Sign in" %>
     <% end %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,9 +1,11 @@
-<h1 class="govuk-heading-l">Sign in</h1>
+<h1 class="govuk-heading-l">Your email address</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(resource, as: resource_name, url: user_session_path, method: :post) do |f| %>
-      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+      <p>You’ll receive a code by email to confirm your email address.</p>
+
+      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Enter your email address" } %>
 
       <%= f.govuk_submit "Send code" %>
     <% end %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,0 +1,11 @@
+<h1 class="govuk-heading-l">Sign in</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(resource, as: resource_name, url: user_session_path, method: :post) do |f| %>
+      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+
+      <%= f.govuk_submit "Send code" %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -330,6 +330,9 @@ Devise.setup do |config|
   config.warden do |manager|
     manager.strategies.add(:staff_http_basic_auth, StaffHttpBasicAuthStrategy)
     manager.default_strategies(scope: :staff).unshift :staff_http_basic_auth
+
+    manager.strategies.add(:otp_authenticatable, OtpAuthenticatable)
+    manager.default_strategies(scope: :user).unshift(:otp_authenticatable)
   end
 
   # ==> Mountable engine configurations

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -331,7 +331,10 @@ Devise.setup do |config|
     manager.strategies.add(:staff_http_basic_auth, StaffHttpBasicAuthStrategy)
     manager.default_strategies(scope: :staff).unshift :staff_http_basic_auth
 
-    manager.strategies.add(:otp_authenticatable, Devise::Strategies::OtpAuthenticatable)
+    manager.strategies.add(
+      :otp_authenticatable,
+      Devise::Strategies::OtpAuthenticatable
+    )
     manager.default_strategies(scope: :user).unshift(:otp_authenticatable)
   end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -331,7 +331,7 @@ Devise.setup do |config|
     manager.strategies.add(:staff_http_basic_auth, StaffHttpBasicAuthStrategy)
     manager.default_strategies(scope: :staff).unshift :staff_http_basic_auth
 
-    manager.strategies.add(:otp_authenticatable, OtpAuthenticatable)
+    manager.strategies.add(:otp_authenticatable, Devise::Strategies::OtpAuthenticatable)
     manager.default_strategies(scope: :user).unshift(:otp_authenticatable)
   end
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -16,6 +16,8 @@ en:
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
+      user:
+        otp_invalid: "Invalid code"
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,10 +17,10 @@ Rails.application.routes.draw do
 
   devise_for(:user)
   devise_scope :user do
-    get '/users/session/new', to: "users/sessions#new", as: "new_user_session"
-    post '/users/session', to: "users/sessions#create", as: "user_session"
-    get '/users/otp/new', to: "users/otp#new", as: "new_user_otp"
-    post '/users/otp', to: "users/otp#create", as: "user_otp"
+    get "/users/session/new", to: "users/sessions#new", as: "new_user_session"
+    post "/users/session", to: "users/sessions#create", as: "user_session"
+    get "/users/otp/new", to: "users/otp#new", as: "new_user_otp"
+    post "/users/otp", to: "users/otp#create", as: "user_otp"
 
     get "/users/sign_out", to: "users/sessions#destroy"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,16 @@ Rails.application.routes.draw do
     get "/staff/sign_out", to: "staff/sessions#destroy"
   end
 
-  get "_sha", to: ->(_) { [200, {}, [ENV.fetch("GIT_SHA", "")]] }
+  devise_for(:user)
+  devise_scope :user do
+    get '/users/session/new', to: "users/sessions#new", as: "new_user_session"
+    post '/users/session', to: "users/sessions#create", as: "user_session"
+    get '/users/otp/new', to: "users/otp#new", as: "new_user_otp"
+    post '/users/otp', to: "users/otp#create", as: "user_otp"
+
+    get "/users/sign_out", to: "users/sessions#destroy"
+  end
+
   get "/start", to: "pages#start"
   get "/who", to: "reporting_as#new"
   post "/who", to: "reporting_as#create"
@@ -115,4 +124,6 @@ Rails.application.routes.draw do
     get "/429", to: "errors#too_many_requests"
     get "/500", to: "errors#internal_server_error"
   end
+
+  get "_sha", to: ->(_) { [200, {}, [ENV.fetch("GIT_SHA", "")]] }
 end

--- a/db/migrate/20221028153803_devise_create_users.rb
+++ b/db/migrate/20221028153803_devise_create_users.rb
@@ -4,21 +4,21 @@ class DeviseCreateUsers < ActiveRecord::Migration[7.0]
   def change
     create_table :users do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
+      t.string :email, null: false, default: ""
 
       ## Rememberable
       t.datetime :remember_created_at
 
       ## Trackable
-      t.integer  :sign_in_count, default: 0, null: false
+      t.integer :sign_in_count, default: 0, null: false
       t.datetime :current_sign_in_at
       t.datetime :last_sign_in_at
-      t.string   :current_sign_in_ip
-      t.string   :last_sign_in_ip
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
 
       t.timestamps null: false
     end
 
-    add_index :users, :email,                unique: true
+    add_index :users, :email, unique: true
   end
 end

--- a/db/migrate/20221028153803_devise_create_users.rb
+++ b/db/migrate/20221028153803_devise_create_users.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email,                unique: true
+  end
+end

--- a/db/migrate/20221101110008_add_secret_key_to_users.rb
+++ b/db/migrate/20221101110008_add_secret_key_to_users.rb
@@ -1,0 +1,5 @@
+class AddSecretKeyToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :secret_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -100,5 +100,19 @@ ActiveRecord::Schema[7.0].define(version: 20_221_103_120_049) do
     t.index ["unlock_token"], name: "index_staff_on_unlock_token", unique: true
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "secret_key"
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
   add_foreign_key "referrers", "referrals"
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                  :bigint           not null, primary key
+#  current_sign_in_at  :datetime
+#  current_sign_in_ip  :string
+#  email               :string           default(""), not null
+#  last_sign_in_at     :datetime
+#  last_sign_in_ip     :string
+#  remember_created_at :datetime
+#  secret_key          :string
+#  sign_in_count       :integer          default(0), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email  (email) UNIQUE
+#
+FactoryBot.define do
+  factory :user do
+    
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,6 +20,5 @@
 #
 FactoryBot.define do
   factory :user do
-    
   end
 end

--- a/spec/lib/devise/otp_comparison_spec.rb
+++ b/spec/lib/devise/otp_comparison_spec.rb
@@ -13,10 +13,9 @@ RSpec.describe Devise::OtpComparison do
     it "returns false if the OTPs don't match" do
       secret_key = ROTP::Base32.random
       resource = double(secret_key:)
-      submitted_otp = 'bad_guess'
+      submitted_otp = "bad_guess"
 
       expect(described_class.success?(resource, submitted_otp)).to eq false
-
     end
   end
 end

--- a/spec/lib/devise/otp_comparison_spec.rb
+++ b/spec/lib/devise/otp_comparison_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Devise::OtpComparison do
+  describe ".success?" do
+    it "returns true if the OTPs match" do
+      secret_key = ROTP::Base32.random
+      resource = double(secret_key:)
+      submitted_otp = ROTP::HOTP.new(secret_key).at(0)
+
+      expect(described_class.success?(resource, submitted_otp)).to eq true
+    end
+
+    it "returns false if the OTPs don't match" do
+      secret_key = ROTP::Base32.random
+      resource = double(secret_key:)
+      submitted_otp = 'bad_guess'
+
+      expect(described_class.success?(resource, submitted_otp)).to eq false
+
+    end
+  end
+end

--- a/spec/lib/devise/strategies/otp_authenticatable_spec.rb
+++ b/spec/lib/devise/strategies/otp_authenticatable_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Devise::Strategies::OtpAuthenticatable do
+  def build_rack_env(params)
+    env = Rack::MockRequest.env_for("/strategy-test", params)
+    env["devise.allow_params_authentication"] = true
+    env
+  end
+
+  let(:valid_params) do
+    { params: { user: { email: "test@example.com", otp: "123456" } } }
+  end
+
+  describe "#valid?" do
+    it "is true when given a rack env with the expected data" do
+      env = build_rack_env(valid_params)
+      strategy = described_class.new(env, :user)
+      expect(strategy.valid?).to eq true
+    end
+
+    it "is false when otp param is missing" do
+      params = {
+        params: { user: { email: "test@example.com"} }
+      }
+      env = build_rack_env(params)
+      strategy = described_class.new(env, :user)
+      expect(strategy.valid?).to eq false
+    end
+
+    it "is false when email param is missing" do
+      params = {
+        params: { user: { email: "test@example.com" } }
+      }
+      env = build_rack_env(params)
+      strategy = described_class.new(env, :user)
+      expect(strategy.valid?).to eq false
+    end
+  end
+end

--- a/spec/lib/devise/strategies/otp_authenticatable_spec.rb
+++ b/spec/lib/devise/strategies/otp_authenticatable_spec.rb
@@ -19,18 +19,14 @@ RSpec.describe Devise::Strategies::OtpAuthenticatable do
     end
 
     it "is false when otp param is missing" do
-      params = {
-        params: { user: { email: "test@example.com"} }
-      }
+      params = { params: { user: { email: "test@example.com" } } }
       env = build_rack_env(params)
       strategy = described_class.new(env, :user)
       expect(strategy.valid?).to eq false
     end
 
     it "is false when email param is missing" do
-      params = {
-        params: { user: { email: "test@example.com" } }
-      }
+      params = { params: { user: { email: "test@example.com" } } }
       env = build_rack_env(params)
       strategy = described_class.new(env, :user)
       expect(strategy.valid?).to eq false

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                  :bigint           not null, primary key
+#  current_sign_in_at  :datetime
+#  current_sign_in_ip  :string
+#  email               :string           default(""), not null
+#  last_sign_in_at     :datetime
+#  last_sign_in_ip     :string
+#  remember_created_at :datetime
+#  secret_key          :string
+#  sign_in_count       :integer          default(0), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email  (email) UNIQUE
+#
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,7 +18,7 @@
 #
 #  index_users_on_email  (email) UNIQUE
 #
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe User, type: :model do
 end

--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -21,9 +21,7 @@ RSpec.feature "User accounts" do
 
   def when_i_visit_the_sign_in_page
     visit root_path
-    within(".govuk-header") do
-      click_link "Sign in"
-    end
+    within(".govuk-header") { click_link "Sign in" }
   end
 
   def and_i_submit_my_email
@@ -34,9 +32,7 @@ RSpec.feature "User accounts" do
 
   def when_i_provide_the_wrong_otp
     fill_in "Enter your code", with: "wrong_value"
-    within("main") do
-      click_on "Sign in"
-    end
+    within("main") { click_on "Sign in" }
   end
 
   def then_i_see_an_error
@@ -49,15 +45,10 @@ RSpec.feature "User accounts" do
     expected_otp = Devise::OtpComparison.derive_otp(user.secret_key)
 
     fill_in "Enter your code", with: expected_otp
-    within("main") do
-      click_on "Sign in"
-    end
+    within("main") { click_on "Sign in" }
   end
 
   def then_i_am_signed_in
-    within(".govuk-header") do
-      expect(page).to have_content "Sign out"
-    end
+    within(".govuk-header") { expect(page).to have_content "Sign out" }
   end
 end
-

--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "User accounts" do
+  scenario "User signs in" do
+    given_the_service_is_open
+    when_i_visit_the_sign_in_page
+    and_i_submit_my_email
+    when_i_provide_the_wrong_otp
+    then_i_see_an_error
+    when_i_submit_my_email
+    when_i_provide_the_expected_otp
+    then_i_am_signed_in
+  end
+
+  private
+
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def when_i_visit_the_sign_in_page
+    visit root_path
+    within(".govuk-header") do
+      click_link "Sign in"
+    end
+  end
+
+  def and_i_submit_my_email
+    fill_in "Email", with: "test@example.com"
+    click_on "Send code"
+  end
+  alias_method :when_i_submit_my_email, :and_i_submit_my_email
+
+  def when_i_provide_the_wrong_otp
+    fill_in "Otp", with: "wrong_value"
+    within("main") do
+      click_on "Sign in"
+    end
+  end
+
+  def then_i_see_an_error
+    expect(page).to have_content "Invalid code"
+  end
+
+  def when_i_provide_the_expected_otp
+    # TODO: inspect sent email once mailer code is implemented
+    user = User.find_by(email: "test@example.com")
+    expected_otp = Devise::OtpComparison.derive_otp(user.secret_key)
+
+    fill_in "Otp", with: expected_otp
+    within("main") do
+      click_on "Sign in"
+    end
+  end
+
+  def then_i_am_signed_in
+    within(".govuk-header") do
+      expect(page).to have_content "Sign out"
+    end
+  end
+end
+

--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -27,13 +27,13 @@ RSpec.feature "User accounts" do
   end
 
   def and_i_submit_my_email
-    fill_in "Email", with: "test@example.com"
+    fill_in "Enter your email address", with: "test@example.com"
     click_on "Send code"
   end
   alias_method :when_i_submit_my_email, :and_i_submit_my_email
 
   def when_i_provide_the_wrong_otp
-    fill_in "Otp", with: "wrong_value"
+    fill_in "Enter your code", with: "wrong_value"
     within("main") do
       click_on "Sign in"
     end
@@ -48,7 +48,7 @@ RSpec.feature "User accounts" do
     user = User.find_by(email: "test@example.com")
     expected_otp = Devise::OtpComparison.derive_otp(user.secret_key)
 
-    fill_in "Otp", with: expected_otp
+    fill_in "Enter your code", with: expected_otp
     within("main") do
       click_on "Sign in"
     end


### PR DESCRIPTION
### Context

Users need to be able to sign in with an email to continue completing any referrals they've started and view those they've submitted.

### Changes proposed in this pull request

This is an initial implementation of OTP-based User auth, and will be iterated on to add more functionality.
This PR contains everything needed to sign in to a new user session and sign out via links in the header.

The commit messages provide the best summary of the various changes. The following will be added in subsequent PRs:

- Emailing OTPs to the user
- Authenticating access to the eligibility screener and employer form
- Associating Users with Referrals, and ensuring any database retrieval is scope to current_user
- Expiring OTPs after a period of time
- Keeping the user on the OTP screen when they make an incorrect guess, rather than redirecting them to the email page (ie — starting the sign in from scratch)
- Limiting the number of guesses for a single generated OTP


### Guidance to review

Sign in via the header to start the auth flow.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
