### PR TITLE
Add the ability to specify if the form is complete

### DIFF
--- a/app/controllers/referrals/referrer_details_controller.rb
+++ b/app/controllers/referrals/referrer_details_controller.rb
@@ -1,7 +1,0 @@
-module Referrals
-  class ReferrerDetailsController < Referrals::BaseController
-    def show
-      @referrer = current_referral.referrer
-    end
-  end
-end

--- a/app/controllers/referrals/referrer_phone_controller.rb
+++ b/app/controllers/referrals/referrer_phone_controller.rb
@@ -10,7 +10,7 @@ module Referrals
           referrer_phone_form_params.merge(referral: current_referral)
         )
       if @referrer_phone_form.save
-        redirect_to referral_referrer_details_path(current_referral)
+        redirect_to referral_referrer_path(current_referral)
       else
         render :edit
       end

--- a/app/controllers/referrals/referrers_controller.rb
+++ b/app/controllers/referrals/referrers_controller.rb
@@ -1,0 +1,29 @@
+module Referrals
+  class ReferrersController < BaseController
+    def show
+      @referrer = current_referral.referrer
+      @referrer_form = ReferrerForm.new(referrer: @referrer)
+    end
+
+    def update
+      @referrer_form =
+        ReferrerForm.new(
+          complete: referrer_params[:complete],
+          referrer: current_referral.referrer
+        )
+
+      if @referrer_form.save
+        redirect_to edit_referral_path(current_referral)
+      else
+        @referrer = current_referral.referrer
+        render :show
+      end
+    end
+
+    private
+
+    def referrer_params
+      params.require(:referrer_form).permit(:complete)
+    end
+  end
+end

--- a/app/forms/referrer_form.rb
+++ b/app/forms/referrer_form.rb
@@ -1,0 +1,19 @@
+class ReferrerForm
+  include ActiveModel::Model
+
+  attr_accessor :referrer
+  attr_writer :complete
+
+  validates :complete, inclusion: { in: %w[true false] }
+  validates :referrer, presence: true
+
+  def complete
+    @complete || referrer&.completed_at? || nil
+  end
+
+  def save
+    return false unless valid?
+
+    referrer.update(completed_at: complete == "true" ? Time.current : nil)
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -2,30 +2,30 @@
 #
 # Table name: referrals
 #
-#  id               :bigint           not null, primary key
-#  address_known    :boolean
-#  address_line_1   :string
-#  address_line_2   :string
-#  age_known        :string
-#  approximate_age  :string
-#  country          :string
-#  date_of_birth    :date
-#  email_address    :string(256)
-#  email_known      :boolean
-#  first_name       :string
-#  has_qts          :string
-#  last_name        :string
-#  name_has_changed :string
+#  id                        :bigint           not null, primary key
+#  address_known             :boolean
+#  address_line_1            :string
+#  address_line_2            :string
+#  age_known                 :string
+#  approximate_age           :string
+#  country                   :string
+#  date_of_birth             :date
+#  email_address             :string(256)
+#  email_known               :boolean
+#  first_name                :string
+#  has_qts                   :string
+#  last_name                 :string
+#  name_has_changed          :string
 #  personal_details_complete :boolean
-#  phone_known      :boolean
-#  phone_number     :string
-#  postcode         :string(11)
-#  previous_name    :string
-#  town_or_city     :string
-#  trn              :string
-#  trn_known        :boolean
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  phone_known               :boolean
+#  phone_number              :string
+#  postcode                  :string(11)
+#  previous_name             :string
+#  town_or_city              :string
+#  trn                       :string
+#  trn_known                 :boolean
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #
 class Referral < ApplicationRecord
   has_one :referrer, dependent: :destroy

--- a/app/models/referrer.rb
+++ b/app/models/referrer.rb
@@ -2,13 +2,14 @@
 #
 # Table name: referrers
 #
-#  id          :bigint           not null, primary key
-#  job_title   :string
-#  name        :string
-#  phone       :string
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  referral_id :bigint           not null
+#  id           :bigint           not null, primary key
+#  completed_at :datetime
+#  job_title    :string
+#  name         :string
+#  phone        :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  referral_id  :bigint           not null
 #
 # Indexes
 #
@@ -21,7 +22,13 @@
 class Referrer < ApplicationRecord
   belongs_to :referral
 
+  def completed?
+    completed_at.present?
+  end
+
   def status
+    return :complete if completed?
+
     :incomplete
   end
 end

--- a/app/views/referrals/referrers/show.html.erb
+++ b/app/views/referrals/referrers/show.html.erb
@@ -34,6 +34,13 @@
       <%= render SummaryCardHeaderComponent.new(title: 'Your details') %>
     <% end %>
 
-    <%= govuk_button_to "Save and continue", edit_referral_path(current_referral), method: :get  %>
+    <%= form_with model: @referrer_form, url: referral_referrer_path(current_referral), method: :patch do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :complete, legend: { size: 'm', text: 'Have you completed this section?' } do %>
+        <%= f.hidden_field :complete %>
+        <%= f.govuk_radio_button :complete, 'true', label: { text: "Yes, I’ve completed this section" } %>
+        <%= f.govuk_radio_button :complete, 'false', label: { text: "No, I’ll come back to it later" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,6 +131,10 @@ en:
           attributes:
             name:
               blank: Enter your name
+        referrer_form:
+          attributes:
+            complete:
+              inclusion: Tell us if you have completed this section
 
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
     get "/delete", to: "referrals#delete", on: :member
     get "/deleted", to: "referrals#deleted", on: :collection
 
+    resource :referrer, only: %i[show update], controller: "referrals/referrers"
     resource :referrer_details,
              only: %i[show],
              path: "referrer-details",

--- a/db/migrate/20221107130734_add_completed_at_to_referrer.rb
+++ b/db/migrate/20221107130734_add_completed_at_to_referrer.rb
@@ -1,0 +1,5 @@
+class AddCompletedAtToReferrer < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrers, :completed_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_221_107_114_023) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_07_130734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,24 +36,24 @@ ActiveRecord::Schema[7.0].define(version: 20_221_107_114_023) do
   create_table "referrals", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "email_known"
-    t.string "email_address", limit: 256
     t.string "first_name"
     t.string "last_name"
     t.string "previous_name"
     t.string "name_has_changed"
+    t.boolean "email_known"
+    t.string "email_address", limit: 256
     t.date "date_of_birth"
     t.string "age_known"
     t.string "approximate_age"
     t.string "trn"
     t.boolean "trn_known"
+    t.string "has_qts"
     t.boolean "address_known"
     t.string "address_line_1"
     t.string "address_line_2"
     t.string "town_or_city"
     t.string "postcode", limit: 11
     t.string "country"
-    t.string "has_qts"
     t.boolean "phone_known"
     t.string "phone_number"
     t.boolean "personal_details_complete"
@@ -66,6 +66,7 @@ ActiveRecord::Schema[7.0].define(version: 20_221_107_114_023) do
     t.datetime "updated_at", null: false
     t.string "phone"
     t.string "job_title"
+    t.datetime "completed_at", precision: nil
     t.index ["referral_id"], name: "index_referrers_on_referral_id"
   end
 

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -2,30 +2,30 @@
 #
 # Table name: referrals
 #
-#  id               :bigint           not null, primary key
-#  address_known    :age_known
-#  address_line_1   :string
-#  address_line_2   :string
-#  age_known        :string
-#  approximate_age  :string
-#  country          :string
-#  date_of_birth    :date
-#  email_address    :string(256)
-#  email_known      :boolean
-#  first_name       :string
-#  has_qts          :string
-#  last_name        :string
-#  name_has_changed :string
+#  id                        :bigint           not null, primary key
+#  address_known             :boolean
+#  address_line_1            :string
+#  address_line_2            :string
+#  age_known                 :string
+#  approximate_age           :string
+#  country                   :string
+#  date_of_birth             :date
+#  email_address             :string(256)
+#  email_known               :boolean
+#  first_name                :string
+#  has_qts                   :string
+#  last_name                 :string
+#  name_has_changed          :string
 #  personal_details_complete :boolean
-#  phone_known      :boolean
-#  phone_number     :string
-#  postcode         :string(11)
-#  previous_name    :string
-#  town_or_city     :string
-#  trn              :string
-#  trn_known        :boolean
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  phone_known               :boolean
+#  phone_number              :string
+#  postcode                  :string(11)
+#  previous_name             :string
+#  town_or_city              :string
+#  trn                       :string
+#  trn_known                 :boolean
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #
 FactoryBot.define do
   factory :referral do

--- a/spec/factories/referrers.rb
+++ b/spec/factories/referrers.rb
@@ -2,13 +2,14 @@
 #
 # Table name: referrers
 #
-#  id          :bigint           not null, primary key
-#  job_title   :string
-#  name        :string
-#  phone       :string
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  referral_id :bigint           not null
+#  id           :bigint           not null, primary key
+#  completed_at :datetime
+#  job_title    :string
+#  name         :string
+#  phone        :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  referral_id  :bigint           not null
 #
 # Indexes
 #

--- a/spec/forms/referrer_form_spec.rb
+++ b/spec/forms/referrer_form_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe ReferrerForm, type: :model do
+  describe "validations" do
+    subject { described_class.new(referrer:) }
+
+    let(:referrer) { build(:referrer) }
+
+    it do
+      is_expected.to validate_inclusion_of(:complete).in_array(%w[true false])
+    end
+    it { is_expected.to validate_presence_of(:referrer) }
+  end
+
+  describe "#complete" do
+    subject(:form_complete) { referrer_form.complete }
+
+    let(:complete) { nil }
+    let(:referrer) { build(:referrer) }
+    let(:referrer_form) { described_class.new(complete:, referrer:) }
+
+    context "when the value of complete is nil" do
+      let(:referrer) { build(:referrer, completed_at: Time.current) }
+
+      it "returns the value from referrer" do
+        expect(form_complete).to eq(referrer.completed?)
+      end
+    end
+
+    context "when the value of complete is set" do
+      let(:complete) { true }
+
+      it "returns the value of complete" do
+        expect(complete).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -2,33 +2,30 @@
 #
 # Table name: referrals
 #
-#  id               :bigint           not null, primary key
-#  address_known    :boolean
-#  address_line_1   :string
-#  address_line_2   :string
-#  age_known        :string
-#  approximate_age  :string
-#  country          :string
-#  date_of_birth    :date
-#  email_address    :string(256)
-#  email_known      :boolean
-#  first_name       :string
-#  last_name        :string
-#  name_has_changed :string
+#  id                        :bigint           not null, primary key
+#  address_known             :boolean
+#  address_line_1            :string
+#  address_line_2            :string
+#  age_known                 :string
+#  approximate_age           :string
+#  country                   :string
+#  date_of_birth             :date
+#  email_address             :string(256)
+#  email_known               :boolean
+#  first_name                :string
+#  has_qts                   :string
+#  last_name                 :string
+#  name_has_changed          :string
 #  personal_details_complete :boolean
-#  phone_known      :boolean
-#  phone_number     :string
-#  postcode         :string(11)
-#  previous_name    :string
-#  has_qts          :string
-#  last_name        :string
-#  name_has_changed :string
-#  previous_name    :string
-#  town_or_city     :string
-#  trn              :string
-#  trn_known        :boolean
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  phone_known               :boolean
+#  phone_number              :string
+#  postcode                  :string(11)
+#  previous_name             :string
+#  town_or_city              :string
+#  trn                       :string
+#  trn_known                 :boolean
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #
 require "rails_helper"
 

--- a/spec/models/referrer_spec.rb
+++ b/spec/models/referrer_spec.rb
@@ -2,13 +2,14 @@
 #
 # Table name: referrers
 #
-#  id          :bigint           not null, primary key
-#  job_title   :string
-#  name        :string
-#  phone       :string
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  referral_id :bigint           not null
+#  id           :bigint           not null, primary key
+#  completed_at :datetime
+#  job_title    :string
+#  name         :string
+#  phone        :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  referral_id  :bigint           not null
 #
 # Indexes
 #
@@ -29,5 +30,27 @@ RSpec.describe Referrer, type: :model do
     let(:referrer) { build(:referrer) }
 
     it { is_expected.to eq(:incomplete) }
+
+    context "when completed_at is present" do
+      let(:referrer) { build(:referrer, completed_at: Time.current) }
+
+      it { is_expected.to eq(:complete) }
+    end
+  end
+
+  describe "#completed?" do
+    subject { referrer.completed? }
+
+    let(:referrer) { build(:referrer) }
+
+    context "when completed_at is nil" do
+      it { is_expected.to be_falsey }
+    end
+
+    context "when completed_at is present" do
+      let(:referrer) { build(:referrer, completed_at: Time.current) }
+
+      it { is_expected.to be_truthy }
+    end
   end
 end

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -37,9 +37,24 @@ RSpec.feature "Employer Referral: About You", type: :system do
     and_i_see_my_name_in_the_form_field
 
     when_i_click_back
-    when_i_click_save_and_continue
+    and_i_choose_no_come_back_later
+    and_i_click_save_and_continue
     then_i_am_on_the_referral_summary_page
     and_i_see_your_details_flagged_as_incomplete
+
+    when_i_click_on_your_details
+    then_i_see_the_name_prefilled
+
+    when_i_click_save_and_continue
+    then_i_see_the_job_title_prefilled
+
+    when_i_click_save_and_continue
+    then_i_see_the_phone_number_prefilled
+
+    when_i_click_save_and_continue
+    and_i_choose_complete
+    and_i_click_save_and_continue
+    then_i_see_your_details_flagged_as_complete
   end
 
   private
@@ -55,6 +70,14 @@ RSpec.feature "Employer Referral: About You", type: :system do
 
   def and_i_am_on_the_referral_summary_page
     visit edit_referral_path(@referral)
+  end
+
+  def and_i_choose_complete
+    choose "Yes, I’ve completed this section", visible: false
+  end
+
+  def and_i_choose_no_come_back_later
+    choose "No, I’ll come back to it later", visible: false
   end
 
   def and_i_have_an_existing_referral
@@ -85,7 +108,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
 
   def then_i_am_on_the_your_details_page
     expect(page).to have_current_path(
-      "/referrals/#{Referral.last.id}/referrer-name/edit"
+      "/referrals/#{@referral.id}/referrer-name/edit"
     )
     expect(page).to have_title(
       "What is your name? - Refer serious misconduct by a teacher in England"
@@ -107,14 +130,27 @@ RSpec.feature "Employer Referral: About You", type: :system do
     expect(page).to have_content("Enter your job title")
   end
 
+  def then_i_see_the_job_title_prefilled
+    expect(page).to have_field("What is your job title?", with: "Teacher")
+  end
+
+  def then_i_see_the_phone_number_prefilled
+    expect(page).to have_field(
+      "What is your telephone number?",
+      with: "01234567890"
+    )
+  end
+
   def then_i_see_the_name_error_message
     expect(page).to have_content("Enter your name")
   end
 
+  def then_i_see_the_name_prefilled
+    expect(page).to have_field("What is your name?", with: "Test Name")
+  end
+
   def then_i_see_the_referrer_check_your_answers_page
-    expect(page).to have_current_path(
-      "/referrals/#{Referral.last.id}/referrer-details"
-    )
+    expect(page).to have_current_path("/referrals/#{@referral.id}/referrer")
     expect(page).to have_title(
       "Your details - Refer serious misconduct by a teacher in England"
     )
@@ -127,12 +163,16 @@ RSpec.feature "Employer Referral: About You", type: :system do
 
   def then_i_see_the_what_is_your_telephone_number_page
     expect(page).to have_current_path(
-      "/referrals/#{Referral.last.id}/referrer-phone/edit"
+      "/referrals/#{@referral.id}/referrer-phone/edit"
     )
     expect(page).to have_title(
       "What is your telephone number? - Refer serious misconduct by a teacher in England"
     )
     expect(page).to have_content("What is your telephone number?")
+  end
+
+  def then_i_see_your_details_flagged_as_complete
+    expect(page).to have_content("Your details\nCOMPLETE")
   end
 
   def when_i_click_back


### PR DESCRIPTION
When filling in the about you section of the referral, we offer the
ability for someone to indicate whether they have completed a section or
not.

Assumptions:

* no validation required on the complete flag because all fields have a
  presence validation on them anyway
* at some point the presence of the complete flag will be used to
  validate submitting the referral

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1010" alt="Screenshot 2022-11-08 at 12 01 42 pm" src="https://user-images.githubusercontent.com/3126/200558865-525819b1-780b-4e91-b2be-f41589d9268c.png">
