### PR TITLE
Add review app

### DIFF
--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -12,6 +12,9 @@ inputs:
   azure_credentials:
     description: JSON object containing a service principal that can read from Azure Key Vault
     required: true
+  site_up_retries:
+    description: The number of times that the site up test will be retried
+    default: 60
 
 outputs:
   environment_url:
@@ -28,19 +31,28 @@ runs:
     # Extract configuration from tfvars
     - id: config
       run: |
-        KEY_VAULT_NAME=$(jq -r '.key_vault_name' $TFVARS)
-        RESOURCE_GROUP_NAME=$(jq -r '.resource_group_name' $TFVARS)
+        APP_RESOURCE_GROUP_NAME=$(jq -r '.resource_group_name' $TFVARS)
         RESOURCE_PREFIX=$(jq -r '.resource_prefix' $TFVARS)
         STORAGE_ACCOUNT_NAME=$(jq -r '.storage_account_name' $TFVARS)
         TERRAFORM_VERSION=$(awk '/{/{f=/^terraform/;next}f' terraform.tf | grep -o [0-9\.]*)
 
-        if [ -z "$KEY_VAULT_NAME" ]; then
-          echo "::error ::Failed to extract key_vault_name from $TFVARS"
+        if [ ${{ inputs.environment_name }} == "review" ]; then
+          DEV_TFVARS=workspace_variables/dev.tfvars.json
+          KEY_VAULT_NAME=$(jq -r '.key_vault_name' $DEV_TFVARS)
+          REVIEW_APP_SUFFIX=-pr-${{ github.event.pull_request.number }}
+          TF_RESOURCE_GROUP_NAME=$(jq -r '.resource_group_name' $DEV_TFVARS)
+        else
+          KEY_VAULT_NAME=$(jq -r '.key_vault_name' $TFVARS)
+          TF_RESOURCE_GROUP_NAME=$(jq -r '.resource_group_name' $TFVARS)
+        fi
+
+        if [ -z "$APP_RESOURCE_GROUP_NAME" ]; then
+          echo "::error ::Failed to extract resource_group_name from $TFVARS"
           exit 1
         fi
 
-        if [ -z "$RESOURCE_GROUP_NAME" ]; then
-          echo "::error ::Failed to extract resource_group_name from $TFVARS"
+        if [ -z "$KEY_VAULT_NAME" ]; then
+          echo "::error ::Failed to extract key_vault_name from $TFVARS"
           exit 1
         fi
 
@@ -59,11 +71,18 @@ runs:
           exit 1
         fi
 
-        echo "resource_group_name=$RESOURCE_GROUP_NAME" >> $GITHUB_ENV
+        if [ -z "$TF_RESOURCE_GROUP_NAME" ]; then
+          echo "::error ::Failed to extract resource_group_name from $TFVARS"
+          exit 1
+        fi
+
+        echo "app_resource_group_name=$APP_RESOURCE_GROUP_NAME" >> $GITHUB_ENV
         echo "key_vault_name=$KEY_VAULT_NAME" >> $GITHUB_ENV
         echo "resource_prefix=$RESOURCE_PREFIX" >> $GITHUB_ENV
+        echo "review_app_suffix=$REVIEW_APP_SUFFIX" >> $GITHUB_ENV
         echo "storage_account_name=$STORAGE_ACCOUNT_NAME" >> $GITHUB_ENV
         echo "terraform_version=$TERRAFORM_VERSION" >> $GITHUB_ENV
+        echo "tf_resource_group_name=$TF_RESOURCE_GROUP_NAME" >> $GITHUB_ENV
 
       shell: bash
       env:
@@ -75,13 +94,14 @@ runs:
         creds: ${{ inputs.azure_credentials }}
 
     - id: deploy-arm-resources
+      if: ${{ inputs.environment_name != 'review' }}
       run: |
         make ci ${{ inputs.environment_name }} deploy-azure-resources
       shell: bash
 
     # get TFSTATE-CONTAINER-ACCESS-KEY
     - run: |
-        TFSTATE_CONTAINER_ACCESS_KEY="$(az storage account keys list -g ${{ env.resource_group_name }} -n ${{ env.storage_account_name }} | jq -r '.[0].value')"
+        TFSTATE_CONTAINER_ACCESS_KEY="$(az storage account keys list -g ${{ env.tf_resource_group_name }} -n ${{ env.storage_account_name }} | jq -r '.[0].value')"
         echo "::add-mask::$TFSTATE_CONTAINER_ACCESS_KEY"
         echo "TFSTATE_CONTAINER_ACCESS_KEY=$TFSTATE_CONTAINER_ACCESS_KEY" >> $GITHUB_ENV
       shell: bash
@@ -93,7 +113,11 @@ runs:
 
     - id: terraform
       run: |
-        make ci ${{ inputs.environment_name }} terraform-apply
+        if [ ${{ inputs.environment_name }} == "review" ]; then
+          make ci ${{ inputs.environment_name }} terraform-apply pr_id=${{ github.event.pull_request.number }}
+        else
+          make ci ${{ inputs.environment_name }} terraform-apply
+        fi
         cd terraform && echo "url=https://$(terraform output -raw app_fqdn)" >> $GITHUB_ENV
         echo "postgres_server_name=$(terraform output -raw postgres_server_name)" >> $GITHUB_ENV
         echo "slot_name=$(terraform output -raw web_app_slot_name)" >> $GITHUB_ENV
@@ -105,7 +129,7 @@ runs:
 
     - uses: azure/webapps-deploy@v2
       with:
-        app-name: ${{ env.resource_prefix }}rsm-${{ inputs.environment_name}}-app
+        app-name: ${{ env.resource_prefix }}rsm-${{ inputs.environment_name}}${{ env.review_app_suffix }}-app
         images: ${{ inputs.image_name_tag }}
         slot-name: ${{ env.slot_name }}
 
@@ -113,13 +137,13 @@ runs:
       if: ${{ env.slot_name != 'production' }}
       with:
         inlineScript: |
-          az webapp deployment slot swap  -g ${{ env.resource_group_name }} -n ${{ env.resource_prefix }}rsm-${{ inputs.environment_name}}-app --slot ${{ env.slot_name}} --target-slot production
+          az webapp deployment slot swap  -g ${{ env.app_resource_group_name }} -n ${{ env.resource_prefix }}rsm-${{ inputs.environment_name}}-app --slot ${{ env.slot_name}} --target-slot production
 
     # Check new site is up
     - run: |
         echo "Checking new site is up"
         attempt_counter=0
-        max_attempts=60
+        max_attempts=$RETRIES
 
         SHA_URL="${{ env.url }}/_sha"
         APP_SHA=$(curl $SHA_URL --silent)
@@ -136,3 +160,4 @@ runs:
       shell: bash
       env:
         EXPECTED_SHA: ${{ inputs.image_tag }}
+        RETRIES: ${{ inputs.site_up_retries }}

--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -47,7 +47,7 @@ runs:
         fi
 
         if [ -z "$APP_RESOURCE_GROUP_NAME" ]; then
-          echo "::error ::Failed to extract resource_group_name from $TFVARS"
+          echo "::error ::Failed to extract app_resource_group_name from $TFVARS"
           exit 1
         fi
 
@@ -67,12 +67,12 @@ runs:
         fi
 
         if [ -z "$TERRAFORM_VERSION" ]; then
-          echo "::error ::Failed to extract terraform_version from $TFVARS"
+          echo "::error ::Failed to extract terraform_version from terraform.tf"
           exit 1
         fi
 
         if [ -z "$TF_RESOURCE_GROUP_NAME" ]; then
-          echo "::error ::Failed to extract resource_group_name from $TFVARS"
+          echo "::error ::Failed to extract tf_resource_group_name from TFVARS"
           exit 1
         fi
 
@@ -99,7 +99,6 @@ runs:
         make ci ${{ inputs.environment_name }} deploy-azure-resources
       shell: bash
 
-    # get TFSTATE-CONTAINER-ACCESS-KEY
     - run: |
         TFSTATE_CONTAINER_ACCESS_KEY="$(az storage account keys list -g ${{ env.tf_resource_group_name }} -n ${{ env.storage_account_name }} | jq -r '.[0].value')"
         echo "::add-mask::$TFSTATE_CONTAINER_ACCESS_KEY"

--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -123,7 +123,6 @@ runs:
       env:
         ARM_ACCESS_KEY: ${{ env.TFSTATE_CONTAINER_ACCESS_KEY }}
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure_credentials }}
-        IMAGE_TAG: ${{ inputs.image_tag }}
       shell: bash
 
     - uses: azure/webapps-deploy@v2

--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -127,7 +127,7 @@ runs:
 
     - uses: azure/webapps-deploy@v2
       with:
-        app-name: ${{ env.resource_prefix }}rsm-${{ inputs.environment_name}}${{ env.review_app_suffix }}-app
+        app-name: ${{ env.resource_prefix }}-${{ inputs.environment_name}}${{ env.review_app_suffix }}-app
         images: ${{ inputs.image_name_tag }}
         slot-name: ${{ env.slot_name }}
 
@@ -135,7 +135,7 @@ runs:
       if: ${{ env.slot_name != 'production' }}
       with:
         inlineScript: |
-          az webapp deployment slot swap  -g ${{ env.app_resource_group_name }} -n ${{ env.resource_prefix }}rsm-${{ inputs.environment_name}}-app --slot ${{ env.slot_name}} --target-slot production
+          az webapp deployment slot swap  -g ${{ env.app_resource_group_name }} -n ${{ env.resource_prefix }}-${{ inputs.environment_name}}-app --slot ${{ env.slot_name}} --target-slot production
 
     # Check new site is up
     - run: |

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -31,6 +31,36 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
 
+  deploy_review_app:
+    name: Deploy to review environment
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'deploy')
+    concurrency: deploy_review_${{ github.event.pull_request.number }}
+    needs: [build_image]
+    environment:
+      name: review
+      url: ${{ steps.deploy.outputs.environment_url }}
+    outputs:
+      environment_url: ${{ steps.deploy.outputs.environment_url }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/deploy-environment
+        id: deploy
+        with:
+          environment_name: review
+          image_name_tag: ${{ needs.build_image.outputs.image_name_tag }}
+          image_tag: ${{ github.sha }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          site_up_retries: 150
+
+      - uses: ./.github/actions/smoke-test
+        id: smoke-test
+        with:
+          environment: review
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
   deploy:
     name: Deploy to ${{ matrix.environment }} environment
     runs-on: ubuntu-latest

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -1,0 +1,130 @@
+name: Delete Review App
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number of review app to delete
+        required: true
+        type: string
+jobs:
+  delete-review-app:
+    name: Delete Review App ${{ github.event.pull_request.number }}
+    concurrency: deploy_review_${{ github.event.pull_request.number }}
+    runs-on: ubuntu-latest
+    environment: review
+    steps:
+      - uses: actions/checkout@v3
+      - name: Extract configuration from tfvars
+        id: config
+        run: |
+          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+            PR_NUMBER=${{ github.event.inputs.pr_number }}
+          else
+            PR_NUMBER=${{ github.event.pull_request.number }}
+          fi
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error ::Failed to extract PR_NUMBER"
+            exit 1
+          fi
+
+          RESOURCE_PREFIX=$(jq -r '.resource_prefix' $TFVARS)
+          APP_RESOURCE_GROUP_NAME=$RESOURCE_PREFIX-review-pr-$PR_NUMBER-rg
+          STORAGE_ACCOUNT_NAME=$(jq -r '.storage_account_name' $TFVARS)
+          TERRAFORM_VERSION=$(awk '/{/{f=/^terraform/;next}f' terraform.tf | grep -o [0-9\.]*)
+          DEV_TFVARS=workspace_variables/dev.tfvars.json
+          TF_RESOURCE_GROUP_NAME=$(jq -r '.resource_group_name' $DEV_TFVARS)
+          TF_STATE_CONTAINER=$(awk '/{/{f=/backend/;next}f' terraform.tf | grep -o "\"[a-z\-]*\"" | tr -d \")
+
+          if [ -z "$APP_RESOURCE_GROUP_NAME" ]; then
+            echo "::error ::Failed to extract app_resource_group_name from $TFVARS"
+            exit 1
+          fi
+
+          if [ -z "$STORAGE_ACCOUNT_NAME" ]; then
+            echo "::error ::Failed to extract storage_account_name from $TFVARS"
+            exit 1
+          fi
+
+          if [ -z "$TERRAFORM_VERSION" ]; then
+            echo "::error ::Failed to extract terraform_version from terraform.tf"
+            exit 1
+          fi
+
+          if [ -z "$TF_RESOURCE_GROUP_NAME" ]; then
+            echo "::error ::Failed to extract resource_group_name from $DEV_TFVARS"
+            exit 1
+          fi
+
+          if [ -z "$TF_STATE_CONTAINER" ]; then
+            echo "::error ::Failed to extract tf_state_container from terraform.tf"
+            exit 1
+          fi
+
+          echo "app_resource_group_name=$APP_RESOURCE_GROUP_NAME" >> $GITHUB_ENV
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_ENV
+          echo "storage_account_name=$STORAGE_ACCOUNT_NAME" >> $GITHUB_ENV
+          echo "terraform_version=$TERRAFORM_VERSION" >> $GITHUB_ENV
+          echo "tf_resource_group_name=$TF_RESOURCE_GROUP_NAME" >> $GITHUB_ENV
+          echo "tf_state_container=$TF_STATE_CONTAINER" >> $GITHUB_ENV
+        shell: bash
+        env:
+          TFVARS: workspace_variables/review.tfvars.json
+        working-directory: terraform
+
+      - uses: Azure/login@v1
+        with:
+          creds: ${{ secrets.azure_credentials }}
+
+      - run: |
+          TFSTATE_CONTAINER_ACCESS_KEY="$(az storage account keys list -g ${{ env.tf_resource_group_name }} -n ${{ env.storage_account_name }} | jq -r '.[0].value')"
+          echo "::add-mask::$TFSTATE_CONTAINER_ACCESS_KEY"
+          echo "TFSTATE_CONTAINER_ACCESS_KEY=$TFSTATE_CONTAINER_ACCESS_KEY" >> $GITHUB_ENV
+        shell: bash
+
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ ENV.terraform_version }}
+          terraform_wrapper: false
+
+      - name: Check resource group exists
+        run: |
+          GROUP=$(az group exists --name ${{ env.app_resource_group_name }})
+          if [[ "$GROUP" =~ "true" ]]; then
+            echo "REVIEW_APP_EXISTS=true" >> $GITHUB_ENV
+          fi
+
+      - name: Set Environment variables
+        if: env.REVIEW_APP_EXISTS == 'true'
+        run: |
+          TF_STATE_FILE=review/review-pr-${{ env.pr_number }}.tfstate
+          echo "TF_STATE_FILE=$TF_STATE_FILE" >> $GITHUB_ENV
+
+          pr_state_file=$(az storage blob list -c ${{ env.tf_state_container }} \
+            --account-key ${{ env.TFSTATE_CONTAINER_ACCESS_KEY }} \
+            --account-name ${{ env.storage_account_name }} \
+            --prefix $TF_STATE_FILE --query "[].name" -o tsv)
+          if [ -n "$pr_state_file" ]; then
+            echo "TF_STATE_EXISTS=true" >> $GITHUB_ENV
+          fi
+
+      - name: Terraform
+        if: env.TF_STATE_EXISTS == 'true'
+        id: terraform
+        run: |
+          make ci review terraform-destroy pr_id=${{ env.pr_number }}
+        env:
+          ARM_ACCESS_KEY: ${{ env.TFSTATE_CONTAINER_ACCESS_KEY }}
+          TF_VAR_azure_sp_credentials_json: ${{ secrets.AZURE_CREDENTIALS }}
+        shell: bash
+
+      - name: Delete tf state file
+        if: env.TF_STATE_EXISTS == 'true'
+        run: |
+          az storage blob delete -c ${{ env.tf_state_container }} --name ${{ env.TF_STATE_FILE }} \
+          --account-key ${{ env.TFSTATE_CONTAINER_ACCESS_KEY }} \
+          --account-name ${{ env.storage_account_name }}

--- a/Makefile
+++ b/Makefile
@@ -40,16 +40,22 @@ production:
 	$(eval AZURE_BACKUP_STORAGE_ACCOUNT_NAME=s165p01rsmdbbackuppd)
 	$(eval AZURE_BACKUP_STORAGE_CONTAINER_NAME=rsm)
 
-.PHONY: review
-review:
+.PHONY: review-init
+review-init:
 	$(if $(pr_id), , $(error Missing environment variable "pr_id"))
+	$(eval ENV_TAG=dev)
+
+.PHONY: review
+review: review-init set-azure-resource-group-tags
 	$(eval DEPLOY_ENV=review)
 	$(eval AZURE_SUBSCRIPTION=s165-teachingqualificationsservice-development)
+	$(eval RESOURCE_NAME_PREFIX=s165d01)
+	$(eval ENV_SHORT=rv)
 	$(eval env=-pr-$(pr_id))
 	$(eval backend_config=-backend-config="key=review/review$(env).tfstate")
+	$(eval export TF_VAR_resource_group_tags=$(RG_TAGS))
 	$(eval export TF_VAR_app_suffix=$(env))
 	$(eval export TF_VAR_resource_group_name=s165d01-rsm-review$(env)-rg)
-	$(eval export TF_VAR_domain=review$(env).refer-serious-misconduct.education.gov.uk)
 	$(eval export TF_VAR_allegations_storage_account_name=s165d01rsmallegr$(pr_id))
 
 .PHONY: domain

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,18 @@ production:
 	$(eval AZURE_BACKUP_STORAGE_ACCOUNT_NAME=s165p01rsmdbbackuppd)
 	$(eval AZURE_BACKUP_STORAGE_CONTAINER_NAME=rsm)
 
+.PHONY: review
+review:
+	$(if $(pr_id), , $(error Missing environment variable "pr_id"))
+	$(eval DEPLOY_ENV=review)
+	$(eval AZURE_SUBSCRIPTION=s165-teachingqualificationsservice-development)
+	$(eval env=-pr-$(pr_id))
+	$(eval backend_config=-backend-config="key=review/review$(env).tfstate")
+	$(eval export TF_VAR_app_suffix=$(env))
+	$(eval export TF_VAR_resource_group_name=s165d01-rsm-review$(env)-rg)
+	$(eval export TF_VAR_domain=review$(env).refer-serious-misconduct.education.gov.uk)
+	$(eval export TF_VAR_allegations_storage_account_name=s165d01rsmallegr$(pr_id))
+
 .PHONY: domain
 domain:
 	$(eval DEPLOY_ENV=production)

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -5,7 +5,7 @@ locals {
       ApplicationInsights__ConnectionString = azurerm_application_insights.insights.connection_string
       DATABASE_URL                          = "postgres://postgres@${local.postgres_server_name}.postgres.database.azure.com:5432"
       DATABASE_PASSWORD                     = local.infrastructure_secrets.POSTGRES_ADMIN_PASSWORD
-      HOSTING_DOMAIN                        = "https://${var.domain}"
+      HOSTING_DOMAIN                        = var.domain != null ? "https://${var.domain}" : "https://${local.rsm_app_name}.azurewebsites.net"
       HOSTING_ENVIRONMENT_NAME              = local.hosting_environment
       RAILS_SERVE_STATIC_FILES              = "true"
       ConnectionStrings__Redis              = azurerm_redis_cache.redis.primary_connection_string

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,10 +1,14 @@
 data "azurerm_resource_group" "group" {
-  name = var.resource_group_name
+  name  = var.environment_name == "review" ? azurerm_resource_group.review_app_rg[0].name : var.resource_group_name
+}
+
+data "azurerm_resource_group" "keyvault_group" {
+  name  = var.environment_name == "review" ? var.key_vault_resource_group : var.resource_group_name
 }
 
 data "azurerm_key_vault" "vault" {
   name                = var.key_vault_name
-  resource_group_name = data.azurerm_resource_group.group.name
+  resource_group_name = data.azurerm_resource_group.keyvault_group.name
 }
 
 data "azurerm_key_vault_secrets" "secrets" {

--- a/terraform/monitor-diagnostics.tf
+++ b/terraform/monitor-diagnostics.tf
@@ -1,4 +1,5 @@
-resource "azurerm_monitor_diagnostic_setting" "getanid-keyvault-diagnostics" {
+resource "azurerm_monitor_diagnostic_setting" "rsm-keyvault-diagnostics" {
+  count                      = local.keyvault_logging_enabled ? 1 : 0
   name                       = "${data.azurerm_key_vault.vault.name}-diagnostics"
   target_resource_id         = data.azurerm_key_vault.vault.id
   log_analytics_workspace_id = azurerm_log_analytics_workspace.analytics.id

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -11,10 +11,13 @@ provider "azurerm" {
   tenant_id                  = try(local.azure_credentials.tenantId, null)
   skip_provider_registration = true
 
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = var.create_env_resource_group ? false : true
+    }
+  }
 }
 
 provider "statuscake" {
   api_token = local.monitoring_secrets.STATUSCAKE_PASSWORD
 }
-

--- a/terraform/review-app.tf
+++ b/terraform/review-app.tf
@@ -1,0 +1,5 @@
+resource "azurerm_resource_group" "review_app_rg" {
+  count    = var.create_env_resource_group ? 1 : 0
+  name     = var.resource_group_name
+  location = "West Europe"
+}

--- a/terraform/review-app.tf
+++ b/terraform/review-app.tf
@@ -1,5 +1,6 @@
 resource "azurerm_resource_group" "review_app_rg" {
   count    = var.create_env_resource_group ? 1 : 0
   name     = var.resource_group_name
-  location = "West Europe"
+  location = var.region_name
+  tags     = jsondecode(var.resource_group_tags)
 }

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -16,9 +16,7 @@ resource "azurerm_storage_account" "allegations" {
     }
   }
 
-  lifecycle {
-    prevent_destroy = true
-  }
+  depends_on = [data.azurerm_resource_group.group]
 }
 
 
@@ -33,8 +31,4 @@ resource "azurerm_storage_container" "uploads" {
   name                  = "uploads"
   storage_account_name  = azurerm_storage_account.allegations.name
   container_access_type = "private"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,7 +4,6 @@ variable "environment_name" {
 
 variable "resource_prefix" {
   type    = string
-  default = ""
 }
 
 variable "app_suffix" {
@@ -147,13 +146,13 @@ variable "create_env_resource_group" {
 
 locals {
   hosting_environment          = var.environment_name
-  rsm_app_name                = "${var.resource_prefix}rsm-${var.environment_name}${var.app_suffix}-app"
-  postgres_server_name         = "${var.resource_prefix}rsm-${var.environment_name}${var.app_suffix}-psql"
+  rsm_app_name                = "${var.resource_prefix}-${var.environment_name}${var.app_suffix}-app"
+  postgres_server_name         = "${var.resource_prefix}-${var.environment_name}${var.app_suffix}-psql"
   postgres_database_name       = "refer_serious_misconduct_production"
-  redis_database_name          = "${var.resource_prefix}rsm-${var.environment_name}${var.app_suffix}-redis"
-  app_insights_name            = "${var.resource_prefix}rsm-${var.environment_name}${var.app_suffix}-appi"
-  log_analytics_workspace_name = "${var.resource_prefix}rsm-${var.environment_name}-log"
-  app_service_plan_name        = "${var.resource_prefix}rsm-${var.environment_name}-plan"
+  redis_database_name          = "${var.resource_prefix}-${var.environment_name}${var.app_suffix}-redis"
+  app_insights_name            = "${var.resource_prefix}-${var.environment_name}${var.app_suffix}-appi"
+  log_analytics_workspace_name = "${var.resource_prefix}-${var.environment_name}-log"
+  app_service_plan_name        = "${var.resource_prefix}-${var.environment_name}-plan"
 
   keyvault_logging_enabled            = var.keyvault_logging_enabled
   storage_diagnostics_logging_enabled = length(var.storage_log_categories) > 0

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,6 +40,12 @@ variable "key_vault_name" {
   type = string
 }
 
+variable "key_vault_resource_group" {
+  description = "Only required for review apps which use the dev KeyVault"
+  type = string
+  default = ""
+}
+
 variable "resource_group_name" {
   type = string
 }
@@ -126,6 +132,11 @@ variable "allegations_storage_account_name" {
 variable "region_name" {
   default = "west europe"
   type    = string
+}
+
+variable "create_env_resource_group" {
+  default = false
+  type = bool
 }
 
 locals {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -50,6 +50,12 @@ variable "resource_group_name" {
   type = string
 }
 
+variable "resource_group_tags" {
+  description = "Only required for review apps which are deployed into their own, tempoarary, resource group"
+  type = string
+  default = ""
+}
+
 variable "redis_service_sku" {
   type    = string
   default = "Basic"

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -7,7 +7,7 @@
   "app_service_plan_sku": "S1",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
-  "resource_prefix": "s165d01-",
+  "resource_prefix": "s165d01-rsm",
   "domain": "dev.refer-serious-misconduct.education.gov.uk",
   "allegations_storage_account_name": "s165d01rsmallegationsdv"
 }

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -7,7 +7,7 @@
   "app_service_plan_sku": "S1",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
-  "resource_prefix": "s165t01-",
+  "resource_prefix": "s165t01-rsm",
   "domain": "preprod.refer-serious-misconduct.education.gov.uk",
   "allegations_storage_account_name": "s165t01rsmallegationspp"
 }

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -7,7 +7,7 @@
   "app_service_plan_sku": "P1v2",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
-  "resource_prefix": "s165p01-",
+  "resource_prefix": "s165p01-rsm",
   "worker_count": 3,
   "postgres_flexible_server_sku": "GP_Standard_D2s_v3",
   "enable_postgres_high_availability": true,

--- a/terraform/workspace_variables/review.backend.tfvars
+++ b/terraform/workspace_variables/review.backend.tfvars
@@ -1,0 +1,2 @@
+storage_account_name = "s165d01rsmtfstatedv"
+resource_group_name  = "s165d01-rsm-dv-rg"

--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -3,7 +3,6 @@
   "key_vault_name": "s165d01-rsm-dv-kv",
   "key_vault_resource_group": "s165d01-rsm-dv-rg",
   "storage_account_name": "s165d01rsmtfstatedv",
-  "keyvault_logging_enabled": true,
   "storage_log_categories": [],
   "resource_prefix": "s165d01-",
   "create_env_resource_group": true

--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -4,6 +4,6 @@
   "key_vault_resource_group": "s165d01-rsm-dv-rg",
   "storage_account_name": "s165d01rsmtfstatedv",
   "storage_log_categories": [],
-  "resource_prefix": "s165d01-",
+  "resource_prefix": "s165d01-rsm",
   "create_env_resource_group": true
 }

--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -1,0 +1,10 @@
+{
+  "environment_name": "review",
+  "key_vault_name": "s165d01-rsm-dv-kv",
+  "key_vault_resource_group": "s165d01-rsm-dv-rg",
+  "storage_account_name": "s165d01rsmtfstatedv",
+  "keyvault_logging_enabled": true,
+  "storage_log_categories": [],
+  "resource_prefix": "s165d01-",
+  "create_env_resource_group": true
+}

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -7,7 +7,7 @@
   "app_service_plan_sku": "S1",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
-  "resource_prefix": "s165t01-",
+  "resource_prefix": "s165t01-rsm",
   "domain": "test.refer-serious-misconduct.education.gov.uk",
   "allegations_storage_account_name": "s165t01rsmallegationsts"
 }


### PR DESCRIPTION
### Context

To test changes, we require the option to deploy temporary review apps.

### Changes proposed in this pull request

- Changes to terraform and addition of workflows to deploy review apps
- Addition of workflow to delete review apps
- Remove `prevent_destroy` lifecycle metadata that protects Azure Storage from accidental deletion by terraform.  This provides limited value (any service or user other than terraform can still delete the storage account) and prevents the creation of a temporary storage account for the review app

### Guidance to review

- To test the delete process run `gh workflow run "Delete Review App" --ref=add-review-app -f pr_number=173` locally
- To test the review app deployment process rerun the last Build and Action triggered by this branch
- Tested changes against dev environment [here](https://github.com/DFE-Digital/refer-serious-misconduct/actions/runs/3488756326)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
