### PR TITLE
Add redirect to check answers page

### DIFF
--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -26,5 +26,9 @@ module Referrals
     def store_user_location!
       store_location_for(:user, request.fullpath)
     end
+
+    def go_to_check_answers?
+      params["go_to_check_answers"] == "true"
+    end
   end
 end

--- a/app/controllers/referrals/contact_details/email_controller.rb
+++ b/app/controllers/referrals/contact_details/email_controller.rb
@@ -15,9 +15,7 @@ module Referrals
             contact_details_email_form_params.merge(referral: current_referral)
           )
         if @contact_details_email_form.save
-          redirect_to referrals_update_contact_details_telephone_path(
-                        current_referral
-                      )
+          redirect_to save_redirect_path
         else
           render :edit
         end
@@ -30,6 +28,18 @@ module Referrals
           :email_known,
           :email_address
         )
+      end
+
+      def save_redirect_path
+        if go_to_check_answers?
+          return(
+            referrals_update_contact_details_check_answers_path(
+              current_referral
+            )
+          )
+        end
+
+        referrals_update_contact_details_telephone_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/contact_details/telephone_controller.rb
+++ b/app/controllers/referrals/contact_details/telephone_controller.rb
@@ -17,9 +17,7 @@ module Referrals
             )
           )
         if @contact_details_telephone_form.save
-          redirect_to referrals_update_contact_details_address_path(
-                        current_referral
-                      )
+          redirect_to save_redirect_path
         else
           render :edit
         end
@@ -32,6 +30,18 @@ module Referrals
           :phone_known,
           :phone_number
         )
+      end
+
+      def save_redirect_path
+        if go_to_check_answers?
+          return(
+            referrals_update_contact_details_check_answers_path(
+              current_referral
+            )
+          )
+        end
+
+        referrals_update_contact_details_address_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/organisation_name_controller.rb
+++ b/app/controllers/referrals/organisation_name_controller.rb
@@ -11,13 +11,7 @@ module Referrals
           organisation_name_form_params.merge(referral: current_referral)
         )
       if @organisation_name_form.save
-        redirect_to(
-          if go_to_check_answers?
-            referral_organisation_path(current_referral)
-          else
-            edit_referral_organisation_address_path(current_referral)
-          end
-        )
+        redirect_to save_redirect_path
       else
         render :edit
       end
@@ -25,8 +19,12 @@ module Referrals
 
     private
 
-    def go_to_check_answers?
-      params["check_answers"] == "true"
+    def save_redirect_path
+      if go_to_check_answers?
+        return referral_organisation_path(current_referral)
+      end
+
+      edit_referral_organisation_address_path(current_referral)
     end
 
     def organisation_name_form_params

--- a/app/views/referrals/contact_details/email/edit.html.erb
+++ b/app/views/referrals/contact_details/email/edit.html.erb
@@ -5,6 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @contact_details_email_form, url: referrals_update_contact_details_email_url, method: :put do |f| %>
       <%= f.govuk_error_summary %>
+      <%= hidden_field_tag :go_to_check_answers, request.referrer == referrals_update_contact_details_check_answers_url(current_referral) %>
       <%= f.govuk_radio_buttons_fieldset :email_known, legend: { size: "l", text: "Do you know the personal email address of the person you are referring?" }  do %>
         <%= f.hidden_field :email_known %>
         <%= f.govuk_radio_button :email_known, true, label: { text: "Yes" } do %>

--- a/app/views/referrals/contact_details/telephone/edit.html.erb
+++ b/app/views/referrals/contact_details/telephone/edit.html.erb
@@ -5,6 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @contact_details_telephone_form, url: referrals_update_contact_details_telephone_url, method: :put do |f| %>
       <%= f.govuk_error_summary %>
+      <%= hidden_field_tag :go_to_check_answers, request.referrer == referrals_update_contact_details_check_answers_url(current_referral) %>
       <%= f.govuk_radio_buttons_fieldset :phone_known, legend: { size: "xl", text: "Do you know their main contact number?" }  do %>
         <%= f.hidden_field :phone_known %>
         <%= f.govuk_radio_button :phone_known, true, label: { text: "Yes" } do %>

--- a/app/views/referrals/organisation_name/edit.html.erb
+++ b/app/views/referrals/organisation_name/edit.html.erb
@@ -5,9 +5,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @organisation_name_form, url: referral_organisation_name_url(current_referral), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
-      <%= hidden_field_tag :check_answers, request.referrer == referral_organisation_url(current_referral) %>
+      <%= hidden_field_tag :go_to_check_answers, request.referrer == referral_organisation_url(current_referral) %>
       <%= f.govuk_text_field :name, label: { size: 'xl', text: "What’s the name of your organisation?" } %>
-      
+
       <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>
     <% end %>
   </div>

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -97,6 +97,22 @@ RSpec.feature "Contact details", type: :system do
     and_i_press_continue
     then_i_get_redirected_to_the_referral_summary
     then_i_see_the_status_section_in_the_referral_summary(status: "INCOMPLETE")
+
+    # Editing single answers
+    when_i_visit_the_check_answers_page
+    and_i_click_the_change_email_link
+    and_i_press_continue
+    then_i_see_the_check_answers_page
+
+    when_i_visit_the_check_answers_page
+    and_i_click_the_change_phone_link
+    and_i_press_continue
+    then_i_see_the_check_answers_page
+
+    when_i_visit_the_check_answers_page
+    and_i_click_the_change_address_link
+    and_i_press_continue
+    then_i_see_the_check_answers_page
   end
 
   private
@@ -294,5 +310,17 @@ RSpec.feature "Contact details", type: :system do
         expect(find(".app-task-list__tag").text).to eq(status)
       end
     end
+  end
+
+  def and_i_click_the_change_email_link
+    within(all(".govuk-summary-list__row")[0]) { click_link "Change" }
+  end
+
+  def and_i_click_the_change_phone_link
+    within(all(".govuk-summary-list__row")[1]) { click_link "Change" }
+  end
+
+  def and_i_click_the_change_address_link
+    within(all(".govuk-summary-list__row")[2]) { click_link "Change" }
   end
 end


### PR DESCRIPTION
### Changes proposed in this pull request

The pages from the contact details section are now redirecting back to the check answers page when accesses via the "Change" link

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
