### PR TITLE
Integrate user auth with existing form flows

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,9 @@
 class ApplicationController < ActionController::Base
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 
-  http_basic_authenticate_with name: ENV.fetch("SUPPORT_USERNAME", nil),
-                               password: ENV.fetch("SUPPORT_PASSWORD", nil),
-                               unless: -> {
-                                 FeatureFlags::FeatureFlag.active?(
-                                   "service_open"
-                                 )
-                               }
+  http_basic_authenticate_with(
+    name: ENV.fetch("SUPPORT_USERNAME", nil),
+    password: ENV.fetch("SUPPORT_PASSWORD", nil),
+    unless: -> { FeatureFlags::FeatureFlag.active?("service_open") }
+  )
 end

--- a/app/controllers/have_complained_controller.rb
+++ b/app/controllers/have_complained_controller.rb
@@ -1,4 +1,4 @@
-class HaveComplainedController < ApplicationController
+class HaveComplainedController < Referrals::BaseController
   include EnforceQuestionOrder
 
   def new

--- a/app/controllers/is_teacher_controller.rb
+++ b/app/controllers/is_teacher_controller.rb
@@ -1,4 +1,4 @@
-class IsTeacherController < ApplicationController
+class IsTeacherController < Referrals::BaseController
   include EnforceQuestionOrder
 
   def new

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,7 @@ class PagesController < ApplicationController
     @eligibility_check =
       EligibilityCheck.find_by(id: session[:eligibility_check_id])
     return redirect_to(start_path) if @eligibility_check.nil?
-    reset_session
+    session[:eligibility_check_id] = nil
   end
 
   def start

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,5 +7,6 @@ class PagesController < ApplicationController
   end
 
   def start
+    @start_now_path = (current_user ? who_path : new_user_session_path)
   end
 end

--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -1,5 +1,6 @@
 module Referrals
   class BaseController < ApplicationController
+    before_action :authenticate_user!
     before_action :redirect_if_feature_flag_disabled
 
     private

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -1,4 +1,4 @@
-class ReferralsController < ApplicationController
+class ReferralsController < Referrals::BaseController
   before_action :check_employer_form_feature_flag_enabled
 
   def new

--- a/app/controllers/reporting_as_controller.rb
+++ b/app/controllers/reporting_as_controller.rb
@@ -1,4 +1,4 @@
-class ReportingAsController < ApplicationController
+class ReportingAsController < Referrals::BaseController
   include EnforceQuestionOrder
 
   def new

--- a/app/controllers/serious_misconduct_controller.rb
+++ b/app/controllers/serious_misconduct_controller.rb
@@ -1,4 +1,4 @@
-class SeriousMisconductController < ApplicationController
+class SeriousMisconductController < Referrals::BaseController
   include EnforceQuestionOrder
 
   def new

--- a/app/controllers/teaching_in_england_controller.rb
+++ b/app/controllers/teaching_in_england_controller.rb
@@ -1,4 +1,4 @@
-class TeachingInEnglandController < ApplicationController
+class TeachingInEnglandController < Referrals::BaseController
   include EnforceQuestionOrder
 
   def new

--- a/app/controllers/unsupervised_teaching_controller.rb
+++ b/app/controllers/unsupervised_teaching_controller.rb
@@ -1,4 +1,4 @@
-class UnsupervisedTeachingController < ApplicationController
+class UnsupervisedTeachingController < Referrals::BaseController
   include EnforceQuestionOrder
 
   def new

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -21,7 +21,7 @@
     </p>
 
     <p class="govuk-body">
-      You should provide any evidence to support your allegation, for example signed witness statements or previous complaints against the teacher. 
+      You should provide any evidence to support your allegation, for example signed witness statements or previous complaints against the teacher.
     </p>
     <p class="govuk-body">
       All cases of incompetence and less serious misconduct should be dealt with by employers.
@@ -32,7 +32,7 @@
       You should allow an hour or more to complete your referral. The time it will take depends on the case. It will be faster if you’ve prepared the evidence.
     </p>
 
-    <%= govuk_start_button(text: 'Start now', href: who_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
+    <%= govuk_start_button(text: 'Start now', href: @start_now_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,5 +20,6 @@
 #
 FactoryBot.define do
   factory :user do
+    email { "#{SecureRandom.hex(5)}@example.com" }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,9 +7,11 @@ if Rails.env.production?
   abort("The Rails environment is running in production mode!")
 end
 require "rspec/rails"
+#
 # Add additional requires below this line. Rails is not loaded until this point!
 require "capybara/cuprite"
 require "sidekiq/testing"
+require "support/devise"
 
 Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(

--- a/spec/system/eligibility_screener_spec.rb
+++ b/spec/system/eligibility_screener_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-require_relative "../support/devise"
 
 RSpec.feature "Eligibility screener", type: :system do
   scenario "happy path" do

--- a/spec/system/eligibility_screener_spec.rb
+++ b/spec/system/eligibility_screener_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 require "rails_helper"
+require_relative "../support/devise"
 
-RSpec.describe "Eligibility screener", type: :system do
-  it "happy path" do
+RSpec.feature "Eligibility screener", type: :system do
+  scenario "happy path" do
     given_the_service_is_open
+    and_i_am_signed_in
     when_i_visit_the_service
     then_i_see_the_start_page
 
@@ -85,6 +87,11 @@ RSpec.describe "Eligibility screener", type: :system do
 
   def given_the_service_is_open
     FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_i_am_signed_in
+    @user = create(:user)
+    sign_in(@user)
   end
 
   def then_i_see_a_validation_error

--- a/spec/system/question_order_spec.rb
+++ b/spec/system/question_order_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 require "rails_helper"
+require_relative "../support/devise"
 
-RSpec.describe "Question order", type: :system do
-  it "is enforced correctly" do
+RSpec.feature "Question order", type: :system do
+  scenario "is enforced correctly" do
     given_the_service_is_open
+    and_i_am_signed_in
     when_i_visit_the_service
     then_i_see_the_start_page
 
@@ -42,6 +44,11 @@ RSpec.describe "Question order", type: :system do
 
   def given_the_service_is_open
     FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_i_am_signed_in
+    @user = create(:user)
+    sign_in(@user)
   end
 
   def then_i_see_the_is_a_teacher_page

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.feature "Contact details" do
+RSpec.feature "Contact details", type: :system do
   scenario "User submits contact details for the referred person" do
     given_the_service_is_open
+    and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_i_have_an_existing_referral
     when_i_visit_the_referral_summary
@@ -81,6 +82,11 @@ RSpec.feature "Contact details" do
 
   def given_the_service_is_open
     FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_i_am_signed_in
+    @user = create(:user)
+    sign_in(@user)
   end
 
   def and_the_employer_form_feature_is_active

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.feature "Personal details" do
+RSpec.feature "Personal details", type: :system do
   scenario "User adds personal details to a referral" do
     given_the_service_is_open
+    and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_i_visit_a_referral
     then_i_see_the_referral_summary
@@ -76,6 +77,11 @@ RSpec.feature "Personal details" do
 
   def given_the_service_is_open
     FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_i_am_signed_in
+    @user = create(:user)
+    sign_in(@user)
   end
 
   def and_the_employer_form_feature_is_active

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
-RSpec.feature "Employer Referral: About You" do
+RSpec.feature "Employer Referral: About You", type: :system do
   scenario "User provides their details" do
     given_the_service_is_open
+    and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_i_have_an_existing_referral
     and_i_am_on_the_referral_summary_page
@@ -43,6 +44,15 @@ RSpec.feature "Employer Referral: About You" do
 
   private
 
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_i_am_signed_in
+    @user = create(:user)
+    sign_in(@user)
+  end
+
   def and_i_am_on_the_referral_summary_page
     visit edit_referral_path(@referral)
   end
@@ -66,10 +76,6 @@ RSpec.feature "Employer Referral: About You" do
 
   def and_the_employer_form_feature_is_active
     FeatureFlags::FeatureFlag.activate(:employer_form)
-  end
-
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
   end
 
   def then_i_am_on_the_referral_summary_page

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -71,7 +71,8 @@ RSpec.feature "Employer Referral: About You", type: :system do
   end
 
   def and_i_see_your_details_flagged_as_incomplete
-    expect(page).to have_content("Your details INCOMPLETE")
+    your_details_row = find(".app-task-list__item", text: "Your details")
+    expect(your_details_row).to have_content("INCOMPLETE")
   end
 
   def and_the_employer_form_feature_is_active

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "Employer Referral: About You" do
-  scenario "Referrer provides their details" do
+RSpec.feature "Employer Referral: About You" do
+  scenario "User provides their details" do
     given_the_service_is_open
     and_the_employer_form_feature_is_active
     and_i_have_an_existing_referral
@@ -61,7 +61,7 @@ RSpec.describe "Employer Referral: About You" do
   end
 
   def and_i_see_your_details_flagged_as_incomplete
-    expect(page).to have_content("Your details\nINCOMPLETE")
+    expect(page).to have_content("Your details INCOMPLETE")
   end
 
   def and_the_employer_form_feature_is_active

--- a/spec/system/user_deletes_a_draft_referral_spec.rb
+++ b/spec/system/user_deletes_a_draft_referral_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.feature "User deletes a draft referral" do
+RSpec.feature "User deletes a draft referral", type: :system do
   scenario "User deletes a draft referral" do
     given_the_service_is_open
+    and_i_am_signed_in
     and_the_employer_form_feature_is_active
 
     when_i_make_a_new_referral
@@ -22,6 +23,11 @@ RSpec.feature "User deletes a draft referral" do
 
   def given_the_service_is_open
     FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_i_am_signed_in
+    @user = create(:user)
+    sign_in(@user)
   end
 
   def and_the_employer_form_feature_is_active

--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -4,13 +4,15 @@ require "rails_helper"
 RSpec.feature "User accounts" do
   scenario "User signs in" do
     given_the_service_is_open
-    when_i_visit_the_sign_in_page
+    when_i_visit_the_root_page
+    and_click_start_now
     and_i_submit_my_email
     when_i_provide_the_wrong_otp
     then_i_see_an_error
     when_i_submit_my_email
-    when_i_provide_the_expected_otp
+    and_i_provide_the_expected_otp
     then_i_am_signed_in
+    and_i_am_not_prompted_to_sign_in_again
   end
 
   private
@@ -19,9 +21,12 @@ RSpec.feature "User accounts" do
     FeatureFlags::FeatureFlag.activate(:service_open)
   end
 
-  def when_i_visit_the_sign_in_page
+  def when_i_visit_the_root_page
     visit root_path
-    within(".govuk-header") { click_link "Sign in" }
+  end
+
+  def and_click_start_now
+    click_on "Start now"
   end
 
   def and_i_submit_my_email
@@ -39,7 +44,7 @@ RSpec.feature "User accounts" do
     expect(page).to have_content "Invalid code"
   end
 
-  def when_i_provide_the_expected_otp
+  def and_i_provide_the_expected_otp
     # TODO: inspect sent email once mailer code is implemented
     user = User.find_by(email: "test@example.com")
     expected_otp = Devise::OtpComparison.derive_otp(user.secret_key)
@@ -50,5 +55,10 @@ RSpec.feature "User accounts" do
 
   def then_i_am_signed_in
     within(".govuk-header") { expect(page).to have_content "Sign out" }
+  end
+
+  def and_i_am_not_prompted_to_sign_in_again
+    click_on "Start now"
+    expect(page).to have_current_path who_path
   end
 end

--- a/spec/system/user_views_a_referral_summary_spec.rb
+++ b/spec/system/user_views_a_referral_summary_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.feature "User views an existing referral summary" do
+RSpec.feature "User views an existing referral summary", type: :system do
   scenario "Views referral summary sections" do
     given_the_service_is_open
+    and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_i_have_an_existing_referral
     when_i_visit_the_referral_summary
@@ -14,6 +15,11 @@ RSpec.feature "User views an existing referral summary" do
 
   def given_the_service_is_open
     FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_i_am_signed_in
+    @user = create(:user)
+    sign_in(@user)
   end
 
   def and_the_employer_form_feature_is_active


### PR DESCRIPTION
### Context

The OTP-based user auth is implemented, it now needs hooking up with the rest of the service.

https://trello.com/c/qDvX8DHU

### Changes proposed in this pull request

- Prompt user sign in after "Start now"
- Have all referral-related controllers inherit from Referrals::BaseController
- Check for current_user in Referrals::BaseController
- Change how we clear the session at the end of the eligibility screener

### Guidance to review

Fairly straightforward to test manually in either the review app or locally. Just click "Start now" on the root path!

This will be followed by some work which ensures referrals are scoped to the current_user.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
