### PR TITLE
Set up SSH on azure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,5 +80,14 @@ RUN apk add --no-cache libpq
 COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
-CMD bundle exec rails db:migrate && \
+# SSH access specific to Azure
+# Install OpenSSH and set the password for root to "Docker!".
+RUN apk add --no-cache openssh && echo "root:Docker!" | chpasswd
+
+# Copy the Azure specific sshd_config file to the /etc/ssh/ directory
+RUN ssh-keygen -A && mkdir -p /var/run/sshd
+COPY azure/.sshd_config /etc/ssh/sshd_config
+
+CMD /usr/sbin/sshd && \
+    bundle exec rails db:migrate && \
     bundle exec rails server -b 0.0.0.0

--- a/azure/.sshd_config
+++ b/azure/.sshd_config
@@ -1,0 +1,12 @@
+Port      2222
+ListenAddress     0.0.0.0
+LoginGraceTime    180
+X11Forwarding     yes
+Ciphers aes128-cbc,3des-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr
+MACs hmac-sha1,hmac-sha1-96
+StrictModes     yes
+SyslogFacility    DAEMON
+PasswordAuthentication  yes
+PermitEmptyPasswords  no
+PermitRootLogin   yes
+Subsystem sftp internal-sftp


### PR DESCRIPTION
### Context

Azure has specific requirements for SSH access.
See https://learn.microsoft.com/en-us/azure/app-service/configure-custom-container?pivots=container-linux#enable-ssh

### Changes proposed in this pull request

Adds necessary SSH dependencies and config for Azure container.

### Guidance to review

This PR is based on recent work [setting up SSH for Azure on Access Your Teaching Profile](https://github.com/DFE-Digital/access-your-teaching-profile/pull/44) 

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
