### PR TITLE
Contact details / Check answers page

### DIFF
--- a/app/controllers/referrals/contact_details/address_controller.rb
+++ b/app/controllers/referrals/contact_details/address_controller.rb
@@ -1,24 +1,29 @@
 module Referrals
   module ContactDetails
-    class AddressController < ReferralsController
+    class AddressController < Referrals::BaseController
       def edit
         @contact_details_address_form =
           AddressForm.new(
-            address_known: referral.address_known,
-            address_line_1: referral.address_line_1,
-            address_line_2: referral.address_line_2,
-            town_or_city: referral.town_or_city,
-            postcode: referral.postcode,
-            country: referral.country
+            address_known: current_referral.address_known,
+            address_line_1: current_referral.address_line_1,
+            address_line_2: current_referral.address_line_2,
+            town_or_city: current_referral.town_or_city,
+            postcode: current_referral.postcode,
+            country: current_referral.country
           )
       end
 
       def update
         @contact_details_address_form =
-          AddressForm.new(contact_details_address_form_params.merge(referral:))
+          AddressForm.new(
+            contact_details_address_form_params.merge(
+              referral: current_referral
+            )
+          )
         if @contact_details_address_form.save
-          # TODO: Redirect to check answers page
-          redirect_to edit_referral_path(referral)
+          redirect_to referrals_update_contact_details_check_answers_path(
+                        current_referral
+                      )
         else
           render :edit
         end

--- a/app/controllers/referrals/contact_details/check_answers_controller.rb
+++ b/app/controllers/referrals/contact_details/check_answers_controller.rb
@@ -1,0 +1,34 @@
+module Referrals
+  module ContactDetails
+    class CheckAnswersController < Referrals::BaseController
+      def edit
+        @contact_details_check_answers_form =
+          CheckAnswersForm.new(
+            contact_details_complete: current_referral.contact_details_complete
+          )
+      end
+
+      def update
+        @contact_details_check_answers_form =
+          CheckAnswersForm.new(
+            contact_details_check_answers_form_params.merge(
+              referral: current_referral
+            )
+          )
+        if @contact_details_check_answers_form.save
+          redirect_to edit_referral_path(current_referral)
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def contact_details_check_answers_form_params
+        params.require(:referrals_contact_details_check_answers_form).permit(
+          :contact_details_complete
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/referrals/contact_details/email_controller.rb
+++ b/app/controllers/referrals/contact_details/email_controller.rb
@@ -1,19 +1,23 @@
 module Referrals
   module ContactDetails
-    class EmailController < ReferralsController
+    class EmailController < Referrals::BaseController
       def edit
         @contact_details_email_form =
           EmailForm.new(
-            email_known: referral.email_known,
-            email_address: referral.email_address
+            email_known: current_referral.email_known,
+            email_address: current_referral.email_address
           )
       end
 
       def update
         @contact_details_email_form =
-          EmailForm.new(contact_details_email_form_params.merge(referral:))
+          EmailForm.new(
+            contact_details_email_form_params.merge(referral: current_referral)
+          )
         if @contact_details_email_form.save
-          redirect_to referrals_update_contact_details_telephone_path(referral)
+          redirect_to referrals_update_contact_details_telephone_path(
+                        current_referral
+                      )
         else
           render :edit
         end

--- a/app/controllers/referrals/contact_details/telephone_controller.rb
+++ b/app/controllers/referrals/contact_details/telephone_controller.rb
@@ -1,21 +1,25 @@
 module Referrals
   module ContactDetails
-    class TelephoneController < ReferralsController
+    class TelephoneController < Referrals::BaseController
       def edit
         @contact_details_telephone_form =
           TelephoneForm.new(
-            phone_known: referral.phone_known,
-            phone_number: referral.phone_number
+            phone_known: current_referral.phone_known,
+            phone_number: current_referral.phone_number
           )
       end
 
       def update
         @contact_details_telephone_form =
           TelephoneForm.new(
-            contact_details_telephone_form_params.merge(referral:)
+            contact_details_telephone_form_params.merge(
+              referral: current_referral
+            )
           )
         if @contact_details_telephone_form.save
-          redirect_to referrals_update_contact_details_address_path(referral)
+          redirect_to referrals_update_contact_details_address_path(
+                        current_referral
+                      )
         else
           render :edit
         end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -62,7 +62,7 @@ class ReferralForm
         ReferralSectionItem.new(
           I18n.t("referral_form.contact_details"),
           referrals_edit_contact_details_email_path(referral),
-          :not_started_yet
+          section_status(:contact_details_complete)
         ),
         ReferralSectionItem.new(
           I18n.t("referral_form.about_their_role"),

--- a/app/forms/referrals/contact_details/check_answers_form.rb
+++ b/app/forms/referrals/contact_details/check_answers_form.rb
@@ -1,0 +1,24 @@
+module Referrals
+  module ContactDetails
+    class CheckAnswersForm
+      include ActiveModel::Model
+
+      attr_accessor :referral
+      attr_reader :contact_details_complete
+
+      validates :referral, presence: true
+      validates :contact_details_complete, inclusion: { in: [true, false] }
+
+      def contact_details_complete=(value)
+        @contact_details_complete = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save
+        return false unless valid?
+
+        referral.contact_details_complete = contact_details_complete
+        referral.save
+      end
+    end
+  end
+end

--- a/app/helpers/referrer_helper.rb
+++ b/app/helpers/referrer_helper.rb
@@ -1,0 +1,11 @@
+module ReferrerHelper
+  def address(referral)
+    [
+      referral.address_line_1,
+      referral.address_line_2,
+      referral.town_or_city,
+      referral.postcode,
+      referral.country
+    ].compact_blank.join("<br>").html_safe
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -8,6 +8,7 @@
 #  address_line_2            :string
 #  age_known                 :string
 #  approximate_age           :string
+#  contact_details_complete  :boolean
 #  country                   :string
 #  date_of_birth             :date
 #  email_address             :string(256)

--- a/app/views/referrals/contact_details/check_answers/edit.html.erb
+++ b/app/views/referrals/contact_details/check_answers/edit.html.erb
@@ -1,0 +1,52 @@
+<% content_for :page_title, "#{"Error: " if @contact_details_check_answers_form.errors.any?}Have you completed this section?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">About the person you are referring</span>
+      Contact details
+    </h1>
+    <% rows = [
+      {
+        actions: [
+          { text: "Change", href: referrals_edit_contact_details_email_path(current_referral), visually_hidden_text: "email" },
+
+        ],
+        key: { text: "Email address" },
+        value: { text: current_referral.email_known ? current_referral.email_address : "Not known" },
+      },
+      {
+        actions: [
+          { text: "Change", href: referrals_edit_contact_details_telephone_path(current_referral), visually_hidden_text: "telephone" },
+
+        ],
+        key: { text: "Phone number" },
+        value: { text: current_referral.phone_known ? current_referral.phone_number : "Not known" },
+      },
+      {
+        actions: [
+          { text: "Change", href: referrals_edit_contact_details_address_path(current_referral), visually_hidden_text: "address" },
+
+        ],
+        key: { text: "Address" },
+        value: { text: current_referral.address_known ? address(current_referral) : "Not known" },
+      }
+    ] %>
+    <%= render(SummaryCardComponent.new(rows:)) do %>
+      <%= render SummaryCardHeaderComponent.new(title: 'Contact details') %>
+    <% end %>
+
+    <%= form_with model: @contact_details_check_answers_form, url: referrals_update_contact_details_check_answers_url, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_radio_buttons_fieldset :contact_details_complete,
+        legend: { size: "m", text: "Have you completed this section?" },
+        hint: { text: "You can still make changes to a completed section" } do %>
+        <%= f.hidden_field :contact_details_complete %>
+        <%= f.govuk_radio_button :contact_details_complete, true, label: { text: "Yes, I’ve completed this section" } %>
+        <%= f.govuk_radio_button :contact_details_complete, false, label: { text: "No, I’ll come back to it later" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue", prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/contact_details/telephone/edit.html.erb
+++ b/app/views/referrals/contact_details/telephone/edit.html.erb
@@ -8,7 +8,7 @@
       <%= f.govuk_radio_buttons_fieldset :phone_known, legend: { size: "xl", text: "Do you know their main contact number?" }  do %>
         <%= f.hidden_field :phone_known %>
         <%= f.govuk_radio_button :phone_known, true, label: { text: "Yes" } do %>
-          <%= f.govuk_text_field :phone_number, label: { text: "Contact number" } %>
+          <%= f.govuk_text_field :phone_number, label: { text: "Main contact number" } %>
         <% end %>
         <%= f.govuk_radio_button :phone_known, false, label: { text: "No" } %>
       <% end %>

--- a/app/views/referrals/referrers/show.html.erb
+++ b/app/views/referrals/referrers/show.html.erb
@@ -10,7 +10,7 @@
       {
         actions: [
           { text: "Change", href: edit_referral_referrer_name_path(current_referral), visually_hidden_text: "name" },
-          
+
         ],
         key: { text: "Your name" },
         value: { text: @referrer.name },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,6 +119,10 @@ en:
             postcode:
               blank: Enter their postcode
               invalid: Enter a real postcode
+        "referrals/contact_details/check_answers_form":
+          attributes:
+            contact_details_complete:
+              inclusion: Tell us if you have completed this section
         referrer_job_title_form:
           attributes:
             job_title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,24 +105,30 @@ Rails.application.routes.draw do
         to: "personal_details/confirm#update",
         as: "update_personal_details_confirm"
 
-    get "/:id/contact-details/email",
+    get "/:referral_id/contact-details/email",
         to: "contact_details/email#edit",
         as: "edit_contact_details_email"
-    put "/:id/contact-details/email",
+    put "/:referral_id/contact-details/email",
         to: "contact_details/email#update",
         as: "update_contact_details_email"
-    get "/:id/contact-details/telephone",
+    get "/:referral_id/contact-details/telephone",
         to: "contact_details/telephone#edit",
         as: "edit_contact_details_telephone"
-    put "/:id/contact-details/telephone",
+    put "/:referral_id/contact-details/telephone",
         to: "contact_details/telephone#update",
         as: "update_contact_details_telephone"
-    get "/:id/contact-details/address",
+    get "/:referral_id/contact-details/address",
         to: "contact_details/address#edit",
         as: "edit_contact_details_address"
-    put "/:id/contact-details/address",
+    put "/:referral_id/contact-details/address",
         to: "contact_details/address#update",
         as: "update_contact_details_address"
+    get "/:referral_id/contact-details/check-answers",
+        to: "contact_details/check_answers#edit",
+        as: "edit_contact_details_check_answers"
+    put "/:referral_id/contact-details/check-answers",
+        to: "contact_details/check_answers#update",
+        as: "update_contact_details_check_answers"
   end
 
   get "/performance", to: "performance#index"

--- a/db/migrate/20221107155435_add_contact_details_completed_to_referrals.rb
+++ b/db/migrate/20221107155435_add_contact_details_completed_to_referrals.rb
@@ -1,0 +1,5 @@
+class AddContactDetailsCompletedToReferrals < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrals, :contact_details_complete, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_07_130734) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_07_155435) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_07_130734) do
     t.boolean "phone_known"
     t.string "phone_number"
     t.boolean "personal_details_complete"
+    t.boolean "contact_details_complete"
   end
 
   create_table "referrers", force: :cascade do |t|

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -8,6 +8,7 @@
 #  address_line_2            :string
 #  age_known                 :string
 #  approximate_age           :string
+#  contact_details_complete  :boolean
 #  country                   :string
 #  date_of_birth             :date
 #  email_address             :string(256)

--- a/spec/forms/referrals/contact_details/address_form_spec.rb
+++ b/spec/forms/referrals/contact_details/address_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
-  let(:referral) { Referral.new }
+  let(:referral) { create(:referral) }
   let(:form) do
     described_class.new(
       referral:,
@@ -88,9 +88,7 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
   end
 
   describe "#save" do
-    subject(:save) { form.save }
-
-    before { save }
+    before { form.save }
 
     it "saves address_known" do
       expect(referral.address_known).to be_truthy

--- a/spec/forms/referrals/contact_details/check_answers_form_spec.rb
+++ b/spec/forms/referrals/contact_details/check_answers_form_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Referrals::ContactDetails::CheckAnswersForm, type: :model do
+  let(:referral) { create(:referral) }
+  let(:form) { described_class.new(referral:, contact_details_complete:) }
+  let(:contact_details_complete) { true }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:referral) }
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    it { is_expected.to be_truthy }
+
+    before { valid }
+
+    context "when contact_details_complete is blank" do
+      let(:contact_details_complete) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:contact_details_complete]).to eq(
+          ["Tell us if you have completed this section"]
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    before { form.save }
+
+    it "saves contact_details_complete" do
+      expect(referral.contact_details_complete).to be_truthy
+    end
+
+    context "when the form is marked as in progress" do
+      let(:contact_details_complete) { false }
+
+      it "saves contact_details_complete as false" do
+        expect(referral.contact_details_complete).to be_falsy
+      end
+    end
+  end
+end

--- a/spec/forms/referrals/contact_details/email_form_spec.rb
+++ b/spec/forms/referrals/contact_details/email_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Referrals::ContactDetails::EmailForm, type: :model do
-  let(:referral) { Referral.new }
+  let(:referral) { create(:referral) }
   let(:form) { described_class.new(referral:, email_known:, email_address:) }
   let(:email_known) { true }
   let(:email_address) { "name@example.com" }
@@ -62,9 +62,7 @@ RSpec.describe Referrals::ContactDetails::EmailForm, type: :model do
   end
 
   describe "#save" do
-    subject(:save) { form.save }
-
-    before { save }
+    before { form.save }
 
     it "saves email_known" do
       expect(referral.email_known).to be_truthy

--- a/spec/forms/referrals/contact_details/telephone_form_spec.rb
+++ b/spec/forms/referrals/contact_details/telephone_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Referrals::ContactDetails::TelephoneForm, type: :model do
-  let(:referral) { Referral.new }
+  let(:referral) { create(:referral) }
   let(:form) { described_class.new(referral:, phone_known:, phone_number:) }
   let(:phone_known) { true }
   let(:phone_number) { "07700 900 982" }
@@ -62,9 +62,7 @@ RSpec.describe Referrals::ContactDetails::TelephoneForm, type: :model do
   end
 
   describe "#save" do
-    subject(:save) { form.save }
-
-    before { save }
+    before { form.save }
 
     it "saves phone_known" do
       expect(referral.phone_known).to be_truthy

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -8,6 +8,7 @@
 #  address_line_2            :string
 #  age_known                 :string
 #  approximate_age           :string
+#  contact_details_complete  :boolean
 #  country                   :string
 #  date_of_birth             :date
 #  email_address             :string(256)


### PR DESCRIPTION
### Context

When the contact details have been submitted the user can check and confirm.

https://trello.com/c/ROS5BGje/943-contact-details-check-answers-page
https://teacher-misconduct.herokuapp.com/report/teacher-contact-details/check-answers

### Changes proposed in this pull request
<img width="1022" alt="Screenshot 2022-11-08 at 15 47 50" src="https://user-images.githubusercontent.com/1636476/200611655-daaed596-b782-43f9-a536-bbaea22f153d.png">

- Update the routes
- Generate a migration for adding the `contact_details_complete` field to the referrals table.
- Add the form, including validation
- Link the form to the address question page and the referral summary page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
