### PR TITLE
Add check answers for the organisation details

### DIFF
--- a/app/controllers/referrals/organisation_controller.rb
+++ b/app/controllers/referrals/organisation_controller.rb
@@ -1,0 +1,30 @@
+module Referrals
+  class OrganisationController < BaseController
+    def show
+      @organisation =
+        current_referral.organisation || current_referral.build_organisation
+      @organisation_form = OrganisationForm.new(referral: current_referral)
+    end
+
+    def update
+      @organisation_form =
+        OrganisationForm.new(
+          complete: organisation_params[:complete],
+          referral: current_referral
+        )
+
+      if @organisation_form.save
+        redirect_to edit_referral_path(current_referral)
+      else
+        @organisation = current_referral.organisation
+        render :show
+      end
+    end
+
+    private
+
+    def organisation_params
+      params.require(:organisation_form).permit(:complete)
+    end
+  end
+end

--- a/app/forms/organisation_form.rb
+++ b/app/forms/organisation_form.rb
@@ -1,0 +1,25 @@
+class OrganisationForm
+  include ActiveModel::Model
+
+  attr_accessor :referral
+  attr_writer :complete
+
+  validates :complete, inclusion: { in: %w[true false] }
+  validates :referral, presence: true
+
+  def complete
+    @complete || organisation&.completed_at? || nil
+  end
+
+  def save
+    return false unless valid?
+
+    organisation.update(completed_at: complete == "true" ? Time.current : nil)
+  end
+
+  private
+
+  def organisation
+    @organisation ||= referral&.organisation || referral&.build_organisation
+  end
+end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -42,8 +42,8 @@ class ReferralForm
         ),
         ReferralSectionItem.new(
           I18n.t("referral_form.your_organisation"),
-          "#",
-          :not_started_yet
+          referral_organisation_path(referral),
+          referral.organisation_status
         )
       ]
     )

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: organisations
+#
+#  id           :bigint           not null, primary key
+#  completed_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  referral_id  :bigint           not null
+#
+# Indexes
+#
+#  index_organisations_on_referral_id  (referral_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (referral_id => referrals.id)
+#
+class Organisation < ApplicationRecord
+  belongs_to :referral
+
+  def completed?
+    completed_at.present?
+  end
+
+  def status
+    return :complete if completed?
+
+    :incomplete
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -28,7 +28,14 @@
 #  updated_at                :datetime         not null
 #
 class Referral < ApplicationRecord
+  has_one :organisation, dependent: :destroy
   has_one :referrer, dependent: :destroy
+
+  def organisation_status
+    return :not_started_yet if organisation.blank?
+
+    organisation.status
+  end
 
   def referrer_status
     return :not_started_yet if referrer.blank?

--- a/app/views/referrals/organisation/show.html.erb
+++ b/app/views/referrals/organisation/show.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title, "Your organisation" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">About you</span>
+      Your organisation
+    </h1>
+    <% rows = [] %>
+    <%= render(SummaryCardComponent.new(rows:)) do %>
+      <%= render SummaryCardHeaderComponent.new(title: 'Your organisation') %>
+    <% end %>
+
+    <%= form_with model: @organisation_form, url: referral_organisation_path(current_referral), method: :patch do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :complete, legend: { size: 'm', text: 'Have you completed this section?' } do %>
+        <%= f.hidden_field :complete %>
+        <%= f.govuk_radio_button :complete, 'true', label: { text: "Yes, I’ve completed this section" } %>
+        <%= f.govuk_radio_button :complete, 'false', label: { text: "No, I’ll come back to it later" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,10 @@ en:
           attributes:
             name:
               blank: Enter your name
+        organisation_form:
+          attributes:
+            complete:
+              inclusion: Tell us if you have completed this section
         referrer_form:
           attributes:
             complete:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,10 @@ Rails.application.routes.draw do
     get "/delete", to: "referrals#delete", on: :member
     get "/deleted", to: "referrals#deleted", on: :collection
 
+    resource :organisation,
+             only: %i[show update],
+             controller: "referrals/organisation"
+
     resource :referrer, only: %i[show update], controller: "referrals/referrers"
     resource :referrer_details,
              only: %i[show],

--- a/db/migrate/20221109112738_create_organisations.rb
+++ b/db/migrate/20221109112738_create_organisations.rb
@@ -1,0 +1,9 @@
+class CreateOrganisations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :organisations do |t|
+      t.belongs_to :referral, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221109112834_add_completed_at_to_organisation.rb
+++ b/db/migrate/20221109112834_add_completed_at_to_organisation.rb
@@ -1,0 +1,5 @@
+class AddCompletedAtToOrganisation < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organisations, :completed_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_09_112653) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_09_112834) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_09_112653) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_feature_flags_features_on_name", unique: true
+  end
+
+  create_table "organisations", force: :cascade do |t|
+    t.bigint "referral_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "completed_at", precision: nil
+    t.index ["referral_id"], name: "index_organisations_on_referral_id"
   end
 
   create_table "referrals", force: :cascade do |t|
@@ -121,5 +129,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_09_112653) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "organisations", "referrals"
   add_foreign_key "referrers", "referrals"
 end

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: organisations
+#
+#  id           :bigint           not null, primary key
+#  completed_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  referral_id  :bigint           not null
+#
+# Indexes
+#
+#  index_organisations_on_referral_id  (referral_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (referral_id => referrals.id)
+#
+FactoryBot.define do
+  factory :organisation do
+    referral
+  end
+end

--- a/spec/forms/organisation_form_spec.rb
+++ b/spec/forms/organisation_form_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe OrganisationForm, type: :model do
+  it { is_expected.to validate_presence_of(:referral) }
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:complete) { "true" }
+    let(:form) { described_class.new(complete:, referral:) }
+    let(:organisation) { build(:organisation) }
+    let(:referral) { organisation.referral }
+
+    it { is_expected.to be_truthy }
+
+    it "updates the organisation" do
+      save
+      expect(organisation).to be_completed
+    end
+
+    context "when the form is not valid" do
+      let(:referral) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe "#complete" do
+    subject(:form_complete) { form.complete }
+
+    let(:form) { described_class.new(complete:, referral:) }
+    let(:organisation) { build(:organisation) }
+    let(:referral) { organisation.referral }
+
+    context "when the value of complete is nil" do
+      let(:complete) { nil }
+      let(:organisation) { build(:organisation, completed_at: Time.current) }
+
+      it "returns the value from the organisation" do
+        expect(form_complete).to eq(organisation.completed?)
+      end
+    end
+
+    context "when the value of complete is set" do
+      let(:complete) { true }
+
+      it "returns the value of complete" do
+        expect(complete).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,0 +1,53 @@
+# == Schema Information
+#
+# Table name: organisations
+#
+#  id           :bigint           not null, primary key
+#  completed_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  referral_id  :bigint           not null
+#
+# Indexes
+#
+#  index_organisations_on_referral_id  (referral_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (referral_id => referrals.id)
+#
+require "rails_helper"
+
+RSpec.describe Organisation, type: :model do
+  it { is_expected.to belong_to(:referral) }
+
+  describe "#completed?" do
+    context "when completed_at is not nil" do
+      subject { build(:organisation, completed_at: Time.current) }
+
+      it { is_expected.to be_completed }
+    end
+
+    context "when completed_at is nil" do
+      subject { build(:organisation, completed_at: nil) }
+
+      it { is_expected.not_to be_completed }
+    end
+  end
+
+  describe "#status" do
+    subject { organisation.status }
+
+    context "when completed_at is not nil" do
+      let(:organisation) { build(:organisation, completed_at: Time.current) }
+
+      it { is_expected.to eq(:complete) }
+    end
+
+    context "when completed_at is nil" do
+      let(:organisation) { build(:organisation, completed_at: nil) }
+
+      it { is_expected.to eq(:incomplete) }
+    end
+  end
+end

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -30,6 +30,7 @@
 require "rails_helper"
 
 RSpec.describe Referral, type: :model do
+  it { is_expected.to have_one(:organisation).dependent(:destroy) }
   it { is_expected.to have_one(:referrer).dependent(:destroy) }
 
   describe "#referrer_status" do
@@ -43,6 +44,20 @@ RSpec.describe Referral, type: :model do
       let(:referral) do
         build(:referral, referrer: build(:referrer, :incomplete))
       end
+
+      it { is_expected.to eq(:incomplete) }
+    end
+  end
+
+  describe "#organisation_status" do
+    subject { referral.organisation_status }
+
+    let(:referral) { build(:referral) }
+
+    it { is_expected.to eq(:not_started_yet) }
+
+    context "when an organisation is present" do
+      let(:referral) { build(:organisation).referral }
 
       it { is_expected.to eq(:incomplete) }
     end

--- a/spec/system/referrals/user_adds_organisation_details_spec.rb
+++ b/spec/system/referrals/user_adds_organisation_details_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.feature "Employer Referral: Organisation", type: :system do
+  scenario "User provides the organisation details" do
+    given_the_service_is_open
+    and_i_am_signed_in
+    and_the_employer_form_feature_is_active
+    and_i_have_an_existing_referral
+    and_i_am_on_the_referral_summary_page
+    when_i_click_on_your_organisation
+    then_i_am_on_the_organisation_details_page
+
+    when_i_click_save_and_continue
+    then_i_am_asked_to_make_a_choice
+
+    when_i_choose_no_come_back_later
+    and_i_click_save_and_continue
+    then_i_am_on_the_referral_summary_page
+    and_i_see_your_organisation_flagged_as_incomplete
+
+    when_i_click_on_your_organisation
+    and_i_choose_complete
+    and_i_click_save_and_continue
+    then_i_am_on_the_referral_summary_page
+    and_i_see_your_organisation_flagged_as_complete
+  end
+
+  private
+
+  def and_i_choose_complete
+    choose "Yes, I’ve completed this section", visible: false
+  end
+
+  def and_i_see_your_organisation_flagged_as_incomplete
+    your_organisation_row =
+      find(".app-task-list__item", text: "Your organisation")
+    expect(your_organisation_row).to have_content("INCOMPLETE")
+  end
+
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_i_am_signed_in
+    user = create(:user)
+    sign_in(user)
+  end
+
+  def and_i_am_on_the_referral_summary_page
+    visit edit_referral_path(@referral)
+  end
+
+  def and_i_have_an_existing_referral
+    @referral = create(:referral)
+  end
+
+  def and_i_see_your_organisation_flagged_as_complete
+    expect(page).to have_content("Your organisation\nCOMPLETE")
+  end
+
+  def and_the_employer_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def then_i_am_asked_to_make_a_choice
+    expect(page).to have_content("Tell us if you have completed this section")
+  end
+
+  def then_i_am_on_the_organisation_details_page
+    expect(page).to have_current_path("/referrals/#{@referral.id}/organisation")
+    expect(page).to have_title(
+      "Your organisation - Refer serious misconduct by a teacher in England"
+    )
+    expect(page).to have_content("Your organisation")
+  end
+
+  def then_i_am_on_the_referral_summary_page
+    expect(page).to have_current_path(edit_referral_path(@referral))
+  end
+
+  def when_i_choose_no_come_back_later
+    choose "No, I’ll come back to it later", visible: false
+  end
+
+  def when_i_click_on_your_organisation
+    click_on "Your organisation"
+  end
+
+  def when_i_click_save_and_continue
+    click_on "Save and continue"
+  end
+  alias_method :and_i_click_save_and_continue, :when_i_click_save_and_continue
+end


### PR DESCRIPTION
When a user adds their organisation details, we display a summary of the
information on a check answers page.

They also have the ability to indicate if the details are complete or
not.

I opted to use a separate model, `Organisation`, to store the organisation
details rather than overloading `Referral`.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1020" alt="Screenshot 2022-11-09 at 12 53 07 pm" src="https://user-images.githubusercontent.com/3126/200839574-38d16464-c7a3-46f7-81aa-326ad9460ec5.png">
<img width="1004" alt="Screenshot 2022-11-09 at 12 53 12 pm" src="https://user-images.githubusercontent.com/3126/200839598-1939a6cf-8c5a-43ee-b9d7-2b75024a1630.png">
<img width="1020" alt="Screenshot 2022-11-09 at 1 13 27 pm" src="https://user-images.githubusercontent.com/3126/200839665-59180c14-0bca-4af2-b523-9207606ff89e.png">
