### PR TITLE
Personal details check and confirm section

### DIFF
--- a/app/controllers/referrals/personal_details/confirm_controller.rb
+++ b/app/controllers/referrals/personal_details/confirm_controller.rb
@@ -1,0 +1,28 @@
+module Referrals
+  module PersonalDetails
+    class ConfirmController < ReferralsController
+      def edit
+        @personal_details_confirm_form = ConfirmForm.new(referral:)
+      end
+
+      def update
+        @personal_details_confirm_form =
+          ConfirmForm.new(confirm_params.merge(referral:))
+
+        if @personal_details_confirm_form.save
+          redirect_to edit_referral_path(referral)
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def confirm_params
+        params.fetch(:referrals_personal_details_confirm_form, {}).permit(
+          :personal_details_complete
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/referrals/personal_details/qts_controller.rb
+++ b/app/controllers/referrals/personal_details/qts_controller.rb
@@ -10,7 +10,7 @@ module Referrals
         @personal_details_qts_form = QtsForm.new(qts_params.merge(referral:))
 
         if @personal_details_qts_form.save
-          # TODO: Redirect to personal details summary
+          redirect_to referrals_edit_personal_details_confirm_path(referral)
         else
           render :edit
         end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -57,7 +57,7 @@ class ReferralForm
         ReferralSectionItem.new(
           I18n.t("referral_form.personal_details"),
           referrals_edit_personal_details_name_path(referral),
-          :not_started_yet
+          section_status(:personal_details_complete)
         ),
         ReferralSectionItem.new(
           I18n.t("referral_form.contact_details"),
@@ -95,5 +95,12 @@ class ReferralForm
         )
       ]
     )
+  end
+
+  def section_status(section_complete_method)
+    status = referral.send(section_complete_method)
+    return :not_started_yet if status.nil?
+
+    status ? :completed : :incomplete
   end
 end

--- a/app/forms/referrals/personal_details/confirm_form.rb
+++ b/app/forms/referrals/personal_details/confirm_form.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Referrals
+  module PersonalDetails
+    class ConfirmForm
+      include ActiveModel::Model
+
+      validates :personal_details_complete, inclusion: { in: [true, false] }
+
+      attr_accessor :referral
+      attr_reader :personal_details_complete
+
+      def personal_details_complete=(value)
+        @personal_details_complete = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save
+        referral.update(personal_details_complete:) if valid?
+      end
+    end
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -16,6 +16,7 @@
 #  has_qts          :string
 #  last_name        :string
 #  name_has_changed :string
+#  personal_details_complete :boolean
 #  phone_known      :boolean
 #  phone_number     :string
 #  postcode         :string(11)

--- a/app/views/referrals/personal_details/confirm/edit.html.erb
+++ b/app/views/referrals/personal_details/confirm/edit.html.erb
@@ -1,0 +1,64 @@
+<% content_for :page_title, "#{'Error: ' if @personal_details_confirm_form.errors.any?}Personal details" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<% rows = [
+  {
+    actions: [
+      { text: "Change", href: referrals_edit_personal_details_name_path(@referral), visually_hidden_text: "name" },
+    ],
+    key: { text: "Name" },
+    value: { text: "#{@referral.first_name} #{@referral.last_name}" },
+  },
+  {
+    actions: [
+      { text: "Change", href: referrals_edit_personal_details_age_path(@referral), visually_hidden_text: "date of birth" },
+    ],
+    key: { text: "Date of birth" },
+    value: { text: @referral.date_of_birth&.to_fs(:long_ordinal_uk) },
+  },
+  {
+    actions: [
+      { text: "Change", href: referrals_edit_personal_details_trn_path(@referral), visually_hidden_text: "teacher reference number (TRN)" },
+    ],
+    key: { text: "Teacher reference number (TRN)" },
+    value: { text: @referral.trn },
+  },
+  {
+    actions: [
+      { text: "Change", href: referrals_edit_personal_details_qts_path(@referral), visually_hidden_text: "do they have QTS?" },
+    ],
+    key: { text: "Do they have QTS?" },
+    value: { text: @referral.has_qts&.humanize },
+  },
+] %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">
+          <span class="govuk-caption-xl">About the person you are referring</span>
+          Personal details
+        </h1>
+      </div>
+    </div>
+
+    <%= render(SummaryCardComponent.new(rows:)) do %>
+      <%= render SummaryCardHeaderComponent.new(title: "Personal details") %>
+    <% end %>
+
+    <%= form_with model: @personal_details_confirm_form, url: referrals_update_personal_details_confirm_path(@referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(
+        :personal_details_complete,
+        legend: { text: "Have you completed this section?", size: "m" },
+        hint: { text: "You can still make changes to a completed section" },
+      ) do %>
+        <%= f.govuk_radio_button :personal_details_complete, "true", label: { text: "Yes, I’ve completed this section" } %>
+        <%= f.govuk_radio_button :personal_details_complete, "false", label: { text: "No, I’ll come back to it later" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,10 @@ en:
           attributes:
             has_qts:
               inclusion: Tell us if you know whether they have QTS
+        "referrals/personal_details/confirm_form":
+          attributes:
+            personal_details_complete:
+              inclusion: Tell us if you have completed this section
         "referrals/contact_details/email_form":
           attributes:
             email_known:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,12 @@ Rails.application.routes.draw do
     put "/:id/personal-details/qts",
         to: "personal_details/qts#update",
         as: "update_personal_details_qts"
+    get "/:id/personal-details/confirm",
+        to: "personal_details/confirm#edit",
+        as: "edit_personal_details_confirm"
+    put "/:id/personal-details/confirm",
+        to: "personal_details/confirm#update",
+        as: "update_personal_details_confirm"
 
     get "/:id/contact-details/email",
         to: "contact_details/email#edit",

--- a/db/migrate/20221107114023_add_referrals_personal_details_complete_field.rb
+++ b/db/migrate/20221107114023_add_referrals_personal_details_complete_field.rb
@@ -1,0 +1,5 @@
+class AddReferralsPersonalDetailsCompleteField < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrals, :personal_details_complete, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_07_113436) do
+ActiveRecord::Schema[7.0].define(version: 20_221_107_114_023) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_07_113436) do
     t.string "has_qts"
     t.boolean "phone_known"
     t.string "phone_number"
+    t.boolean "personal_details_complete"
   end
 
   create_table "referrers", force: :cascade do |t|

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -16,6 +16,7 @@
 #  has_qts          :string
 #  last_name        :string
 #  name_has_changed :string
+#  personal_details_complete :boolean
 #  phone_known      :boolean
 #  phone_number     :string
 #  postcode         :string(11)

--- a/spec/forms/referrals/personal_details/confirm_form_spec.rb
+++ b/spec/forms/referrals/personal_details/confirm_form_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Referrals::PersonalDetails::ConfirmForm, type: :model do
+  describe "#save" do
+    let(:referral) { Referral.new }
+    let(:personal_details_complete) { false }
+    subject(:save) { confirm_form.save }
+
+    let(:confirm_form) do
+      described_class.new(referral:, personal_details_complete:)
+    end
+
+    context "with a valid value" do
+      it "saves the value on the referral" do
+        save
+        expect(referral.personal_details_complete).to eq(false)
+      end
+    end
+
+    context "with no values" do
+      let(:personal_details_complete) { nil }
+      it "adds an error" do
+        save
+        expect(confirm_form.errors[:personal_details_complete]).to eq(
+          ["Tell us if you have completed this section"]
+        )
+      end
+    end
+  end
+end

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -15,6 +15,7 @@
 #  first_name       :string
 #  last_name        :string
 #  name_has_changed :string
+#  personal_details_complete :boolean
 #  phone_known      :boolean
 #  phone_number     :string
 #  postcode         :string(11)


### PR DESCRIPTION
### Context

Once all personal details have been submitted the user can check and confirm.
https://trello.com/c/hxiRTsic/935-referrals-employer-form-personal-details-check-answers-page
https://teacher-misconduct.herokuapp.com/report/teacher/check-answers

### Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/93511/200383874-581c8bc3-2950-465b-a68e-0c8933ddbba2.png)

- Adds confirm route/form object and view.
- Status of section summary updates once complete.

### Guidance to review

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
