### PR TITLE
Referrals employer form - About their role job start date page 

### DIFF
--- a/app/controllers/referrals/teacher_role/start_date_controller.rb
+++ b/app/controllers/referrals/teacher_role/start_date_controller.rb
@@ -1,0 +1,42 @@
+module Referrals
+  module TeacherRole
+    class StartDateController < Referrals::BaseController
+      def edit
+        @role_start_date_form =
+          StartDateForm.new(
+            referral: current_referral,
+            role_start_date_known: current_referral.role_start_date_known,
+            role_start_date: current_referral.role_start_date
+          )
+      end
+
+      def update
+        @role_start_date_form =
+          StartDateForm.new(role_params.merge(referral: current_referral))
+
+        if @role_start_date_form.save(start_date_params)
+          # TODO: redirect to job end date page
+          redirect_to edit_referral_path(current_referral)
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def role_params
+        params.require(:referrals_teacher_role_start_date_form).permit(
+          :role_start_date_known
+        )
+      end
+
+      def start_date_params
+        params.require(:referrals_teacher_role_start_date_form).permit(
+          "role_start_date(3i)",
+          "role_start_date(2i)",
+          "role_start_date(1i)"
+        )
+      end
+    end
+  end
+end

--- a/app/forms/concerns/validated_date.rb
+++ b/app/forms/concerns/validated_date.rb
@@ -3,7 +3,12 @@ module ValidatedDate
   extend ActiveSupport::Concern
 
   included do
-    def validated_date(date_params:, attribute:, date_of_birth: false)
+    def validated_date(
+      date_params:,
+      attribute:,
+      date_of_birth: false,
+      in_the_future: false
+    )
       date_fields = [
         date_params["#{attribute}(1i)"],
         date_params["#{attribute}(2i)"],
@@ -49,15 +54,17 @@ module ValidatedDate
         return false
       end
 
+      return true unless date_of_birth || !in_the_future
+
+      if year > Time.zone.today.year
+        errors.add(attribute, :in_the_future)
+        return false
+      end
+
       return true unless date_of_birth
 
       if year < 1900
         errors.add(attribute, :born_after_1900)
-        return false
-      end
-
-      if year > Time.zone.today.year
-        errors.add(attribute, :in_the_future)
         return false
       end
 

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -66,7 +66,7 @@ class ReferralForm
         ),
         ReferralSectionItem.new(
           I18n.t("referral_form.about_their_role"),
-          "#",
+          referrals_edit_teacher_role_start_date_path(referral),
           :not_started_yet
         )
       ]

--- a/app/forms/referrals/teacher_role/start_date_form.rb
+++ b/app/forms/referrals/teacher_role/start_date_form.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module Referrals
+  module TeacherRole
+    class StartDateForm
+      include ActiveModel::Model
+      include ValidatedDate
+
+      attr_accessor :referral
+      attr_writer :role_start_date
+      attr_reader :role_start_date_known
+
+      validates :referral, presence: true
+      validates :role_start_date_known, inclusion: { in: [true, false] }
+
+      def role_start_date
+        @role_start_date ||= referral.role_start_date
+      end
+
+      def role_start_date_known=(value)
+        @role_start_date_known = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save(params = {})
+        return false if invalid?
+
+        if role_start_date_known &&
+             !validated_date(date_params: params, attribute: :role_start_date)
+          return false
+        end
+
+        referral.update(role_start_date:, role_start_date_known:)
+        true
+      end
+    end
+  end
+end

--- a/app/views/referrals/teacher_role/start_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/start_date/edit.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title, "#{'Error: ' if @role_start_date_form.errors.any?}Do you know when they started their job?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <%= form_with model: @role_start_date_form, url: referrals_update_teacher_role_start_date_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :role_start_date_known,
+        legend: { size: "l", text: "Do you know when they started their job?" },
+        hint: { size: "m", text: "This is the job the person had when the allegation of serious misconduct was made against them." } do %>
+        <%= f.hidden_field :role_start_date_known %>
+        <%= f.govuk_radio_button :role_start_date_known, true, label: { text: "Yes" } do %>
+          <%= f.govuk_date_field :role_start_date,
+            legend: { text: "Start date", size: "m" },
+            hint: { text: "For example, 27 3 2021" } %>
+        <% end %>
+        <%= f.govuk_radio_button :role_start_date_known, false, label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,6 +121,17 @@ en:
           attributes:
             contact_details_complete:
               inclusion: Tell us if you have completed this section
+        "referrals/teacher_role/start_date_form":
+          attributes:
+            role_start_date_known:
+              inclusion: Tell us if you know their role start date
+            role_start_date:
+              blank: Enter their role start date
+              in_the_future: Their role start date must be in the past
+              invalid: Enter their role start date in the correct format
+              missing_day: Enter a day for their role start date, formatted as a number
+              missing_month: Enter a month for their role start date, formatted as a number
+              missing_year: Enter a year with 4 digits
         referrer_job_title_form:
           attributes:
             job_title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,6 +160,13 @@ Rails.application.routes.draw do
     put "/:referral_id/allegation/confirm",
         to: "allegation/confirm#update",
         as: "update_allegation_confirm"
+
+    get "/:referral_id/teacher-role/start-date",
+        to: "teacher_role/start_date#edit",
+        as: "edit_teacher_role_start_date"
+    put "/:referral_id/teacher-role/start-date",
+        to: "teacher_role/start_date#update",
+        as: "update_teacher_role_start_date"
   end
 
   get "/performance", to: "performance#index"

--- a/db/migrate/20221110114307_add_role_start_date_to_referrals.rb
+++ b/db/migrate/20221110114307_add_role_start_date_to_referrals.rb
@@ -1,0 +1,8 @@
+class AddRoleStartDateToReferrals < ActiveRecord::Migration[7.0]
+  def change
+    change_table :referrals, bulk: true do |t|
+      t.boolean :role_start_date_known
+      t.date :role_start_date
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_15_110834) do
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", 
+unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
@@ -103,6 +104,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_15_110834) do
     t.string "allegation_details"
     t.boolean "dbs_notified"
     t.boolean "allegation_details_complete"
+    t.boolean "role_start_date_known"
+    t.date "role_start_date"
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 

--- a/spec/forms/referrals/teacher_role/start_date_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/start_date_form_spec.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Referrals::TeacherRole::StartDateForm, type: :model do
+  let(:referral) { build(:referral) }
+  let(:role_start_date_known) { true }
+  subject(:start_date_form) do
+    described_class.new(referral:, role_start_date_known:)
+  end
+
+  describe "#valid?" do
+    subject(:valid) { start_date_form.valid? }
+
+    it { is_expected.to be_truthy }
+
+    before { valid }
+
+    context "when role_start_date_known is blank" do
+      let(:role_start_date_known) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(start_date_form.errors[:role_start_date_known]).to eq(
+          ["Tell us if you know their role start date"]
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when role_start_date_known is true" do
+      let(:role_start_date_known) { true }
+
+      before { start_date_form.save(params) }
+
+      let(:params) do
+        {
+          "role_start_date(1i)" => "2000",
+          "role_start_date(2i)" => "01",
+          "role_start_date(3i)" => "01"
+        }
+      end
+
+      it "updates the role start date" do
+        expect(referral.role_start_date).to eq(Date.new(2000, 1, 1))
+      end
+
+      context "with a short month name" do
+        let(:params) do
+          {
+            "role_start_date(1i)" => "2000",
+            "role_start_date(2i)" => "Jan",
+            "role_start_date(3i)" => "01"
+          }
+        end
+
+        it "updates the role start date" do
+          expect(referral.role_start_date).to eq(Date.new(2000, 1, 1))
+        end
+      end
+
+      context "with a word for a number for the day and month" do
+        let(:params) do
+          {
+            "role_start_date(1i)" => "2000",
+            "role_start_date(2i)" => "tWeLvE  ",
+            "role_start_date(3i)" => "One"
+          }
+        end
+
+        it "updates the role start date" do
+          expect(referral.role_start_date).to eq(Date.new(2000, 12, 1))
+        end
+      end
+
+      context "without a valid date" do
+        let(:params) do
+          {
+            "role_start_date(1i)" => "2000",
+            "role_start_date(2i)" => "02",
+            "role_start_date(3i)" => "30"
+          }
+        end
+
+        it "does not update the role start date" do
+          expect(referral.role_start_date).to be_nil
+        end
+
+        it "adds an error" do
+          expect(start_date_form.errors[:role_start_date]).to eq(
+            ["Enter their role start date in the correct format"]
+          )
+        end
+      end
+
+      context "with a blank date" do
+        let(:params) do
+          {
+            "role_start_date(1i)" => "",
+            "role_start_date(2i)" => "",
+            "role_start_date(3i)" => ""
+          }
+        end
+
+        it "adds an error" do
+          expect(start_date_form.errors[:role_start_date]).to eq(
+            ["Enter their role start date"]
+          )
+        end
+      end
+
+      context "when the date is in the future" do
+        let(:params) do
+          {
+            "role_start_date(1i)" => 1.year.from_now.year,
+            "role_start_date(2i)" => "01",
+            "role_start_date(3i)" => "01"
+          }
+        end
+
+        it "adds an error" do
+          expect(start_date_form.errors[:role_start_date]).to eq(
+            ["Their role start date must be in the past"]
+          )
+        end
+      end
+
+      context "with a year that is less than 4 digits" do
+        let(:params) do
+          {
+            "role_start_date(1i)" => "99",
+            "role_start_date(2i)" => "1",
+            "role_start_date(3i)" => "1"
+          }
+        end
+
+        it "adds an error" do
+          expect(start_date_form.errors[:role_start_date]).to eq(
+            ["Enter a year with 4 digits"]
+          )
+        end
+      end
+
+      context "with a missing day" do
+        let(:params) do
+          {
+            "role_start_date(1i)" => "1990",
+            "role_start_date(2i)" => "1",
+            "role_start_date(3i)" => ""
+          }
+        end
+
+        it "adds an error" do
+          expect(start_date_form.errors[:role_start_date]).to eq(
+            ["Enter a day for their role start date, formatted as a number"]
+          )
+        end
+      end
+
+      context "with a missing month" do
+        let(:params) do
+          {
+            "role_start_date(1i)" => "1990",
+            "role_start_date(2i)" => "",
+            "role_start_date(3i)" => "1"
+          }
+        end
+
+        it "adds an error" do
+          expect(start_date_form.errors[:role_start_date]).to eq(
+            ["Enter a month for their role start date, formatted as a number"]
+          )
+        end
+      end
+
+      context "with a whitespace month" do
+        let(:params) do
+          {
+            "role_start_date(1i)" => "1990",
+            "role_start_date(2i)" => " ",
+            "role_start_date(3i)" => "1"
+          }
+        end
+
+        it "adds an error" do
+          expect(start_date_form.errors[:role_start_date]).to eq(
+            ["Enter a month for their role start date, formatted as a number"]
+          )
+        end
+      end
+
+      context "with a word as a month" do
+        let(:params) do
+          {
+            "role_start_date(1i)" => "1990",
+            "role_start_date(2i)" => "Potatoes",
+            "role_start_date(3i)" => "1"
+          }
+        end
+
+        it "adds an error" do
+          expect(start_date_form.errors[:role_start_date]).to eq(
+            ["Enter a month for their role start date, formatted as a number"]
+          )
+        end
+      end
+    end
+
+    context "when role_start_date_known is false" do
+      let(:role_start_date_known) { false }
+
+      it "updates the start_date_known to false" do
+        expect { start_date_form.save }.to change(
+          referral,
+          :role_start_date_known
+        ).from(nil).to(false)
+      end
+    end
+  end
+end

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Teacher role", type: :system do
+  scenario "User adds teacher role details to a referral" do
+    given_the_service_is_open
+    and_i_am_signed_in
+    and_the_employer_form_feature_is_active
+    and_i_visit_a_referral
+    then_i_see_the_referral_summary
+
+    when_i_edit_teacher_role_details
+    then_i_am_asked_their_role_start_date
+    and_i_click_back
+    then_i_see_the_referral_summary
+
+    when_i_edit_teacher_role_details
+    then_i_am_asked_their_role_start_date
+    and_i_click_save_and_continue
+    then_i_see_role_start_date_known_field_validation_errors
+
+    when_i_choose_no
+    and_i_click_save_and_continue
+    then_i_see_the_referral_summary
+
+    when_i_edit_teacher_role_details
+    when_i_choose_yes
+    and_i_click_save_and_continue
+    then_i_see_role_start_date_field_validation_errors
+
+    when_i_choose_yes
+    when_i_fill_out_the_role_start_date_fields
+    and_i_click_save_and_continue
+    then_i_see_the_referral_summary
+  end
+
+  private
+
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_i_am_signed_in
+    @user = create(:user)
+    sign_in(@user)
+  end
+
+  def and_the_employer_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_i_visit_a_referral
+    @referral = create(:referral, user: @user)
+    visit edit_referral_path(@referral)
+  end
+
+  def when_i_edit_teacher_role_details
+    within(all(".app-task-list__section")[1]) { click_on "About their role" }
+  end
+
+  def when_i_click_back
+    click_on "Back"
+  end
+  alias_method :and_i_click_back, :when_i_click_back
+
+  def then_i_see_the_referral_summary
+    expect(page).to have_content("Your allegation of serious misconduct")
+  end
+
+  def and_i_click_save_and_continue
+    click_on "Save and continue"
+  end
+
+  def then_i_am_asked_their_role_start_date
+    expect(page).to have_content("Do you know when they started their job?")
+  end
+
+  def then_i_see_role_start_date_known_field_validation_errors
+    expect(page).to have_content("Tell us if you know their role start date")
+  end
+
+  def then_i_see_role_start_date_field_validation_errors
+    expect(page).to have_content("Enter their role start date")
+  end
+
+  def when_i_choose_yes
+    choose "Yes", visible: false
+  end
+
+  def when_i_choose_no
+    choose "No", visible: false
+  end
+
+  def when_i_fill_out_the_role_start_date_fields
+    fill_in "Day", with: "17"
+    fill_in "Month", with: "1"
+    fill_in "Year", with: "1990"
+  end
+end


### PR DESCRIPTION
### Context

When making a referral, the role start date of the person being referred needs to be specified.

https://teacher-misconduct.herokuapp.com/report/teacher-role/start-date

https://trello.com/c/AN2Nkohy/945-about-their-role-forms-add-start-date-page

### Changes proposed in this pull request

Add the following page, linked from the employer form hub page under the "About the person you are referring"/"About their role" section:
<img width="709" alt="Screenshot 2022-11-15 at 21 03 22" src="https://user-images.githubusercontent.com/1636476/202024863-d142a334-b1b6-4274-b109-17db4810b4a4.png">

* Update the routes
* Generate a migration for adding the role start date fields to the referrals table.
* Add the form, including validation 
* Link the form to the employer form hub

### Checklist

- [X] Attach to Trello card
- [X] Rebased main
- [X] Cleaned commit history
- [X] Tested by running locally