### PR TITLE
Collect the organisation name

### DIFF
--- a/app/controllers/referrals/organisation_name_controller.rb
+++ b/app/controllers/referrals/organisation_name_controller.rb
@@ -1,0 +1,26 @@
+module Referrals
+  class OrganisationNameController < BaseController
+    def edit
+      @organisation_name_form =
+        OrganisationNameForm.new(referral: current_referral)
+    end
+
+    def update
+      @organisation_name_form =
+        OrganisationNameForm.new(
+          organisation_name_form_params.merge(referral: current_referral)
+        )
+      if @organisation_name_form.save
+        redirect_to referral_organisation_path(current_referral)
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def organisation_name_form_params
+      params.require(:organisation_name_form).permit(:name)
+    end
+  end
+end

--- a/app/forms/organisation_name_form.rb
+++ b/app/forms/organisation_name_form.rb
@@ -1,0 +1,23 @@
+class OrganisationNameForm
+  include ActiveModel::Model
+
+  attr_accessor :referral
+  attr_writer :name
+
+  validates :name, presence: true
+  validates :referral, presence: true
+
+  def name
+    @name ||= organisation&.name
+  end
+
+  def organisation
+    @organisation ||= referral&.organisation || referral&.build_organisation
+  end
+
+  def save
+    return false unless valid?
+
+    organisation.update(name:)
+  end
+end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -42,7 +42,7 @@ class ReferralForm
         ),
         ReferralSectionItem.new(
           I18n.t("referral_form.your_organisation"),
-          referral_organisation_path(referral),
+          edit_referral_organisation_name_path(referral),
           referral.organisation_status
         )
       ]

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -4,6 +4,7 @@
 #
 #  id           :bigint           not null, primary key
 #  completed_at :datetime
+#  name         :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  referral_id  :bigint           not null

--- a/app/views/referrals/organisation/show.html.erb
+++ b/app/views/referrals/organisation/show.html.erb
@@ -6,7 +6,16 @@
       <span class="govuk-caption-xl">About you</span>
       Your organisation
     </h1>
-    <% rows = [] %>
+    <% rows = [
+      {
+        actions: [
+          { text: "Change", href: edit_referral_organisation_name_path(current_referral), visually_hidden_text: "name" },
+
+        ],
+        key: { text: "Organisation" },
+        value: { text: @organisation.name },
+      }
+    ] %>
     <%= render(SummaryCardComponent.new(rows:)) do %>
       <%= render SummaryCardHeaderComponent.new(title: 'Your organisation') %>
     <% end %>

--- a/app/views/referrals/organisation_name/edit.html.erb
+++ b/app/views/referrals/organisation_name/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, "#{'Error: ' if @organisation_name_form.errors.any?}What’s the name of your organisation?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @organisation_name_form, url: referral_organisation_name_url(current_referral), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field :name, label: { size: 'xl', text: "What’s the name of your organisation?" } %>
+      
+      <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,6 +137,10 @@ en:
           attributes:
             complete:
               inclusion: Tell us if you have completed this section
+        organisation_name_form:
+          attributes:
+            name:
+              blank: Tell us the name of your organisation
         referrer_form:
           attributes:
             complete:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,10 @@ Rails.application.routes.draw do
              only: %i[show update],
              controller: "referrals/organisation"
 
+    resource :organisation_name,
+             only: %i[edit update],
+             controller: "referrals/organisation_name"
+
     resource :referrer, only: %i[show update], controller: "referrals/referrers"
     resource :referrer_details,
              only: %i[show],

--- a/db/migrate/20221110095734_add_name_to_organisation.rb
+++ b/db/migrate/20221110095734_add_name_to_organisation.rb
@@ -1,0 +1,5 @@
+class AddNameToOrganisation < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organisations, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_09_112834) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_10_095734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,6 +38,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_09_112834) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "completed_at", precision: nil
+    t.string "name"
     t.index ["referral_id"], name: "index_organisations_on_referral_id"
   end
 

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -4,6 +4,7 @@
 #
 #  id           :bigint           not null, primary key
 #  completed_at :datetime
+#  name         :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  referral_id  :bigint           not null

--- a/spec/forms/organisation_name_form_spec.rb
+++ b/spec/forms/organisation_name_form_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe OrganisationNameForm, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:referral) }
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    let(:referral) { build(:referral) }
+    let(:form) { described_class.new(referral:, name:) }
+    let(:name) { "Name" }
+
+    it { is_expected.to be_truthy }
+
+    context "when name is blank" do
+      let(:name) { "" }
+
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:name) { "Name" }
+    let(:organisation) { build(:organisation) }
+    let(:referral) { organisation.referral }
+    let(:form) { described_class.new(referral:, name:) }
+
+    it "saves the Referral" do
+      save
+      expect(organisation.name).to eq("Name")
+    end
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id           :bigint           not null, primary key
 #  completed_at :datetime
+#  name         :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  referral_id  :bigint           not null

--- a/spec/system/referrals/user_adds_organisation_details_spec.rb
+++ b/spec/system/referrals/user_adds_organisation_details_spec.rb
@@ -8,6 +8,20 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
     and_i_have_an_existing_referral
     and_i_am_on_the_referral_summary_page
     when_i_click_on_your_organisation
+
+    then_i_am_on_the_organisation_name_page
+    when_i_click_save_and_continue
+    then_i_see_the_missing_name_error
+
+    when_i_fill_in_the_organisation_name
+    and_i_click_save_and_continue
+    then_i_am_on_the_organisation_details_page
+
+    when_i_click_change_organisation_name
+    then_i_am_on_the_organisation_name_page
+    and_i_see_the_name_prefilled
+
+    when_i_click_save_and_continue
     then_i_am_on_the_organisation_details_page
 
     when_i_click_save_and_continue
@@ -18,7 +32,7 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
     then_i_am_on_the_referral_summary_page
     and_i_see_your_organisation_flagged_as_incomplete
 
-    when_i_click_on_your_organisation
+    when_i_go_back
     and_i_choose_complete
     and_i_click_save_and_continue
     then_i_am_on_the_referral_summary_page
@@ -29,6 +43,13 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
 
   def and_i_choose_complete
     choose "Yes, I’ve completed this section", visible: false
+  end
+
+  def and_i_see_the_name_prefilled
+    expect(page).to have_field(
+      "What’s the name of your organisation?",
+      with: "My organisation"
+    )
   end
 
   def and_i_see_your_organisation_flagged_as_incomplete
@@ -77,12 +98,30 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
     expect(page).to have_content("Your organisation")
   end
 
+  def then_i_am_on_the_organisation_name_page
+    expect(page).to have_current_path(
+      "/referrals/#{@referral.id}/organisation_name/edit"
+    )
+    expect(page).to have_title(
+      "What’s the name of your organisation? - Refer serious misconduct by a teacher in England"
+    )
+    expect(page).to have_content("What’s the name of your organisation?")
+  end
+
   def then_i_am_on_the_referral_summary_page
     expect(page).to have_current_path(edit_referral_path(@referral))
   end
 
+  def then_i_see_the_missing_name_error
+    expect(page).to have_content("Tell us the name of your organisation")
+  end
+
   def when_i_choose_no_come_back_later
     choose "No, I’ll come back to it later", visible: false
+  end
+
+  def when_i_click_change_organisation_name
+    click_on "Change name"
   end
 
   def when_i_click_on_your_organisation
@@ -93,4 +132,12 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
     click_on "Save and continue"
   end
   alias_method :and_i_click_save_and_continue, :when_i_click_save_and_continue
+
+  def when_i_fill_in_the_organisation_name
+    fill_in "What’s the name of your organisation?", with: "My organisation"
+  end
+
+  def when_i_go_back
+    page.go_back
+  end
 end


### PR DESCRIPTION
When collecting details about the referrer's organisations, we want to
accept the organisation name.

Assumptions:

* we don't need to validate the organisation name beyond a simple
  presence check

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="994" alt="Screenshot 2022-11-10 at 11 24 52 am" src="https://user-images.githubusercontent.com/3126/201078917-1a33f1fd-8353-44d1-9e22-991058cee32e.png">
<img width="1000" alt="Screenshot 2022-11-10 at 11 24 57 am" src="https://user-images.githubusercontent.com/3126/201078936-8d672bc1-8d30-4d4f-a977-5caf8e4a9668.png">
<img width="1040" alt="Screenshot 2022-11-10 at 11 25 06 am" src="https://user-images.githubusercontent.com/3126/201078939-6cf4a63a-0de6-46e3-8b22-53f1a24a57fc.png">
