### PR TITLE
Add redirect to current page after sign-in

### DIFF
--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -1,5 +1,6 @@
 module Referrals
   class BaseController < ApplicationController
+    before_action :store_user_location!, if: :storable_location?
     before_action :authenticate_user!,
                   if: -> { FeatureFlags::FeatureFlag.active?(:user_accounts) }
     before_action :redirect_if_feature_flag_disabled
@@ -15,6 +16,15 @@ module Referrals
       return if FeatureFlags::FeatureFlag.active?(:employer_form)
 
       redirect_to start_path && return
+    end
+
+    def storable_location?
+      request.get? && is_navigational_format? && !devise_controller? &&
+        !request.xhr?
+    end
+
+    def store_user_location!
+      store_location_for(:user, request.fullpath)
     end
   end
 end

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -39,6 +39,10 @@ class Users::OtpController < DeviseController
   private
 
   def after_sign_in_path_for(resource)
+    stored_location_for(resource) || latest_referral_path(resource)
+  end
+
+  def latest_referral_path(resource)
     latest_referral = resource.latest_referral
 
     latest_referral ? referral_path(latest_referral) : root_path

--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -20,6 +20,12 @@ RSpec.feature "User accounts" do
     and_i_sign_out
     when_i_sign_back_in
     then_i_see_my_referral
+
+    when_i_am_signed_out
+    and_i_visit_a_page
+    and_i_submit_my_email
+    and_i_provide_the_expected_otp
+    then_i_see_my_current_page_before_logging_in
   end
 
   private
@@ -84,6 +90,7 @@ RSpec.feature "User accounts" do
   def and_i_sign_out
     within(".govuk-header") { click_on "Sign out" }
   end
+  alias_method :when_i_am_signed_out, :and_i_sign_out
 
   def when_i_sign_back_in
     within(".govuk-header") { click_on "Sign in" }
@@ -93,5 +100,15 @@ RSpec.feature "User accounts" do
 
   def then_i_see_my_referral
     expect(page).to have_current_path(referral_path(@referral))
+  end
+
+  def and_i_visit_a_page
+    visit referrals_edit_contact_details_email_path(@referral)
+  end
+
+  def then_i_see_my_current_page_before_logging_in
+    expect(page).to have_current_path(
+      referrals_edit_contact_details_email_path(@referral)
+    )
   end
 end


### PR DESCRIPTION
### Context

When working locally, I kept having to paste the URL again after logging in as it was redirecting to the start page. I think this is a useful feature to have for the end user as well.

### Changes proposed in this pull request

Saves the page before logging in in the session and redirects to that page if the sign in is successful.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
