### PR TITLE
Update HostingEnvironment test environment names

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module HostingEnvironment
-  TEST_ENVIRONMENTS = %w[local test development review].freeze
+  TEST_ENVIRONMENTS = %w[local dev test].freeze
   PRODUCTION_URL = I18n.t("service.url")
 
   def self.host


### PR DESCRIPTION
Match the naming used by the terraform workspace variable files. This should allow a call to HostingEnvironment.test_environment? to work correctly on dev. 