### PR TITLE
Design review : Remove approximate age field

### DIFF
--- a/app/controllers/referrals/personal_details/age_controller.rb
+++ b/app/controllers/referrals/personal_details/age_controller.rb
@@ -6,8 +6,7 @@ module Referrals
       end
 
       def update
-        @personal_details_age_form =
-          AgeForm.new(approximate_age_params.merge(referral:))
+        @personal_details_age_form = AgeForm.new(referral:)
 
         if @personal_details_age_form.save(date_of_birth_params)
           redirect_to referrals_edit_personal_details_trn_path(referral)
@@ -17,13 +16,6 @@ module Referrals
       end
 
       private
-
-      def approximate_age_params
-        params.require(:referrals_personal_details_age_form).permit(
-          :age_known,
-          :approximate_age
-        )
-      end
 
       def date_of_birth_params
         params.require(:referrals_personal_details_age_form).permit(

--- a/app/forms/referrals/personal_details/age_form.rb
+++ b/app/forms/referrals/personal_details/age_form.rb
@@ -5,42 +5,13 @@ module Referrals
       include ActiveModel::Model
 
       attr_accessor :referral
-      attr_writer :age_known, :approximate_age, :date_of_birth
-
-      validates :age_known, inclusion: { in: %w[yes approximate no] }
-      validates :approximate_age,
-                presence: true,
-                if: -> { age_known == "approximate" }
-      validates :date_of_birth, presence: true, if: -> { age_known == "yes" }
-
-      def age_known
-        @age_known ||= referral.age_known
-      end
-
-      def approximate_age
-        @approximate_age ||= referral.approximate_age
-      end
+      attr_writer :date_of_birth
 
       def date_of_birth
         @date_of_birth ||= referral.date_of_birth
       end
 
       def save(params = {})
-        return save_date_of_birth(params) if age_known == "yes"
-
-        save_age
-      end
-
-      def save_age
-        return false if invalid?
-
-        age_attrs = { age_known:, approximate_age: nil, date_of_birth: nil }
-        age_attrs.merge!(approximate_age:) if age_known == "approximate"
-
-        referral.update(age_attrs)
-      end
-
-      def save_date_of_birth(params = {})
         date_fields = [
           params["date_of_birth(1i)"],
           params["date_of_birth(2i)"],
@@ -101,7 +72,8 @@ module Referrals
           return false
         end
 
-        referral.update(age_known:, date_of_birth:, approximate_age: nil)
+        referral.update(date_of_birth:)
+        true
       end
 
       private

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -2,30 +2,28 @@
 #
 # Table name: referrals
 #
-#  id               :bigint           not null, primary key
-#  address_known    :boolean
-#  address_line_1   :string
-#  address_line_2   :string
-#  age_known        :string
-#  approximate_age  :string
-#  country          :string
-#  date_of_birth    :date
-#  email_address    :string(256)
-#  email_known      :boolean
-#  first_name       :string
-#  has_qts          :string
-#  last_name        :string
-#  name_has_changed :string
+#  id                        :bigint           not null, primary key
+#  address_known             :boolean
+#  address_line_1            :string
+#  address_line_2            :string
+#  country                   :string
+#  date_of_birth             :date
+#  email_address             :string(256)
+#  email_known               :boolean
+#  first_name                :string
+#  has_qts                   :string
+#  last_name                 :string
+#  name_has_changed          :string
 #  personal_details_complete :boolean
-#  phone_known      :boolean
-#  phone_number     :string
-#  postcode         :string(11)
-#  previous_name    :string
-#  town_or_city     :string
-#  trn              :string
-#  trn_known        :boolean
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  phone_known               :boolean
+#  phone_number              :string
+#  postcode                  :string(11)
+#  previous_name             :string
+#  town_or_city              :string
+#  trn                       :string
+#  trn_known                 :boolean
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #
 class Referral < ApplicationRecord
   has_one :referrer, dependent: :destroy

--- a/app/views/referrals/personal_details/age/edit.html.erb
+++ b/app/views/referrals/personal_details/age/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @personal_details_age_form.errors.any?}Do you know their age or date of birth?" %>
+<% content_for :page_title, "#{'Error: ' if @personal_details_age_form.errors.any?}What is their date of birth?" %>
 <% content_for :back_link_url, url_for(:back) %>
 
 <div class="govuk-grid-row">
@@ -6,19 +6,9 @@
     <%= form_with model: @personal_details_age_form, url: referrals_update_personal_details_age_path(@referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <div class="govuk-form-group">
-        <%= f.govuk_radio_buttons_fieldset(:age_known, legend: { size: "xl", text: "Do you know their age or date of birth?" }) do %>
-          <%= f.govuk_radio_button :age_known, "yes", label: { text: "I know their date of birth" } do %>
-            <%= f.govuk_date_field :date_of_birth,
-                legend: { text: "Date of birth", size: "m" },
-                hint: { text: "For example, 27 3 1987" } %>
-          <% end %>
-          <%= f.govuk_radio_button :age_known, "approximate", label: { text: "I know their approximate age" } do %>
-            <%= f.govuk_text_field :approximate_age,
-                label: { text: "Approximate age", class: "govuk-label--s" },
-                hint: { text: "For example, ‘They’re in their 20s’" } %>
-          <% end %>
-          <%= f.govuk_radio_button :age_known, "no", label: { text: "No, I don’t know their age or date of birth" } %>
-        <% end %>
+        <%= f.govuk_date_field :date_of_birth,
+            legend: { text: "What is their date of birth?", size: "xl" },
+            hint: { text: "For example, 27 3 1987" } %>
       </div>
       <%= f.govuk_submit "Save and continue" %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,10 +65,6 @@ en:
               missing_day: Enter a day for their date of birth, formatted as a number
               missing_month: Enter a month for their date of birth, formatted as a number
               missing_year: Enter a year with 4 digits
-            approximate_age:
-              blank: Enter their approximate age
-            age_known:
-              inclusion: Tell us if you know their date of birth or age
         "referrals/personal_details/name_form":
           attributes:
             first_name:

--- a/db/migrate/20221108084542_remove_referrals_approximate_age_field.rb
+++ b/db/migrate/20221108084542_remove_referrals_approximate_age_field.rb
@@ -1,0 +1,15 @@
+class RemoveReferralsApproximateAgeField < ActiveRecord::Migration[7.0]
+  def up
+    change_table :referrals, bulk: true do |t|
+      t.remove :age_known, if_exists: true
+      t.remove :approximate_age, if_exists: true
+    end
+  end
+
+  def down
+    change_table :referrals, bulk: true do |t|
+      t.string :age_known, if_not_exists: true
+      t.string :approximate_age, if_not_exists: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_221_107_114_023) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_08_084542) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,27 +36,25 @@ ActiveRecord::Schema[7.0].define(version: 20_221_107_114_023) do
   create_table "referrals", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "email_known"
-    t.string "email_address", limit: 256
     t.string "first_name"
     t.string "last_name"
     t.string "previous_name"
     t.string "name_has_changed"
     t.date "date_of_birth"
-    t.string "age_known"
-    t.string "approximate_age"
+    t.string "has_qts"
+    t.string "email_address", limit: 256
     t.string "trn"
     t.boolean "trn_known"
+    t.boolean "email_known"
     t.boolean "address_known"
     t.string "address_line_1"
     t.string "address_line_2"
     t.string "town_or_city"
     t.string "postcode", limit: 11
     t.string "country"
-    t.string "has_qts"
+    t.boolean "personal_details_complete"
     t.boolean "phone_known"
     t.string "phone_number"
-    t.boolean "personal_details_complete"
   end
 
   create_table "referrers", force: :cascade do |t|

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -2,30 +2,28 @@
 #
 # Table name: referrals
 #
-#  id               :bigint           not null, primary key
-#  address_known    :age_known
-#  address_line_1   :string
-#  address_line_2   :string
-#  age_known        :string
-#  approximate_age  :string
-#  country          :string
-#  date_of_birth    :date
-#  email_address    :string(256)
-#  email_known      :boolean
-#  first_name       :string
-#  has_qts          :string
-#  last_name        :string
-#  name_has_changed :string
+#  id                        :bigint           not null, primary key
+#  address_known             :boolean
+#  address_line_1            :string
+#  address_line_2            :string
+#  country                   :string
+#  date_of_birth             :date
+#  email_address             :string(256)
+#  email_known               :boolean
+#  first_name                :string
+#  has_qts                   :string
+#  last_name                 :string
+#  name_has_changed          :string
 #  personal_details_complete :boolean
-#  phone_known      :boolean
-#  phone_number     :string
-#  postcode         :string(11)
-#  previous_name    :string
-#  town_or_city     :string
-#  trn              :string
-#  trn_known        :boolean
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  phone_known               :boolean
+#  phone_number              :string
+#  postcode                  :string(11)
+#  previous_name             :string
+#  town_or_city              :string
+#  trn                       :string
+#  trn_known                 :boolean
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #
 FactoryBot.define do
   factory :referral do

--- a/spec/forms/referrals/personal_details/age_form_spec.rb
+++ b/spec/forms/referrals/personal_details/age_form_spec.rb
@@ -2,14 +2,10 @@
 require "rails_helper"
 
 RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
-  describe "#save (date)" do
-    subject(:save) { age_form.save(params) }
+  let(:referral) { Referral.new }
+  subject(:age_form) { described_class.new(referral:) }
 
-    let(:age_known) { "yes" }
-    let(:approximate_age) { "" }
-    let(:age_form) do
-      described_class.new(referral:, age_known:, approximate_age:)
-    end
+  describe "#save" do
     let(:params) do
       {
         "date_of_birth(1i)" => "2000",
@@ -17,10 +13,9 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
         "date_of_birth(3i)" => "01"
       }
     end
-    let(:referral) { Referral.new }
 
     it "updates the date of birth" do
-      save
+      age_form.save(params)
       expect(referral.date_of_birth).to eq(Date.new(2000, 1, 1))
     end
 
@@ -34,7 +29,7 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
       end
 
       it "updates the date of birth" do
-        save
+        expect(age_form.save(params)).to be true
         expect(referral.date_of_birth).to eq(Date.new(2000, 1, 1))
       end
     end
@@ -49,7 +44,7 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
       end
 
       it "updates the date of birth" do
-        save
+        expect(age_form.save(params)).to be true
         expect(referral.date_of_birth).to eq(Date.new(2000, 12, 1))
       end
     end
@@ -63,15 +58,13 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
         }
       end
 
-      it { is_expected.to be_falsy }
-
       it "does not update the date of birth" do
-        save
+        expect(age_form.save(params)).to be_falsy
         expect(referral.date_of_birth).to be_nil
       end
 
       it "adds an error" do
-        save
+        age_form.save(params)
         expect(age_form.errors[:date_of_birth]).to eq(
           ["Enter their date of birth in the correct format"]
         )
@@ -87,10 +80,8 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
         }
       end
 
-      it { is_expected.to be_falsy }
-
       it "adds an error" do
-        save
+        age_form.save(params)
         expect(age_form.errors[:date_of_birth]).to eq(
           ["Enter their date of birth"]
         )
@@ -106,10 +97,8 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
         }
       end
 
-      it { is_expected.to be_falsy }
-
       it "adds an error" do
-        save
+        age_form.save(params)
         expect(age_form.errors[:date_of_birth]).to eq(
           ["Their date of birth must be in the past"]
         )
@@ -125,10 +114,8 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
         }
       end
 
-      it { is_expected.to be_falsy }
-
       it "adds an error" do
-        save
+        age_form.save(params)
         expect(age_form.errors[:date_of_birth]).to eq(
           ["You must be 16 or over to use this service"]
         )
@@ -144,10 +131,8 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
         }
       end
 
-      it { is_expected.to be_falsy }
-
       it "adds an error" do
-        save
+        age_form.save(params)
         expect(age_form.errors[:date_of_birth]).to eq(
           ["Enter a year of birth later than 1900"]
         )
@@ -163,10 +148,8 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
         }
       end
 
-      it { is_expected.to be_falsy }
-
       it "adds an error" do
-        save
+        age_form.save(params)
         expect(age_form.errors[:date_of_birth]).to eq(
           ["Enter a year with 4 digits"]
         )
@@ -182,10 +165,8 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
         }
       end
 
-      it { is_expected.to be_falsy }
-
       it "adds an error" do
-        save
+        age_form.save(params)
         expect(age_form.errors[:date_of_birth]).to eq(
           ["Enter a day for their date of birth, formatted as a number"]
         )
@@ -201,10 +182,8 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
         }
       end
 
-      it { is_expected.to be_falsy }
-
       it "adds an error" do
-        save
+        age_form.save(params)
         expect(age_form.errors[:date_of_birth]).to eq(
           ["Enter a month for their date of birth, formatted as a number"]
         )
@@ -220,10 +199,8 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
         }
       end
 
-      it { is_expected.to be_falsy }
-
       it "adds an error" do
-        save
+        age_form.save(params)
         expect(age_form.errors[:date_of_birth]).to eq(
           ["Enter a month for their date of birth, formatted as a number"]
         )
@@ -239,50 +216,12 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
         }
       end
 
-      it { is_expected.to be_falsy }
-
       it "adds an error" do
-        save
+        age_form.save(params)
         expect(age_form.errors[:date_of_birth]).to eq(
           ["Enter a month for their date of birth, formatted as a number"]
         )
       end
-    end
-  end
-
-  describe "#save (approximate age)" do
-    subject(:save) { age_form.save }
-
-    let(:age_known) { "approximate" }
-    let(:approximate_age) { "They’re in their 20s" }
-    let(:age_form) do
-      described_class.new(referral:, age_known:, approximate_age:)
-    end
-    let(:referral) { Referral.new }
-
-    it "saves the approximate age" do
-      save
-      expect(referral.date_of_birth).to be nil
-      expect(referral.age_known).to eq("approximate")
-      expect(referral.approximate_age).to eq("They’re in their 20s")
-    end
-  end
-
-  describe "#save (age unknown)" do
-    subject(:save) { age_form.save }
-
-    let(:age_known) { "no" }
-    let(:approximate_age) { "" }
-    let(:age_form) do
-      described_class.new(referral:, age_known:, approximate_age:)
-    end
-    let(:referral) { Referral.new }
-
-    it "saves the age_known value" do
-      save
-      expect(referral.date_of_birth).to be nil
-      expect(referral.approximate_age).to be nil
-      expect(referral.age_known).to eq("no")
     end
   end
 end

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -2,33 +2,28 @@
 #
 # Table name: referrals
 #
-#  id               :bigint           not null, primary key
-#  address_known    :boolean
-#  address_line_1   :string
-#  address_line_2   :string
-#  age_known        :string
-#  approximate_age  :string
-#  country          :string
-#  date_of_birth    :date
-#  email_address    :string(256)
-#  email_known      :boolean
-#  first_name       :string
-#  last_name        :string
-#  name_has_changed :string
+#  id                        :bigint           not null, primary key
+#  address_known             :boolean
+#  address_line_1            :string
+#  address_line_2            :string
+#  country                   :string
+#  date_of_birth             :date
+#  email_address             :string(256)
+#  email_known               :boolean
+#  first_name                :string
+#  has_qts                   :string
+#  last_name                 :string
+#  name_has_changed          :string
 #  personal_details_complete :boolean
-#  phone_known      :boolean
-#  phone_number     :string
-#  postcode         :string(11)
-#  previous_name    :string
-#  has_qts          :string
-#  last_name        :string
-#  name_has_changed :string
-#  previous_name    :string
-#  town_or_city     :string
-#  trn              :string
-#  trn_known        :boolean
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  phone_known               :boolean
+#  phone_number              :string
+#  postcode                  :string(11)
+#  previous_name             :string
+#  town_or_city              :string
+#  trn                       :string
+#  trn_known                 :boolean
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #
 require "rails_helper"
 

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -123,17 +123,14 @@ RSpec.feature "Personal details" do
   end
 
   def then_i_am_asked_their_date_of_birth
-    expect(page).to have_content("Do you know their age or date of birth?")
+    expect(page).to have_content("What is their date of birth?")
   end
 
   def then_i_see_age_field_validation_errors
-    expect(page).to have_content(
-      "Tell us if you know their date of birth or age"
-    )
+    expect(page).to have_content("Enter their date of birth")
   end
 
   def when_i_fill_out_their_date_of_birth
-    choose "I know their date of birth", visible: false
     fill_in "Day", with: "17"
     fill_in "Month", with: "1"
     fill_in "Year", with: "1990"


### PR DESCRIPTION
### Context

https://trello.com/c/HbhhmKdC/869-referrals-employer-form-their-date-of-birth-page

The approximate age and age known fields have been removed from the prototype.

### Changes proposed in this pull request

Remove approximate age column and form field.
Don't ask if the use knows their age.

![image](https://user-images.githubusercontent.com/93511/200621272-f440bb4d-0120-4ddd-ba89-d99d96a17b33.png)


### Guidance to review


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
