### PR TITLE
Update the form generator to accept a model

### DIFF
--- a/lib/generators/form/USAGE
+++ b/lib/generators/form/USAGE
@@ -1,10 +1,10 @@
 Description:
-    Form objects are used to collect the eligibility information from a person
+    Form objects are used to collect information from a person
     and validate the data prior to persisting it in the database.
     """
 
 Example:
-    bin/rails generate form Thing attribute:type
+    bin/rails generate form Thing EligibilityCheck attribute:type
 
     This will create:
         app/forms/thing_form.rb

--- a/lib/generators/form/form_generator.rb
+++ b/lib/generators/form/form_generator.rb
@@ -1,6 +1,7 @@
 class FormGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("templates", __dir__)
 
+  argument :model, type: :string, default: "EligibilityCheck"
   argument :attributes,
            type: :array,
            default: [],
@@ -13,14 +14,8 @@ class FormGenerator < Rails::Generators::NamedBase
              "app/controllers/#{plural_name}_controller.rb"
     template "new_form.html.erb", "app/views/#{plural_name}/new.html.erb"
 
-    insert_into_file "config/routes.rb",
-                     before:
-                       "namespace :support_interface, path: \"/support\" do\n" do
-      "  get \"#{plural_name}\", to: \"#{plural_name}#new\"\n" \
-        "  post \"#{plural_name}\", to: \"#{plural_name}#create\"\n"
-    end
     generate :migration,
-             "Add#{class_name}ToEligibilityCheck #{
+             "Add#{class_name}To#{model} #{
                attributes
                  .map { |attribute| [attribute.name, attribute.type].join(":") }
                  .join(" ")

--- a/lib/generators/form/templates/form.erb
+++ b/lib/generators/form/templates/form.erb
@@ -1,12 +1,12 @@
 class <%= class_name %>Form
   include ActiveModel::Model
 
-  attr_accessor :eligibility_check
+  attr_accessor :<%= model.downcase %>
   <% if attributes.any? -%>
 attr_reader <%= attributes.map { |attribute| ":#{attribute.name}" }.join(', ') %>
   <% end -%>
 
-  validates :eligibility_check, presence: true
+  validates :<%= model.downcase %>, presence: true
   <% attributes.map do |attribute| -%>
 validates :<%= attribute.name %>, <%= attribute.type == :boolean ? "inclusion: { in: [true, false] }" : "presence: true" %>
   <% end -%>
@@ -21,8 +21,8 @@ def <%= attribute.name %>=(value)
     return false unless valid?
 
     <% attributes.map do |attribute| -%>
-eligibility_check.<%= attribute.name %> = <%= attribute.name %>
+<%= model.downcase %>.<%= attribute.name %> = <%= attribute.name %>
     <% end -%>
-eligibility_check.save
+<%= model.downcase %>.save
   end
 end

--- a/lib/generators/form/templates/form_controller.erb
+++ b/lib/generators/form/templates/form_controller.erb
@@ -4,7 +4,7 @@ class <%= plural_name.camelize %>Controller < BaseController
   end
 
   def create
-    @<%= model_resource_name %>_form = <%= class_name %>Form.new(<%= model_resource_name %>_form_params.merge(eligibility_check:))
+    @<%= model_resource_name %>_form = <%= class_name %>Form.new(<%= model_resource_name %>_form_params.merge(<%= model.downcase %>: current_<%= model.downcase %>))
     if @<%= model_resource_name %>_form.save
       next_question
     else

--- a/lib/generators/form/templates/form_spec.erb
+++ b/lib/generators/form/templates/form_spec.erb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe <%= class_name %>Form, type: :model do
   describe "validations" do
-    it { is_expected.to validate_presence_of(:eligibility_check) }
+    it { is_expected.to validate_presence_of(:<%= model.downcase %>) }
   end
 
   describe "#valid?" do
     subject(:valid) { form.valid? }
 
-    let(:eligibility_check) { EligibilityCheck.new }
-    let(:form) { described_class.new(eligibility_check:, <%= attributes.map {|attribute| "#{attribute.name}:" }.join(', ') %>) }
+    let(:<%= model.downcase %>) { build(:<%= model.downcase %>)}
+    let(:form) { described_class.new(<%= model.downcase %>:, <%= attributes.map {|attribute| "#{attribute.name}:" }.join(', ') %>) }
     <% attributes.each do |attribute| %>let(:<%= attribute.name %>) { "true" }<% end %>
 
     it { is_expected.to be_truthy }
@@ -25,12 +25,12 @@ RSpec.describe <%= class_name %>Form, type: :model do
   describe "#save" do
     subject(:save) { form.save }
 
-    let(:eligibility_check) { EligibilityCheck.new }
-    let(:form) { described_class.new(eligibility_check:, <%= attributes.map {|attribute| "#{attribute.name}: true" }.join(', ') %>) }
+    let(:<%= model.downcase %>) { build(:<%= model.downcase %>) }
+    let(:form) { described_class.new(<%= model.downcase %>:, <%= attributes.map {|attribute| "#{attribute.name}: true" }.join(', ') %>) }
 
-    it "saves the eligibility check" do
+    it "saves the <%= model %>" do
       save
-      <% attributes.each do |attribute| %>expect(eligibility_check.<%= attribute.name %>).to be_truthy<% end %>
+      <% attributes.each do |attribute| %>expect(<%= model.downcase %>.<%= attribute.name %>).to be_truthy<% end %>
     end
   end
 end


### PR DESCRIPTION
We don't always want to target the EligibilityCheck in our forms.

This change makes the target customisable.