### PR TITLE
Allow retrieval of referrals when user auth flag is disabled

### DIFF
--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -7,7 +7,12 @@ module Referrals
     private
 
     def current_referral
-      @current_referral ||= current_user.referrals.find(params[:referral_id])
+      @current_referral ||=
+        if FeatureFlags::FeatureFlag.active?(:user_accounts)
+          current_user.referrals.find(params[:referral_id])
+        else
+          Referral.find(params[:referral_id])
+        end
     end
     helper_method :current_referral
 


### PR DESCRIPTION
### Context

We're seeing 500s in the dev app with user authentication disabled.
The scope used in `current_referral` doesn't work without `current_user`.

```
I, [2022-11-10T16:32:02.295651 #1]  INFO -- : [caa75438-0957-47ec-9f09-09ac30fd3242] Completed 500 Internal Server Error in 38ms (ActiveRecord: 6.7ms | Allocations: 1849)
F, [2022-11-10T16:32:02.296934 #1] FATAL -- : [caa75438-0957-47ec-9f09-09ac30fd3242]   
[caa75438-0957-47ec-9f09-09ac30fd3242] NoMethodError (undefined method `referrals' for nil:NilClass

      @current_referral ||= current_user.referrals.find(params[:referral_id])
                                        ^^^^^^^^^^):
```

### Changes proposed in this pull request

With user auth feature disabled we allow any Referral to be retrieved.

### Guidance to review

@malcolmbaig not sure if there's a better way to do this, it seems like it could be insecure if the auth flag was ever turned off in the real-world but then that scenario seems bad in so many ways.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
