### PR TITLE
Add task to ignore concurrent migration exceptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,5 +92,5 @@ COPY azure/.sshd_config /etc/ssh/sshd_config
 EXPOSE 2222
 
 CMD /usr/sbin/sshd && \
-    bundle exec rails db:migrate && \
+    bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && \
     bundle exec rails server -b 0.0.0.0

--- a/lib/tasks/ignore_concurrent_migration_exceptions.rake
+++ b/lib/tasks/ignore_concurrent_migration_exceptions.rake
@@ -1,0 +1,10 @@
+namespace :db do
+  namespace :migrate do
+    desc "db:migrate but ignores ActiveRecord::ConcurrentMigrationError errors"
+    task ignore_concurrent_migration_exceptions: :environment do
+      Rake::Task["db:migrate"].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
+    end
+  end
+end


### PR DESCRIPTION
Migrations can fail when deploying to blue/green environments due to concurrent migration exceptions.

See https://github.com/DFE-Digital/find-a-lost-trn/commit/61d8784dff76bd980ba0a55769476a369006cd32

This adds a task that swallows these errors so that deploys can succeed.