### PR TITLE
Put user authentication behind a feature flag

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,12 +1,26 @@
 class PagesController < ApplicationController
+  def start
+    @start_now_path =
+      if FeatureFlags::FeatureFlag.active?(:user_accounts)
+        current_user ? who_path : new_user_session_path
+      else
+        who_path
+      end
+  end
+
+  def you_should_know
+    @continue_path =
+      if FeatureFlags::FeatureFlag.active?(:user_accounts)
+        new_referral_path
+      else
+        complete_path
+      end
+  end
+
   def complete
     @eligibility_check =
       EligibilityCheck.find_by(id: session[:eligibility_check_id])
     return redirect_to(start_path) if @eligibility_check.nil?
     session[:eligibility_check_id] = nil
-  end
-
-  def start
-    @start_now_path = (current_user ? who_path : new_user_session_path)
   end
 end

--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -1,6 +1,7 @@
 module Referrals
   class BaseController < ApplicationController
-    before_action :authenticate_user!
+    before_action :authenticate_user!,
+                  if: -> { FeatureFlags::FeatureFlag.active?(:user_accounts) }
     before_action :redirect_if_feature_flag_disabled
 
     private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,16 +53,18 @@ module ApplicationHelper
         end
       end
 
-      if current_user
-        header.navigation_item(
-          href: main_app.users_sign_out_path,
-          text: "Sign out"
-        )
-      else
-        header.navigation_item(
-          href: main_app.new_user_session_path,
-          text: "Sign in"
-        )
+      if FeatureFlags::FeatureFlag.active?(:user_accounts)
+        if current_user
+          header.navigation_item(
+            href: main_app.users_sign_out_path,
+            text: "Sign out"
+          )
+        else
+          header.navigation_item(
+            href: main_app.new_user_session_path,
+            text: "Sign in"
+          )
+        end
       end
     end
   end

--- a/app/views/pages/you_should_know.html.erb
+++ b/app/views/pages/you_should_know.html.erb
@@ -18,6 +18,6 @@
 
     <p class="govuk_body">A submitted report is kept for 50 years.</p>
 
-    <%= govuk_button_link_to 'Continue', complete_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9' %>
+    <%= govuk_button_link_to 'Continue', @continue_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9' %>
   </div>
 </div>

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -3,10 +3,13 @@ parent_controller: "SupportInterface::SupportInterfaceController"
 feature_flags:
   service_open:
     author: Felix Clack
-    description: Allow users to access the service
+    description: Allow users to access the service.
   employer_form:
     author: Steve Laing
-    description: Allow users to access the employer-specific form
+    description: Allow users to access the employer-specific form.
+  user_accounts:
+    author: Malcolm Baig
+    description: Enable OTP-based user authentication. This will prompt the user for sign in after the start page and join up the eligibility screener with the referral forms.
   staff_http_basic_auth:
     author: Malcolm Baig
     description: Allow signing in as a staff user using HTTP Basic authentication. This is useful before staff users have been created, but should otherwise be inactive.

--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "User accounts" do
   scenario "User signs in" do
     given_the_service_is_open
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
     when_i_visit_the_root_page
     and_click_start_now
     and_i_submit_my_email
@@ -29,6 +30,10 @@ RSpec.feature "User accounts" do
 
   def and_the_employer_form_feature_is_active
     FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
   def when_i_visit_the_root_page


### PR DESCRIPTION

### Context

We need to be able to switch user auth on/off so that a simpler,  screener-only version of the service can be shipped as an MVP.

### Changes proposed in this pull request

Add a `user_accounts` feature flag, and a set of conditional checks around the codebase.

When inactive, the service simply consists of the eligibility screener and a final page pointing towards the appropriate offline forms.

When active, the user auth flow kicks in immediately after the start page and connects the eligibility screener to the online referral form.


### Guidance to review

- Test from root path with feature on and off

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
