### PR TITLE
Open runtime container port 2222 for Azure SSH access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,9 @@ RUN apk add --no-cache openssh && echo "root:Docker!" | chpasswd
 RUN ssh-keygen -A && mkdir -p /var/run/sshd
 COPY azure/.sshd_config /etc/ssh/sshd_config
 
+# Open port 2222 for Azure SSH access
+EXPOSE 2222
+
 CMD /usr/sbin/sshd && \
     bundle exec rails db:migrate && \
     bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
### Context

Missed in https://github.com/DFE-Digital/refer-serious-misconduct/pull/151 ~we need to~ it's document we should open port 2222 for Azure SSH access.

### Changes proposed in this pull request

Opens port 2222 on runtime container.

### Guidance to review

See https://github.com/DFE-Digital/access-your-teaching-profile/blob/main/Dockerfile#L85 for working example

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
