### PR TITLE
Add a job title question to the referrer flow

### DIFF
--- a/app/controllers/referrals/referrer_job_title_controller.rb
+++ b/app/controllers/referrals/referrer_job_title_controller.rb
@@ -1,0 +1,26 @@
+module Referrals
+  class ReferrerJobTitleController < Referrals::BaseController
+    def edit
+      @referrer_job_title_form =
+        ReferrerJobTitleForm.new(referral: current_referral)
+    end
+
+    def update
+      @referrer_job_title_form =
+        ReferrerJobTitleForm.new(
+          job_title_params.merge(referral: current_referral)
+        )
+      if @referrer_job_title_form.save
+        redirect_to edit_referral_referrer_phone_path(current_referral)
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def job_title_params
+      params.require(:referrer_job_title_form).permit(:job_title)
+    end
+  end
+end

--- a/app/controllers/referrals/referrer_name_controller.rb
+++ b/app/controllers/referrals/referrer_name_controller.rb
@@ -11,7 +11,7 @@ module Referrals
           name_params.merge(referral: current_referral)
         )
       if @referrer_name_form.save
-        redirect_to edit_referral_referrer_phone_path(current_referral)
+        redirect_to edit_referral_referrer_job_title_path(current_referral)
       else
         render :edit
       end

--- a/app/forms/referrer_job_title_form.rb
+++ b/app/forms/referrer_job_title_form.rb
@@ -1,0 +1,21 @@
+class ReferrerJobTitleForm
+  include ActiveModel::Model
+
+  attr_accessor :referral
+  attr_writer :job_title
+
+  validates :job_title, presence: true
+  validates :referral, presence: true
+
+  def job_title
+    @job_title ||= referrer&.job_title
+  end
+
+  def save
+    return false unless valid?
+
+    referrer.update(job_title:)
+  end
+
+  delegate :referrer, to: :referral, allow_nil: true
+end

--- a/app/models/referrer.rb
+++ b/app/models/referrer.rb
@@ -3,6 +3,7 @@
 # Table name: referrers
 #
 #  id          :bigint           not null, primary key
+#  job_title   :string
 #  name        :string
 #  phone       :string
 #  created_at  :datetime         not null

--- a/app/views/referrals/referrer_details/show.html.erb
+++ b/app/views/referrals/referrer_details/show.html.erb
@@ -17,6 +17,13 @@
       },
       {
         actions: [
+          { text: "Change", href: edit_referral_referrer_job_title_path(current_referral), visually_hidden_text: "job title" },
+        ],
+        key: { text: "Your job title" },
+        value: { text: @referrer.job_title },
+      },
+      {
+        actions: [
           { text: "Change", href: edit_referral_referrer_phone_path(current_referral), visually_hidden_text: "phone" },
         ],
         key: { text: "Telephone number" },

--- a/app/views/referrals/referrer_job_title/edit.html.erb
+++ b/app/views/referrals/referrer_job_title/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :page_title, "#{'Error: ' if @referrer_job_title_form.errors.any?}What is your job title?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @referrer_job_title_form, url: referral_referrer_job_title_path(current_referral), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field :job_title, label: { size: 'xl', text: "What is your job title?" }, hint: { text: 'For example, ‘Headteacher’' } %>
+      <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,6 +115,10 @@ en:
             postcode:
               blank: Enter their postcode
               invalid: Enter a real postcode
+        referrer_job_title_form:
+          attributes:
+            job_title:
+              blank: Enter your job title
         referrer_phone_form:
           attributes:
             phone:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,11 @@ Rails.application.routes.draw do
              path: "referrer-details",
              controller: "referrals/referrer_details"
 
+    resource :referrer_job_title,
+             only: %i[edit update],
+             path: "referrer-job-title",
+             controller: "referrals/referrer_job_title"
+
     resource :referrer_phone,
              controller: "referrals/referrer_phone",
              only: %i[edit update],

--- a/db/migrate/20221107113436_add_job_title_to_referrer.rb
+++ b/db/migrate/20221107113436_add_job_title_to_referrer.rb
@@ -1,0 +1,5 @@
+class AddJobTitleToReferrer < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrers, :job_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_221_104_124_508) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_07_113436) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -64,6 +64,7 @@ ActiveRecord::Schema[7.0].define(version: 20_221_104_124_508) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "phone"
+    t.string "job_title"
     t.index ["referral_id"], name: "index_referrers_on_referral_id"
   end
 

--- a/spec/factories/referrers.rb
+++ b/spec/factories/referrers.rb
@@ -3,6 +3,7 @@
 # Table name: referrers
 #
 #  id          :bigint           not null, primary key
+#  job_title   :string
 #  name        :string
 #  phone       :string
 #  created_at  :datetime         not null

--- a/spec/forms/referrer_job_title_form_spec.rb
+++ b/spec/forms/referrer_job_title_form_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe ReferrerJobTitleForm, type: :model do
+  let(:referral) { build(:referral, referrer:) }
+  let(:referrer) { build(:referrer) }
+
+  describe "validations" do
+    subject { described_class.new(referral:) }
+
+    it { is_expected.to validate_presence_of(:referral) }
+    it { is_expected.to validate_presence_of(:job_title) }
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    let(:form) { described_class.new(referral:, job_title:) }
+    let(:job_title) { "Job Title" }
+    let(:referral) { build(:referral, referrer:) }
+    let(:referrer) { build(:referrer) }
+
+    it { is_expected.to be_truthy }
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:form) { described_class.new(referral:, job_title:) }
+    let(:job_title) { "Job Title" }
+    let(:referral) { build(:referral, referrer:) }
+    let(:referrer) { build(:referrer) }
+
+    it "saves the referral" do
+      save
+      expect(referrer.job_title).to eq(job_title)
+    end
+
+    context "with an invalid form" do
+      let(:job_title) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end

--- a/spec/models/referrer_spec.rb
+++ b/spec/models/referrer_spec.rb
@@ -3,6 +3,7 @@
 # Table name: referrers
 #
 #  id          :bigint           not null, primary key
+#  job_title   :string
 #  name        :string
 #  phone       :string
 #  created_at  :datetime         not null

--- a/spec/system/referrals/about_you_spec.rb
+++ b/spec/system/referrals/about_you_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe "Employer Referral: About You" do
 
     when_i_enter_my_name
     and_i_click_save_and_continue
+    then_i_see_the_job_title_page
+
+    when_i_click_save_and_continue
+    then_i_see_the_job_title_error_message
+
+    when_i_enter_my_job_title
+    and_i_click_save_and_continue
     then_i_see_the_what_is_your_telephone_number_page
 
     when_i_click_save_and_continue
@@ -79,6 +86,20 @@ RSpec.describe "Employer Referral: About You" do
     expect(page).to have_content("What is your name?")
   end
 
+  def then_i_see_the_job_title_page
+    expect(page).to have_current_path(
+      "/referrals/#{Referral.last.id}/referrer-job-title/edit"
+    )
+    expect(page).to have_title(
+      "What is your job title? - Refer serious misconduct by a teacher in England"
+    )
+    expect(page).to have_content("What is your job title?")
+  end
+
+  def then_i_see_the_job_title_error_message
+    expect(page).to have_content("Enter your job title")
+  end
+
   def then_i_see_the_name_error_message
     expect(page).to have_content("Enter your name")
   end
@@ -123,6 +144,10 @@ RSpec.describe "Employer Referral: About You" do
     click_button "Save and continue"
   end
   alias_method :and_i_click_save_and_continue, :when_i_click_save_and_continue
+
+  def when_i_enter_my_job_title
+    fill_in "What is your job title?", with: "Teacher"
+  end
 
   def when_i_enter_my_name
     fill_in "What is your name?", with: "Test Name"


### PR DESCRIPTION
When collecting details about the referrer, we want to ask them what
their job title is.

This follows the same pattern as the other questions in this flow.

Assumptions:
* the field is required
* we are happy to accept a plain text value for the job title

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="991" alt="Screenshot 2022-11-07 at 12 44 40 pm" src="https://user-images.githubusercontent.com/3126/200313975-cd51b0f5-a7b6-4840-a265-78575b1bff72.png">
<img width="990" alt="Screenshot 2022-11-07 at 12 44 47 pm" src="https://user-images.githubusercontent.com/3126/200313995-5ec65a10-9212-4c1f-8969-4a0678fc9dae.png">
<img width="1019" alt="Screenshot 2022-11-07 at 12 45 58 pm" src="https://user-images.githubusercontent.com/3126/200314013-e8554843-0f77-4b76-983e-3cf1e5acf371.png">
