### PR TITLE
Collect the organisation address

### DIFF
--- a/app/controllers/referrals/organisation_address_controller.rb
+++ b/app/controllers/referrals/organisation_address_controller.rb
@@ -1,0 +1,31 @@
+module Referrals
+  class OrganisationAddressController < BaseController
+    def edit
+      @organisation_address_form =
+        OrganisationAddressForm.new(referral: current_referral)
+    end
+
+    def update
+      @organisation_address_form =
+        OrganisationAddressForm.new(
+          organisation_address_form_params.merge(referral: current_referral)
+        )
+      if @organisation_address_form.save
+        redirect_to referral_organisation_path(current_referral)
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def organisation_address_form_params
+      params.require(:organisation_address_form).permit(
+        :street_1,
+        :street_2,
+        :city,
+        :postcode
+      )
+    end
+  end
+end

--- a/app/controllers/referrals/organisation_name_controller.rb
+++ b/app/controllers/referrals/organisation_name_controller.rb
@@ -11,13 +11,23 @@ module Referrals
           organisation_name_form_params.merge(referral: current_referral)
         )
       if @organisation_name_form.save
-        redirect_to referral_organisation_path(current_referral)
+        redirect_to(
+          if go_to_check_answers?
+            referral_organisation_path(current_referral)
+          else
+            edit_referral_organisation_address_path(current_referral)
+          end
+        )
       else
         render :edit
       end
     end
 
     private
+
+    def go_to_check_answers?
+      params["check_answers"] == "true"
+    end
 
     def organisation_name_form_params
       params.require(:organisation_name_form).permit(:name)

--- a/app/forms/organisation_address_form.rb
+++ b/app/forms/organisation_address_form.rb
@@ -1,0 +1,35 @@
+class OrganisationAddressForm
+  include ActiveModel::Model
+
+  attr_accessor :referral
+  attr_writer :street_1, :street_2, :city, :postcode
+
+  validates :city, presence: true
+  validates :postcode, presence: true
+  validates :referral, presence: true
+  validates :street_1, presence: true
+
+  def city
+    @city ||= organisation&.city
+  end
+
+  delegate :organisation, to: :referral, allow_nil: true
+
+  def postcode
+    @postcode ||= organisation&.postcode
+  end
+
+  def street_1
+    @street_1 ||= organisation&.street_1
+  end
+
+  def street_2
+    @street_2 ||= organisation&.street_2
+  end
+
+  def save
+    return false unless valid?
+
+    organisation.update(city:, postcode:, street_1:, street_2:)
+  end
+end

--- a/app/helpers/referrer_helper.rb
+++ b/app/helpers/referrer_helper.rb
@@ -1,11 +1,30 @@
 module ReferrerHelper
   def address(referral)
-    [
-      referral.address_line_1,
-      referral.address_line_2,
-      referral.town_or_city,
-      referral.postcode,
-      referral.country
-    ].compact_blank.join("<br>").html_safe
+    address_fields_to_html(
+      [
+        referral.address_line_1,
+        referral.address_line_2,
+        referral.town_or_city,
+        referral.postcode,
+        referral.country
+      ]
+    )
+  end
+
+  def organisation_address(organisation)
+    address_fields_to_html(
+      [
+        organisation.street_1,
+        organisation.street_2,
+        organisation.city,
+        organisation.postcode
+      ]
+    )
+  end
+
+  private
+
+  def address_fields_to_html(address)
+    address.compact_blank.join("<br />").html_safe
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -3,8 +3,12 @@
 # Table name: organisations
 #
 #  id           :bigint           not null, primary key
+#  city         :string
 #  completed_at :datetime
 #  name         :string
+#  postcode     :string
+#  street_1     :string
+#  street_2     :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  referral_id  :bigint           not null
@@ -19,6 +23,10 @@
 #
 class Organisation < ApplicationRecord
   belongs_to :referral
+
+  def address?
+    street_1.present? && city.present? && postcode.present?
+  end
 
   def completed?
     completed_at.present?

--- a/app/views/referrals/organisation/show.html.erb
+++ b/app/views/referrals/organisation/show.html.erb
@@ -14,7 +14,15 @@
         ],
         key: { text: "Organisation" },
         value: { text: @organisation.name },
-      }
+      },
+      {
+        actions: [
+          { text: "Change", href: edit_referral_organisation_address_path(current_referral), visually_hidden_text: "address" },
+
+        ],
+        key: { text: "Address" },
+        value: { text: organisation_address(@organisation) },
+      },
     ] %>
     <%= render(SummaryCardComponent.new(rows:)) do %>
       <%= render SummaryCardHeaderComponent.new(title: 'Your organisation') %>

--- a/app/views/referrals/organisation_address/edit.html.erb
+++ b/app/views/referrals/organisation_address/edit.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, "#{'Error: ' if @organisation_address_form.errors.any?}What is your organisation’s address?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @organisation_address_form, url: referral_organisation_address_url(current_referral), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-xl">
+        What is your organisation’s address?
+      </h1>
+      <%= f.govuk_text_field :street_1, label: { text: "Address line 1" } %>
+      <%= f.govuk_text_field :street_2, label: { text: "Address line 2 (optional)" } %>
+      <%= f.govuk_text_field :city, label: { text: "Town or city" } %>
+      <%= f.govuk_text_field :postcode, label: { text: "Postcode" } %>
+      <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/organisation_name/edit.html.erb
+++ b/app/views/referrals/organisation_name/edit.html.erb
@@ -5,6 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @organisation_name_form, url: referral_organisation_name_url(current_referral), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
+      <%= hidden_field_tag :check_answers, request.referrer == referral_organisation_url(current_referral) %>
       <%= f.govuk_text_field :name, label: { size: 'xl', text: "What’s the name of your organisation?" } %>
       
       <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,6 +137,15 @@ en:
           attributes:
             complete:
               inclusion: Tell us if you have completed this section
+        organisation_address_form:
+          attributes:
+            street_1:
+              blank: Tell us the street address for your organisation
+            city:
+              blank: Tell us the city for your organisation
+            postcode:
+              blank: Tell us the postcode for your organisation
+
         organisation_name_form:
           attributes:
             name:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,10 @@ Rails.application.routes.draw do
              only: %i[edit update],
              controller: "referrals/organisation_name"
 
+    resource :organisation_address,
+             only: %i[edit update],
+             controller: "referrals/organisation_address"
+
     resource :referrer, only: %i[show update], controller: "referrals/referrers"
     resource :referrer_details,
              only: %i[show],

--- a/db/migrate/20221110122407_add_address_to_organisation.rb
+++ b/db/migrate/20221110122407_add_address_to_organisation.rb
@@ -1,0 +1,10 @@
+class AddAddressToOrganisation < ActiveRecord::Migration[7.0]
+  def change
+    change_table :organisations, bulk: true do |t|
+      t.string :street_1
+      t.string :street_2
+      t.string :city
+      t.string :postcode
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_10_095734) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_10_122407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,6 +39,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_10_095734) do
     t.datetime "updated_at", null: false
     t.datetime "completed_at", precision: nil
     t.string "name"
+    t.string "street_1"
+    t.string "street_2"
+    t.string "city"
+    t.string "postcode"
     t.index ["referral_id"], name: "index_organisations_on_referral_id"
   end
 

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -3,8 +3,12 @@
 # Table name: organisations
 #
 #  id           :bigint           not null, primary key
+#  city         :string
 #  completed_at :datetime
 #  name         :string
+#  postcode     :string
+#  street_1     :string
+#  street_2     :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  referral_id  :bigint           not null

--- a/spec/forms/organisation_address_form_spec.rb
+++ b/spec/forms/organisation_address_form_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe OrganisationAddressForm, type: :model do
+  describe "validations" do
+    subject { described_class.new(referral:) }
+
+    let(:referral) { build(:referral) }
+
+    it { is_expected.to validate_presence_of(:referral) }
+    it { is_expected.to validate_presence_of(:city) }
+    it { is_expected.to validate_presence_of(:postcode) }
+    it { is_expected.to validate_presence_of(:street_1) }
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    let(:city) { "London" }
+    let(:form) do
+      described_class.new(referral:, street_1:, street_2:, city:, postcode:)
+    end
+    let(:organisation) { build(:organisation) }
+    let(:postcode) { "W1 1CW" }
+    let(:referral) { organisation.referral }
+    let(:street_1) { "1 Street" }
+    let(:street_2) { "" }
+
+    it { is_expected.to be_truthy }
+
+    context "when one of the validations is failing" do
+      let(:street_1) { "" }
+
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:city) { "London" }
+    let(:form) do
+      described_class.new(referral:, street_1:, street_2:, city:, postcode:)
+    end
+    let(:organisation) { build(:organisation) }
+    let(:postcode) { "W1 1CW" }
+    let(:referral) { organisation.referral }
+    let(:street_1) { "1 Street" }
+    let(:street_2) { "Extra" }
+
+    before { save }
+
+    it { expect(organisation.city).to eq(city) }
+    it { expect(organisation.postcode).to eq(postcode) }
+    it { expect(organisation.street_1).to eq(street_1) }
+    it { expect(organisation.street_2).to eq(street_2) }
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -3,8 +3,12 @@
 # Table name: organisations
 #
 #  id           :bigint           not null, primary key
+#  city         :string
 #  completed_at :datetime
 #  name         :string
+#  postcode     :string
+#  street_1     :string
+#  street_2     :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  referral_id  :bigint           not null
@@ -21,6 +25,29 @@ require "rails_helper"
 
 RSpec.describe Organisation, type: :model do
   it { is_expected.to belong_to(:referral) }
+
+  describe "#address?" do
+    subject { organisation.address? }
+
+    context "when the address fields are all present" do
+      let(:organisation) do
+        build(
+          :organisation,
+          street_1: "Street",
+          city: "London",
+          postcode: "AB1 2CD"
+        )
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when any of the address fields are not present" do
+      let(:organisation) { build(:organisation, street_1: nil) }
+
+      it { is_expected.to be_falsey }
+    end
+  end
 
   describe "#completed?" do
     context "when completed_at is not nil" do

--- a/spec/system/referrals/user_adds_organisation_details_spec.rb
+++ b/spec/system/referrals/user_adds_organisation_details_spec.rb
@@ -15,11 +15,25 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
 
     when_i_fill_in_the_organisation_name
     and_i_click_save_and_continue
+    then_i_am_on_the_organisation_address_page
+
+    when_i_click_save_and_continue
+    then_i_see_the_missing_address_errors
+
+    when_i_complete_the_address
+    and_i_click_save_and_continue
     then_i_am_on_the_organisation_details_page
 
     when_i_click_change_organisation_name
     then_i_am_on_the_organisation_name_page
     and_i_see_the_name_prefilled
+
+    when_i_click_save_and_continue
+    then_i_am_on_the_organisation_details_page
+
+    when_i_click_change_organisation_address
+    then_i_am_on_the_organisation_address_page
+    and_i_see_the_address_prefilled
 
     when_i_click_save_and_continue
     then_i_am_on_the_organisation_details_page
@@ -43,6 +57,12 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
 
   def and_i_choose_complete
     choose "Yes, I’ve completed this section", visible: false
+  end
+
+  def and_i_see_the_address_prefilled
+    expect(page).to have_field("Address line 1", with: "1 Street")
+    expect(page).to have_field("Town or city", with: "London")
+    expect(page).to have_field("Postcode", with: "SW1A 1AA")
   end
 
   def and_i_see_the_name_prefilled
@@ -90,6 +110,16 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
     expect(page).to have_content("Tell us if you have completed this section")
   end
 
+  def then_i_am_on_the_organisation_address_page
+    expect(page).to have_current_path(
+      "/referrals/#{@referral.id}/organisation_address/edit"
+    )
+    expect(page).to have_title(
+      "What is your organisation’s address? - Refer serious misconduct by a teacher in England"
+    )
+    expect(page).to have_content("What is your organisation’s address?")
+  end
+
   def then_i_am_on_the_organisation_details_page
     expect(page).to have_current_path("/referrals/#{@referral.id}/organisation")
     expect(page).to have_title(
@@ -112,12 +142,24 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
     expect(page).to have_current_path(edit_referral_path(@referral))
   end
 
+  def then_i_see_the_missing_address_errors
+    expect(page).to have_content(
+      "Tell us the street address for your organisation"
+    )
+    expect(page).to have_content("Tell us the city for your organisation")
+    expect(page).to have_content("Tell us the postcode for your organisation")
+  end
+
   def then_i_see_the_missing_name_error
     expect(page).to have_content("Tell us the name of your organisation")
   end
 
   def when_i_choose_no_come_back_later
     choose "No, I’ll come back to it later", visible: false
+  end
+
+  def when_i_click_change_organisation_address
+    click_on "Change address"
   end
 
   def when_i_click_change_organisation_name
@@ -132,6 +174,12 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
     click_on "Save and continue"
   end
   alias_method :and_i_click_save_and_continue, :when_i_click_save_and_continue
+
+  def when_i_complete_the_address
+    fill_in "Address line 1", with: "1 Street"
+    fill_in "Town or city", with: "London"
+    fill_in "Postcode", with: "SW1A 1AA"
+  end
 
   def when_i_fill_in_the_organisation_name
     fill_in "What’s the name of your organisation?", with: "My organisation"


### PR DESCRIPTION
As part of collecting the referrer's organisation details, we want to
get the address.

This introduces a simple method of persisting the address. I opted to
keep it as fields of the organisation rather than creating a separate
object.

Assumptions:

* an address doesn't need to be verified in any way
* storing duplicate addresses across the service is fine

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1007" alt="Screenshot 2022-11-11 at 12 30 54 pm" src="https://user-images.githubusercontent.com/3126/201341717-2fcbd9d0-2b3b-40a7-8a13-156ea0bd181d.png">
<img width="1030" alt="Screenshot 2022-11-11 at 12 30 48 pm" src="https://user-images.githubusercontent.com/3126/201341725-9270fb2b-85f1-4423-9130-c445ad97804c.png">
