### PR TITLE
Add a check answers page for previous allegation

### DIFF
--- a/app/controllers/referrals/previous_misconduct_controller.rb
+++ b/app/controllers/referrals/previous_misconduct_controller.rb
@@ -1,0 +1,26 @@
+class Referrals::PreviousMisconductController < Referrals::BaseController
+  def show
+    @previous_misconduct_form =
+      PreviousMisconductForm.new(referral: current_referral)
+  end
+
+  def update
+    @previous_misconduct_form =
+      PreviousMisconductForm.new(
+        complete: previous_misconduct_params[:complete],
+        referral: current_referral
+      )
+
+    if @previous_misconduct_form.save
+      redirect_to edit_referral_path(current_referral)
+    else
+      render :show
+    end
+  end
+
+  private
+
+  def previous_misconduct_params
+    params.require(:previous_misconduct_form).permit(:complete)
+  end
+end

--- a/app/forms/previous_misconduct_form.rb
+++ b/app/forms/previous_misconduct_form.rb
@@ -1,0 +1,25 @@
+class PreviousMisconductForm
+  include ActiveModel::Model
+
+  attr_accessor :referral
+  attr_writer :complete
+
+  validates :complete, inclusion: { in: %w[true false] }
+  validates :referral, presence: true
+
+  def complete
+    @complete || previous_misconduct_completed_at? || nil
+  end
+
+  def save
+    return false unless valid?
+
+    referral.previous_misconduct_completed_at = Time.current if complete ==
+      "true"
+    referral.previous_misconduct_deferred_at = Time.current if complete ==
+      "false"
+    referral.save
+  end
+
+  delegate :previous_misconduct_completed_at?, to: :referral, allow_nil: true
+end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -85,8 +85,8 @@ class ReferralForm
         ),
         ReferralSectionItem.new(
           I18n.t("referral_form.previous_allegations"),
-          "#",
-          :not_started_yet
+          referral_previous_misconduct_path(referral),
+          referral.previous_misconduct_status
         ),
         ReferralSectionItem.new(
           I18n.t("referral_form.evidence_and_supporting_information"),

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -10,6 +10,13 @@ class Referral < ApplicationRecord
     organisation.status
   end
 
+  def previous_misconduct_status
+    return :complete if previous_misconduct_completed_at.present?
+    return :incomplete if previous_misconduct_deferred_at.present?
+
+    :not_started_yet
+  end
+
   def referrer_status
     return :not_started_yet if referrer.blank?
 

--- a/app/views/referrals/previous_misconduct/show.html.erb
+++ b/app/views/referrals/previous_misconduct/show.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, "Check and confirm your answers" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">
+          Check and confirm your answers
+        </h1>
+      </div>
+    </div>
+
+    <% rows = [] %>
+    <%= render(SummaryCardComponent.new(rows:)) do %>
+      <%= render SummaryCardHeaderComponent.new(title: 'Previous allegations') %>
+    <% end %>
+
+    <%= form_with model: @previous_misconduct_form, url: referral_previous_misconduct_path(current_referral), method: :patch do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :complete, legend: { size: 'm', text: 'Have you completed this section?' } do %>
+        <%= f.hidden_field :complete %>
+        <%= f.govuk_radio_button :complete, 'true', label: { text: "Yes, I’ve completed this section" } %>
+        <%= f.govuk_radio_button :complete, 'false', label: { text: "No, I’ll come back to it later" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,10 @@ en:
           attributes:
             name:
               blank: Tell us the name of your organisation
+        previous_misconduct_form:
+          attributes:
+            complete:
+              inclusion: Tell us if you have completed this section
         referrer_form:
           attributes:
             complete:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,10 @@ Rails.application.routes.draw do
              only: %i[edit update],
              controller: "referrals/organisation_address"
 
+    resource :previous_misconduct,
+             only: %i[show update],
+             controller: "referrals/previous_misconduct"
+
     resource :referrer, only: %i[show update], controller: "referrals/referrers"
     resource :referrer_details,
              only: %i[show],

--- a/db/migrate/20221116112043_add_previous_misconduct_to_referral.rb
+++ b/db/migrate/20221116112043_add_previous_misconduct_to_referral.rb
@@ -1,0 +1,8 @@
+class AddPreviousMisconductToReferral < ActiveRecord::Migration[7.0]
+  def change
+    change_table :referrals, bulk: true do |t|
+      t.timestamp :previous_misconduct_completed_at
+      t.timestamp :previous_misconduct_deferred_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_15_110834) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_16_112043) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -106,6 +106,8 @@ unique: true
     t.boolean "allegation_details_complete"
     t.boolean "role_start_date_known"
     t.date "role_start_date"
+    t.datetime "previous_misconduct_completed_at", precision: nil
+    t.datetime "previous_misconduct_deferred_at", precision: nil
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 

--- a/spec/factories/previous_allegations.rb
+++ b/spec/factories/previous_allegations.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: previous_allegations
+#
+#  id           :bigint           not null, primary key
+#  completed_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  referral_id  :bigint           not null
+#
+# Indexes
+#
+#  index_previous_allegations_on_referral_id  (referral_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (referral_id => referrals.id)
+#
+FactoryBot.define do
+  factory :previous_allegation do
+    referral
+
+    trait :incomplete do
+      completed_at { nil }
+    end
+  end
+end

--- a/spec/forms/previous_misconduct_form_spec.rb
+++ b/spec/forms/previous_misconduct_form_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe PreviousMisconductForm, type: :model do
+  it { is_expected.to validate_presence_of(:referral) }
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:complete) { "true" }
+    let(:form) { described_class.new(complete:, referral:) }
+    let(:referral) { build(:referral) }
+
+    it { is_expected.to be_truthy }
+
+    it "updates the referral" do
+      save
+      expect(referral.previous_misconduct_completed_at).to be_present
+    end
+
+    context "when the form is not valid" do
+      let(:referral) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe "#complete" do
+    subject(:form_complete) { form.complete }
+
+    let(:form) { described_class.new(complete:, referral:) }
+    let(:referral) { build(:referral) }
+
+    context "when the value of complete is nil" do
+      let(:complete) { nil }
+      let(:referral) do
+        build(:referral, previous_misconduct_completed_at: Time.current)
+      end
+
+      it "returns the value from the referral" do
+        expect(form_complete).to eq(true)
+      end
+    end
+
+    context "when the value of complete is nil and there is no previous_misconduct on the referral" do
+      let(:complete) { nil }
+      let(:referral) { build(:referral, previous_misconduct_completed_at: nil) }
+
+      it "returns nil" do
+        expect(form_complete).to be_nil
+      end
+    end
+
+    context "when the value of complete is set" do
+      let(:complete) { true }
+
+      it "returns the value of complete" do
+        expect(complete).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -33,4 +33,40 @@ RSpec.describe Referral, type: :model do
       it { is_expected.to eq(:incomplete) }
     end
   end
+
+  describe "#previous_misconduct_status" do
+    subject { referral.previous_misconduct_status }
+
+    let(:referral) { build(:referral) }
+
+    it { is_expected.to eq(:not_started_yet) }
+
+    context "when previous_misconduct_completed_at is present" do
+      let(:referral) do
+        build(:referral, previous_misconduct_completed_at: Time.current)
+      end
+
+      it { is_expected.to eq(:complete) }
+    end
+
+    context "when previous_misconduct_deferred_at is present" do
+      let(:referral) do
+        build(:referral, previous_misconduct_deferred_at: Time.current)
+      end
+
+      it { is_expected.to eq(:incomplete) }
+    end
+
+    context "when both previous_misconduct_completed_at and previous_misconduct_deferred_at are present" do
+      let(:referral) do
+        build(
+          :referral,
+          previous_misconduct_completed_at: Time.current,
+          previous_misconduct_deferred_at: Time.current
+        )
+      end
+
+      it { is_expected.to eq(:complete) }
+    end
+  end
 end

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
+  scenario "User provides details of previous misconduct" do
+    given_the_service_is_open
+    and_i_am_signed_in
+    and_the_employer_form_feature_is_active
+    and_i_have_an_existing_referral
+    and_i_am_on_the_referral_summary_page
+    when_i_click_on_previous_misconduct
+    then_i_see_the_previous_misconduct_page
+
+    when_i_click_save_and_continue
+    then_i_am_asked_to_make_a_choice
+
+    when_i_choose_no_come_back_later
+    and_i_click_save_and_continue
+    then_i_am_on_the_referral_summary_page
+    and_i_see_previous_misconduct_flagged_as_incomplete
+
+    when_i_go_back
+    and_i_choose_complete
+    and_i_click_save_and_continue
+    then_i_am_on_the_referral_summary_page
+    and_i_see_previous_misconduct_flagged_as_complete
+  end
+
+  private
+
+  def and_i_am_on_the_referral_summary_page
+    visit edit_referral_path(@referral)
+  end
+
+  def and_i_am_signed_in
+    @user = create(:user)
+    sign_in(@user)
+  end
+
+  def and_i_choose_complete
+    choose "Yes, I’ve completed this section", visible: false
+  end
+
+  def and_i_have_an_existing_referral
+    @referral = create(:referral, user: @user)
+  end
+
+  def and_i_see_previous_misconduct_flagged_as_complete
+    within(".app-task-list__item", text: "Previous allegations") do
+      status_tag = find(".app-task-list__tag")
+      expect(status_tag.text).to match(/^COMPLETE/)
+    end
+  end
+
+  def and_i_see_previous_misconduct_flagged_as_incomplete
+    within(".app-task-list__item", text: "Previous allegations") do
+      status_tag = find(".app-task-list__tag")
+      expect(status_tag.text).to match("INCOMPLETE")
+    end
+  end
+
+  def and_the_employer_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def then_i_am_asked_to_make_a_choice
+    expect(page).to have_content("Tell us if you have completed this section")
+  end
+
+  def then_i_am_on_the_referral_summary_page
+    expect(page).to have_current_path(edit_referral_path(@referral))
+  end
+
+  def then_i_see_the_previous_misconduct_page
+    expect(page).to have_content("Check and confirm your answers")
+    expect(page).to have_content("Previous allegations")
+  end
+
+  def when_i_choose_no_come_back_later
+    choose "No, I’ll come back to it later", visible: false
+  end
+
+  def when_i_click_on_previous_misconduct
+    click_on "Previous allegations"
+  end
+
+  def when_i_click_save_and_continue
+    click_on "Save and continue"
+  end
+  alias_method :and_i_click_save_and_continue, :when_i_click_save_and_continue
+
+  def when_i_go_back
+    page.go_back
+  end
+end


### PR DESCRIPTION
When a user adds details about previous allegations, we display a page
that allows them to review all the details they provided and confirm if
they have finished the section.

This introduces that page and allows us to iterate on the previous
allegation flow.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="998" alt="Screenshot 2022-11-14 at 10 59 03 am" src="https://user-images.githubusercontent.com/3126/201644038-0a456564-3948-41f4-9ddb-155b422cf1d9.png">
