### PR TITLE
Associate users and referrals

### DIFF
--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -6,7 +6,7 @@ module Referrals
     private
 
     def current_referral
-      @current_referral ||= Referral.find(params[:referral_id])
+      @current_referral ||= current_user.referrals.find(params[:referral_id])
     end
     helper_method :current_referral
 

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -1,5 +1,6 @@
 class ReferralsController < Referrals::BaseController
   before_action :check_employer_form_feature_flag_enabled
+  before_action :redirect_to_referral_if_exists, only: %i[new create]
 
   def new
   end
@@ -39,6 +40,12 @@ class ReferralsController < Referrals::BaseController
   end
 
   private
+
+  def redirect_to_referral_if_exists
+    latest_referral = current_user.latest_referral
+
+    redirect_to referral_path(latest_referral) if latest_referral
+  end
 
   def referral
     @referral ||= current_user.referrals.find(params[:id])

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -2,6 +2,14 @@ class ReferralsController < Referrals::BaseController
   before_action :check_employer_form_feature_flag_enabled
 
   def new
+  end
+
+  def create
+    referral = current_user.referrals.create
+    redirect_to referral_path(referral)
+  end
+
+  def show
     @referral_form = ReferralForm.new(referral:)
   end
 
@@ -33,8 +41,7 @@ class ReferralsController < Referrals::BaseController
   private
 
   def referral
-    # TODO: This needs integration with current_user check
-    @referral ||= Referral.find_or_create_by(id: params[:id])
+    @referral ||= current_user.referrals.find(params[:id])
   end
 
   def check_employer_form_feature_flag_enabled

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -38,7 +38,13 @@ class Users::OtpController < DeviseController
 
   private
 
-  def after_sign_in_path_for(_resource)
-    root_path
+  def after_sign_in_path_for(resource)
+    latest_referral = resource.latest_referral
+
+    if latest_referral
+      referral_path(latest_referral)
+    else
+      root_path
+    end
   end
 end

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -41,10 +41,6 @@ class Users::OtpController < DeviseController
   def after_sign_in_path_for(resource)
     latest_referral = resource.latest_referral
 
-    if latest_referral
-      referral_path(latest_referral)
-    else
-      root_path
-    end
+    latest_referral ? referral_path(latest_referral) : root_path
   end
 end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -26,10 +26,20 @@
 #  trn_known                 :boolean
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
+#  user_id                   :bigint
+#
+# Indexes
+#
+#  index_referrals_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 class Referral < ApplicationRecord
   has_one :organisation, dependent: :destroy
   has_one :referrer, dependent: :destroy
+  belongs_to :user
 
   def organisation_status
     return :not_started_yet if organisation.blank?

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -26,7 +26,7 @@
 #  trn_known                 :boolean
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
-#  user_id                   :bigint
+#  user_id                   :bigint           not null
 #
 # Indexes
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,4 +23,8 @@ class User < ApplicationRecord
   include Devise::Models::OtpAuthenticatable
 
   has_many :referrals
+
+  def latest_referral
+    referrals.order(created_at: :desc).first
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,4 +21,6 @@
 class User < ApplicationRecord
   devise :validatable, :trackable
   include Devise::Models::OtpAuthenticatable
+
+  has_many :referrals
 end

--- a/app/views/referrals/new.html.erb
+++ b/app/views/referrals/new.html.erb
@@ -1,27 +1,11 @@
+<% content_for :page_title, "Your progress is saved as you go" %>
+<% content_for :back_link_url, url_for(:back) %>
+
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @referral_form, url: referral_path(@referral), method: :post do |f| %>
-      <h1 class="govuk-heading-xl"><%= t("referral_form.heading") %></h1>
-      <%= render TaskListComponent.new(sections: @referral_form.sections) %>
-      <button class="govuk-button" data-module="govuk-button">
-        Review and send
-      </button>
-    <% end %>
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          I don’t want to continue
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <p>
-          You can delete your draft:<br>
-          <%= govuk_link_to "Delete your draft referral", delete_referral_path(@referral), class: "govuk-button" %>
-        </p>
-        <p>
-          Drafts are automatically deleted after 6 months of no activity. We’ll send you an email before deleting it.
-        </p>
-      </div>
-    </details>
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+      <h1 class="govuk-heading-l">Your progress is saved as you go</h1>
+      <p>You don’t have to complete your referral in a single session. Your answers will automatically be saved and you can return at any time by logging back in.</p>
+      <p class="govuk-!-margin-bottom-6">We’ll send you an email with a link to access your referral.</p>
+      <%= govuk_button_to('Continue', referrals_path, method: :post) %>
   </div>
 </div>

--- a/app/views/referrals/show.html.erb
+++ b/app/views/referrals/show.html.erb
@@ -1,0 +1,27 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: @referral_form, url: referral_path(@referral), method: :post do |f| %>
+      <h1 class="govuk-heading-xl"><%= t("referral_form.heading") %></h1>
+      <%= render TaskListComponent.new(sections: @referral_form.sections) %>
+      <button class="govuk-button" data-module="govuk-button">
+        Review and send
+      </button>
+    <% end %>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          I don’t want to continue
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <p>
+          You can delete your draft:<br>
+          <%= govuk_link_to "Delete your draft referral", delete_referral_path(@referral), class: "govuk-button" %>
+        </p>
+        <p>
+          Drafts are automatically deleted after 6 months of no activity. We’ll send you an email before deleting it.
+        </p>
+      </div>
+    </details>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
 
   root to: redirect("/start")
 
-  resources :referrals, except: %i[index show] do
+  resources :referrals, except: %i[index] do
     get "/delete", to: "referrals#delete", on: :member
     get "/deleted", to: "referrals#deleted", on: :collection
 

--- a/db/migrate/20221108141253_add_user_id_to_referrals.rb
+++ b/db/migrate/20221108141253_add_user_id_to_referrals.rb
@@ -1,0 +1,5 @@
+class AddUserIdToReferrals < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :referrals, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20221108143252_fill_blank_user_ids_on_referrals.rb
+++ b/db/migrate/20221108143252_fill_blank_user_ids_on_referrals.rb
@@ -1,0 +1,9 @@
+class FillBlankUserIdsOnReferrals < ActiveRecord::Migration[7.0]
+  def change
+    # Fill in null user_ids
+    # This will be followed by a migration setting this column to not null.
+    if Referral.exists?
+      Referral.update_all(user_id: 1)
+    end
+  end
+end

--- a/db/migrate/20221108143252_fill_blank_user_ids_on_referrals.rb
+++ b/db/migrate/20221108143252_fill_blank_user_ids_on_referrals.rb
@@ -2,8 +2,6 @@ class FillBlankUserIdsOnReferrals < ActiveRecord::Migration[7.0]
   def change
     # Fill in null user_ids
     # This will be followed by a migration setting this column to not null.
-    if Referral.exists?
-      Referral.update_all(user_id: 1)
-    end
+    Referral.update_all(user_id: 1) if Referral.exists?
   end
 end

--- a/db/migrate/20221108143712_make_user_id_not_null_on_referrals.rb
+++ b/db/migrate/20221108143712_make_user_id_not_null_on_referrals.rb
@@ -1,0 +1,5 @@
+class MakeUserIdNotNullOnReferrals < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :referrals, :user_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,6 +65,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_09_112834) do
     t.string "phone_number"
     t.boolean "age_known"
     t.boolean "contact_details_complete"
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 
   create_table "referrers", force: :cascade do |t|
@@ -130,5 +132,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_09_112834) do
   end
 
   add_foreign_key "organisations", "referrals"
+  add_foreign_key "referrals", "users"
   add_foreign_key "referrers", "referrals"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,7 +65,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_09_112834) do
     t.string "phone_number"
     t.boolean "age_known"
     t.boolean "contact_details_complete"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -26,7 +26,7 @@
 #  trn_known                 :boolean
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
-#  user_id                   :bigint
+#  user_id                   :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -26,8 +26,18 @@
 #  trn_known                 :boolean
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
+#  user_id                   :bigint
+#
+# Indexes
+#
+#  index_referrals_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 FactoryBot.define do
   factory :referral do
+    user
   end
 end

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -26,6 +26,15 @@
 #  trn_known                 :boolean
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
+#  user_id                   :bigint
+#
+# Indexes
+#
+#  index_referrals_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 require "rails_helper"
 

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -26,7 +26,7 @@
 #  trn_known                 :boolean
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
-#  user_id                   :bigint
+#  user_id                   :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,4 +21,14 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
+  describe "#latest_referral" do
+    it "returns the most recently created referral" do
+      user = create(:user)
+      expected_referral = create(:referral, user:, created_at: Time.zone.now + 1.hour)
+      create(:referral, user:, created_at: Time.zone.now)
+      create(:referral, user:, created_at: Time.zone.now - 1.hour)
+
+      expect(user.latest_referral).to eq expected_referral
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe User, type: :model do
   describe "#latest_referral" do
     it "returns the most recently created referral" do
       user = create(:user)
-      expected_referral = create(:referral, user:, created_at: Time.zone.now + 1.hour)
+      expected_referral =
+        create(:referral, user:, created_at: Time.zone.now + 1.hour)
       create(:referral, user:, created_at: Time.zone.now)
       create(:referral, user:, created_at: Time.zone.now - 1.hour)
 

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -115,7 +115,7 @@ RSpec.feature "Contact details", type: :system do
   end
 
   def and_i_have_an_existing_referral
-    @referral = Referral.create!
+    @referral = create(:referral, user: @user)
   end
 
   def when_i_visit_the_referral_summary

--- a/spec/system/referrals/user_adds_organisation_details_spec.rb
+++ b/spec/system/referrals/user_adds_organisation_details_spec.rb
@@ -42,8 +42,8 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
   end
 
   def and_i_am_signed_in
-    user = create(:user)
-    sign_in(user)
+    @user = create(:user)
+    sign_in(@user)
   end
 
   def and_i_am_on_the_referral_summary_page
@@ -51,11 +51,14 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
   end
 
   def and_i_have_an_existing_referral
-    @referral = create(:referral)
+    @referral = create(:referral, user: @user)
   end
 
   def and_i_see_your_organisation_flagged_as_complete
-    expect(page).to have_content("Your organisation\nCOMPLETE")
+    within(".app-task-list__item", text: "Your organisation") do
+      status_tag = find(".app-task-list__tag")
+      expect(status_tag.text).to match(/^COMPLETE/)
+    end
   end
 
   def and_the_employer_form_feature_is_active

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature "Personal details", type: :system do
   end
 
   def and_i_visit_a_referral
-    @referral = create(:referral)
+    @referral = create(:referral, user: @user)
     visit edit_referral_path(@referral)
   end
 

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -94,8 +94,10 @@ RSpec.feature "Employer Referral: About You", type: :system do
   end
 
   def and_i_see_your_details_flagged_as_incomplete
-    your_details_row = find(".app-task-list__item", text: "Your details")
-    expect(your_details_row).to have_content("INCOMPLETE")
+    within(".app-task-list__item", text: "Your details") do
+      status_tag = find(".app-task-list__tag")
+      expect(status_tag.text).to have_content("INCOMPLETE")
+    end
   end
 
   def and_the_employer_form_feature_is_active
@@ -172,7 +174,10 @@ RSpec.feature "Employer Referral: About You", type: :system do
   end
 
   def then_i_see_your_details_flagged_as_complete
-    expect(page).to have_content("Your details\nCOMPLETE")
+    within(".app-task-list__item", text: "Your details") do
+      status_tag = find(".app-task-list__tag")
+      expect(status_tag.text).to match(/^COMPLETE/)
+    end
   end
 
   def when_i_click_back

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
   end
 
   def and_i_have_an_existing_referral
-    @referral = Referral.create!
+    @referral = create(:referral, user: @user)
   end
 
   def and_i_see_my_name_in_the_form_field

--- a/spec/system/user_deletes_a_draft_referral_spec.rb
+++ b/spec/system/user_deletes_a_draft_referral_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "User deletes a draft referral", type: :system do
   end
 
   def when_i_have_an_existing_referral
-    @referral = Referral.create!
+    @referral = create(:referral, user: @user)
   end
 
   def and_i_visit_the_referral_summary
@@ -44,6 +44,7 @@ RSpec.feature "User deletes a draft referral", type: :system do
 
   def when_i_make_a_new_referral
     visit new_referral_path
+    click_on "Continue"
   end
 
   def and_i_dont_want_to_continue

--- a/spec/system/user_views_a_referral_summary_spec.rb
+++ b/spec/system/user_views_a_referral_summary_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "User views an existing referral summary", type: :system do
   end
 
   def and_i_have_an_existing_referral
-    @referral = Referral.create!
+    @referral = create(:referral, user: @user)
   end
 
   def when_i_visit_the_referral_summary


### PR DESCRIPTION
### Context

Users can now sign in, but the relationship between them and their referrals needs defining. Among other things, this allows us to ensure referral database queries are correctly scope to the user that owns them.

### Changes proposed in this pull request

Broadly, this PR contains changes which:

- establish the model relationship
- scope referral querying in the controllers
- implement the interstitial page just prior to viewing the referral summary (the continue button here is the thing which creates the actual referral record). There's more work to be done to connect the eligibility screener flow to this page.

See commits for a more detailed summary.

### Guidance to review

Best way to test manually is to navigate to /referrals/new

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
