### PR TITLE
Improve duplicate date validations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,7 +58,7 @@ en:
           attributes:
             date_of_birth:
               blank: Enter their date of birth
-              born_after_1900: Enter a year of birth later than 1900
+              born_after_1900: Enter a year later than 1900
               inclusion: You must be 16 or over to use this service
               in_the_future: Their date of birth must be in the past
               invalid: Enter their date of birth in the correct format

--- a/spec/forms/referrals/personal_details/age_form_spec.rb
+++ b/spec/forms/referrals/personal_details/age_form_spec.rb
@@ -5,268 +5,31 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
   let(:referral) { build(:referral) }
   let(:age_known) { "false" }
 
-  subject(:age_form) { described_class.new(referral:, age_known:) }
+  let(:date_form) { described_class.new(referral:, age_known:) }
 
   context "with invalid age_known" do
     let(:age_known) { "" }
 
     it "adds an error message" do
-      expect(age_form.valid?).to be false
-      expect(age_form.errors[:age_known]).to eq(
+      expect(date_form.valid?).to be false
+      expect(date_form.errors[:age_known]).to eq(
         ["Tell us if you know their date of birth"]
       )
     end
   end
 
   describe "#save (date)" do
-    subject(:save) { age_form.save(params) }
-
     let(:age_known) { "true" }
-    let(:age_form) { described_class.new(referral:, age_known:) }
-    let(:params) do
-      {
-        "date_of_birth(1i)" => "2000",
-        "date_of_birth(2i)" => "01",
-        "date_of_birth(3i)" => "01"
-      }
-    end
 
-    it "updates the date of birth" do
-      save
-      expect(referral.date_of_birth).to eq(Date.new(2000, 1, 1))
-    end
-
-    context "with a short month name" do
-      let(:params) do
-        {
-          "date_of_birth(1i)" => "2000",
-          "date_of_birth(2i)" => "Jan",
-          "date_of_birth(3i)" => "01"
-        }
-      end
-
-      it "updates the date of birth" do
-        save
-        expect(referral.date_of_birth).to eq(Date.new(2000, 1, 1))
-      end
-    end
-
-    context "with a word for a number for the day and month" do
-      let(:params) do
-        {
-          "date_of_birth(1i)" => "2000",
-          "date_of_birth(2i)" => "tWeLvE  ",
-          "date_of_birth(3i)" => "One"
-        }
-      end
-
-      it "updates the date of birth" do
-        save
-        expect(referral.date_of_birth).to eq(Date.new(2000, 12, 1))
-      end
-    end
-
-    context "without a valid date" do
-      let(:params) do
-        {
-          "date_of_birth(1i)" => "2000",
-          "date_of_birth(2i)" => "02",
-          "date_of_birth(3i)" => "30"
-        }
-      end
-
-      it { is_expected.to be_falsy }
-
-      it "does not update the date of birth" do
-        save
-        expect(referral.date_of_birth).to be_nil
-      end
-
-      it "adds an error" do
-        save
-        expect(age_form.errors[:date_of_birth]).to eq(
-          ["Enter their date of birth in the correct format"]
-        )
-      end
-    end
-
-    context "with a blank date" do
-      let(:params) do
-        {
-          "date_of_birth(1i)" => "",
-          "date_of_birth(2i)" => "",
-          "date_of_birth(3i)" => ""
-        }
-      end
-
-      it { is_expected.to be_falsy }
-
-      it "adds an error" do
-        save
-        expect(age_form.errors[:date_of_birth]).to eq(
-          ["Enter their date of birth"]
-        )
-      end
-    end
-
-    context "when the date is in the future" do
-      let(:params) do
-        {
-          "date_of_birth(1i)" => 1.year.from_now.year,
-          "date_of_birth(2i)" => "01",
-          "date_of_birth(3i)" => "01"
-        }
-      end
-
-      it { is_expected.to be_falsy }
-
-      it "adds an error" do
-        save
-        expect(age_form.errors[:date_of_birth]).to eq(
-          ["Their date of birth must be in the past"]
-        )
-      end
-    end
-
-    context "with a date less than 16 years ago" do
-      let(:params) do
-        {
-          "date_of_birth(1i)" => 15.years.ago.year,
-          "date_of_birth(2i)" => Time.zone.today.month,
-          "date_of_birth(3i)" => Time.zone.today.day
-        }
-      end
-
-      it { is_expected.to be_falsy }
-
-      it "adds an error" do
-        save
-        expect(age_form.errors[:date_of_birth]).to eq(
-          ["You must be 16 or over to use this service"]
-        )
-      end
-    end
-
-    context "with a date before 1900" do
-      let(:params) do
-        {
-          "date_of_birth(1i)" => "1899",
-          "date_of_birth(2i)" => "1",
-          "date_of_birth(3i)" => "1"
-        }
-      end
-
-      it { is_expected.to be_falsy }
-
-      it "adds an error" do
-        save
-        expect(age_form.errors[:date_of_birth]).to eq(
-          ["Enter a year of birth later than 1900"]
-        )
-      end
-    end
-
-    context "with a year that is less than 4 digits" do
-      let(:params) do
-        {
-          "date_of_birth(1i)" => "99",
-          "date_of_birth(2i)" => "1",
-          "date_of_birth(3i)" => "1"
-        }
-      end
-
-      it { is_expected.to be_falsy }
-
-      it "adds an error" do
-        save
-        expect(age_form.errors[:date_of_birth]).to eq(
-          ["Enter a year with 4 digits"]
-        )
-      end
-    end
-
-    context "with a missing day" do
-      let(:params) do
-        {
-          "date_of_birth(1i)" => "1990",
-          "date_of_birth(2i)" => "1",
-          "date_of_birth(3i)" => ""
-        }
-      end
-
-      it { is_expected.to be_falsy }
-
-      it "adds an error" do
-        save
-        expect(age_form.errors[:date_of_birth]).to eq(
-          ["Enter a day for their date of birth, formatted as a number"]
-        )
-      end
-    end
-
-    context "with a missing month" do
-      let(:params) do
-        {
-          "date_of_birth(1i)" => "1990",
-          "date_of_birth(2i)" => "",
-          "date_of_birth(3i)" => "1"
-        }
-      end
-
-      it { is_expected.to be_falsy }
-
-      it "adds an error" do
-        save
-        expect(age_form.errors[:date_of_birth]).to eq(
-          ["Enter a month for their date of birth, formatted as a number"]
-        )
-      end
-    end
-
-    context "with a whitespace month" do
-      let(:params) do
-        {
-          "date_of_birth(1i)" => "1990",
-          "date_of_birth(2i)" => " ",
-          "date_of_birth(3i)" => "1"
-        }
-      end
-
-      it { is_expected.to be_falsy }
-
-      it "adds an error" do
-        save
-        expect(age_form.errors[:date_of_birth]).to eq(
-          ["Enter a month for their date of birth, formatted as a number"]
-        )
-      end
-    end
-
-    context "with a word as a month" do
-      let(:params) do
-        {
-          "date_of_birth(1i)" => "1990",
-          "date_of_birth(2i)" => "Potatoes",
-          "date_of_birth(3i)" => "1"
-        }
-      end
-
-      it { is_expected.to be_falsy }
-
-      it "adds an error" do
-        save
-        expect(age_form.errors[:date_of_birth]).to eq(
-          ["Enter a month for their date of birth, formatted as a number"]
-        )
-      end
-    end
+    it_behaves_like "form with a date validator", "date_of_birth"
+    it_behaves_like "form with a date of birth validator", "date_of_birth"
   end
 
   describe "#save (age unknown)" do
-    subject(:save) { age_form.save }
+    subject(:save) { date_form.save }
 
     let(:age_known) { "false" }
-    let(:age_form) { described_class.new(referral:, age_known:) }
+    let(:date_form) { described_class.new(referral:, age_known:) }
 
     it "saves the age_known value without a date of birth" do
       save

--- a/spec/forms/referrals/teacher_role/start_date_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/start_date_form_spec.rb
@@ -4,12 +4,10 @@ require "rails_helper"
 RSpec.describe Referrals::TeacherRole::StartDateForm, type: :model do
   let(:referral) { build(:referral) }
   let(:role_start_date_known) { true }
-  subject(:start_date_form) do
-    described_class.new(referral:, role_start_date_known:)
-  end
+  subject(:date_form) { described_class.new(referral:, role_start_date_known:) }
 
   describe "#valid?" do
-    subject(:valid) { start_date_form.valid? }
+    subject(:valid) { date_form.valid? }
 
     it { is_expected.to be_truthy }
 
@@ -21,7 +19,7 @@ RSpec.describe Referrals::TeacherRole::StartDateForm, type: :model do
       it { is_expected.to be_falsy }
 
       it "adds an error" do
-        expect(start_date_form.errors[:role_start_date_known]).to eq(
+        expect(date_form.errors[:role_start_date_known]).to eq(
           ["Tell us if you know their role start date"]
         )
       end
@@ -32,186 +30,14 @@ RSpec.describe Referrals::TeacherRole::StartDateForm, type: :model do
     context "when role_start_date_known is true" do
       let(:role_start_date_known) { true }
 
-      before { start_date_form.save(params) }
-
-      let(:params) do
-        {
-          "role_start_date(1i)" => "2000",
-          "role_start_date(2i)" => "01",
-          "role_start_date(3i)" => "01"
-        }
-      end
-
-      it "updates the role start date" do
-        expect(referral.role_start_date).to eq(Date.new(2000, 1, 1))
-      end
-
-      context "with a short month name" do
-        let(:params) do
-          {
-            "role_start_date(1i)" => "2000",
-            "role_start_date(2i)" => "Jan",
-            "role_start_date(3i)" => "01"
-          }
-        end
-
-        it "updates the role start date" do
-          expect(referral.role_start_date).to eq(Date.new(2000, 1, 1))
-        end
-      end
-
-      context "with a word for a number for the day and month" do
-        let(:params) do
-          {
-            "role_start_date(1i)" => "2000",
-            "role_start_date(2i)" => "tWeLvE  ",
-            "role_start_date(3i)" => "One"
-          }
-        end
-
-        it "updates the role start date" do
-          expect(referral.role_start_date).to eq(Date.new(2000, 12, 1))
-        end
-      end
-
-      context "without a valid date" do
-        let(:params) do
-          {
-            "role_start_date(1i)" => "2000",
-            "role_start_date(2i)" => "02",
-            "role_start_date(3i)" => "30"
-          }
-        end
-
-        it "does not update the role start date" do
-          expect(referral.role_start_date).to be_nil
-        end
-
-        it "adds an error" do
-          expect(start_date_form.errors[:role_start_date]).to eq(
-            ["Enter their role start date in the correct format"]
-          )
-        end
-      end
-
-      context "with a blank date" do
-        let(:params) do
-          {
-            "role_start_date(1i)" => "",
-            "role_start_date(2i)" => "",
-            "role_start_date(3i)" => ""
-          }
-        end
-
-        it "adds an error" do
-          expect(start_date_form.errors[:role_start_date]).to eq(
-            ["Enter their role start date"]
-          )
-        end
-      end
-
-      context "when the date is in the future" do
-        let(:params) do
-          {
-            "role_start_date(1i)" => 1.year.from_now.year,
-            "role_start_date(2i)" => "01",
-            "role_start_date(3i)" => "01"
-          }
-        end
-
-        it "adds an error" do
-          expect(start_date_form.errors[:role_start_date]).to eq(
-            ["Their role start date must be in the past"]
-          )
-        end
-      end
-
-      context "with a year that is less than 4 digits" do
-        let(:params) do
-          {
-            "role_start_date(1i)" => "99",
-            "role_start_date(2i)" => "1",
-            "role_start_date(3i)" => "1"
-          }
-        end
-
-        it "adds an error" do
-          expect(start_date_form.errors[:role_start_date]).to eq(
-            ["Enter a year with 4 digits"]
-          )
-        end
-      end
-
-      context "with a missing day" do
-        let(:params) do
-          {
-            "role_start_date(1i)" => "1990",
-            "role_start_date(2i)" => "1",
-            "role_start_date(3i)" => ""
-          }
-        end
-
-        it "adds an error" do
-          expect(start_date_form.errors[:role_start_date]).to eq(
-            ["Enter a day for their role start date, formatted as a number"]
-          )
-        end
-      end
-
-      context "with a missing month" do
-        let(:params) do
-          {
-            "role_start_date(1i)" => "1990",
-            "role_start_date(2i)" => "",
-            "role_start_date(3i)" => "1"
-          }
-        end
-
-        it "adds an error" do
-          expect(start_date_form.errors[:role_start_date]).to eq(
-            ["Enter a month for their role start date, formatted as a number"]
-          )
-        end
-      end
-
-      context "with a whitespace month" do
-        let(:params) do
-          {
-            "role_start_date(1i)" => "1990",
-            "role_start_date(2i)" => " ",
-            "role_start_date(3i)" => "1"
-          }
-        end
-
-        it "adds an error" do
-          expect(start_date_form.errors[:role_start_date]).to eq(
-            ["Enter a month for their role start date, formatted as a number"]
-          )
-        end
-      end
-
-      context "with a word as a month" do
-        let(:params) do
-          {
-            "role_start_date(1i)" => "1990",
-            "role_start_date(2i)" => "Potatoes",
-            "role_start_date(3i)" => "1"
-          }
-        end
-
-        it "adds an error" do
-          expect(start_date_form.errors[:role_start_date]).to eq(
-            ["Enter a month for their role start date, formatted as a number"]
-          )
-        end
-      end
+      it_behaves_like "form with a date validator", "role_start_date"
     end
 
     context "when role_start_date_known is false" do
       let(:role_start_date_known) { false }
 
       it "updates the start_date_known to false" do
-        expect { start_date_form.save }.to change(
+        expect { date_form.save }.to change(
           referral,
           :role_start_date_known
         ).from(nil).to(false)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,6 +84,8 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include ViewComponent::TestHelpers, type: :component
   config.include ActiveJob::TestHelper
+
+  Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/support/shared_examples/validating_date.rb
+++ b/spec/support/shared_examples/validating_date.rb
@@ -1,0 +1,224 @@
+# Required values:
+# field (via argument) - database date field name, e.g. date_of_birth
+# date_form - the form that has the date field, e.g. let(:date_form) { described_class.new(referral:, age_known:) }
+# referral - a Referral object
+
+RSpec.shared_examples "form with a date validator" do |field|
+  subject(:save) { date_form.save(params) }
+
+  let(:date_field) { referral.send(field) }
+
+  before { save }
+
+  context "when valid date values" do
+    let(:params) do
+      {
+        "#{field}(1i)" => "2000",
+        "#{field}(2i)" => "01",
+        "#{field}(3i)" => "01"
+      }
+    end
+
+    it "updates the date field" do
+      expect(date_field).to eq(Date.new(2000, 1, 1))
+    end
+  end
+
+  context "with a short month name" do
+    let(:params) do
+      {
+        "#{field}(1i)" => "2000",
+        "#{field}(2i)" => "Jan",
+        "#{field}(3i)" => "01"
+      }
+    end
+
+    it "updates the date field" do
+      expect(date_field).to eq(Date.new(2000, 1, 1))
+    end
+  end
+
+  context "with a word for a number for the day and month" do
+    let(:params) do
+      {
+        "#{field}(1i)" => "2000",
+        "#{field}(2i)" => "tWeLvE  ",
+        "#{field}(3i)" => "One"
+      }
+    end
+
+    it "updates the date field" do
+      expect(date_field).to eq(Date.new(2000, 12, 1))
+    end
+  end
+
+  context "without a valid date" do
+    let(:params) do
+      {
+        "#{field}(1i)" => "2000",
+        "#{field}(2i)" => "02",
+        "#{field}(3i)" => "30"
+      }
+    end
+
+    it { is_expected.to be_falsy }
+
+    it "does not update the date field" do
+      expect(date_field).to be_nil
+    end
+
+    it "adds an error" do
+      expect(date_form.errors[field.to_s]).to eq(
+        ["Enter their #{field_name(field)} in the correct format"]
+      )
+    end
+  end
+
+  context "with a blank date" do
+    let(:params) do
+      { "#{field}(1i)" => "", "#{field}(2i)" => "", "#{field}(3i)" => "" }
+    end
+
+    it { is_expected.to be_falsy }
+
+    it "adds an error" do
+      expect(date_form.errors[field.to_s]).to eq(
+        ["Enter their #{field_name(field)}"]
+      )
+    end
+  end
+
+  context "with a year that is less than 4 digits" do
+    let(:params) do
+      { "#{field}(1i)" => "99", "#{field}(2i)" => "1", "#{field}(3i)" => "1" }
+    end
+
+    it { is_expected.to be_falsy }
+
+    it "adds an error" do
+      expect(date_form.errors[field.to_s]).to eq(["Enter a year with 4 digits"])
+    end
+  end
+
+  context "with a missing day" do
+    let(:params) do
+      { "#{field}(1i)" => "1990", "#{field}(2i)" => "1", "#{field}(3i)" => "" }
+    end
+
+    it { is_expected.to be_falsy }
+
+    it "adds an error" do
+      expect(date_form.errors[field.to_s]).to eq(
+        ["Enter a day for their #{field_name(field)}, formatted as a number"]
+      )
+    end
+  end
+
+  context "with a missing month" do
+    let(:params) do
+      { "#{field}(1i)" => "1990", "#{field}(2i)" => "", "#{field}(3i)" => "1" }
+    end
+
+    it { is_expected.to be_falsy }
+
+    it "adds an error" do
+      expect(date_form.errors[field.to_s]).to eq(
+        ["Enter a month for their #{field_name(field)}, formatted as a number"]
+      )
+    end
+  end
+
+  context "with a whitespace month" do
+    let(:params) do
+      { "#{field}(1i)" => "1990", "#{field}(2i)" => " ", "#{field}(3i)" => "1" }
+    end
+
+    it { is_expected.to be_falsy }
+
+    it "adds an error" do
+      expect(date_form.errors[field.to_s]).to eq(
+        ["Enter a month for their #{field_name(field)}, formatted as a number"]
+      )
+    end
+  end
+
+  context "with a word as a month" do
+    let(:params) do
+      {
+        "#{field}(1i)" => "1990",
+        "#{field}(2i)" => "Potatoes",
+        "#{field}(3i)" => "1"
+      }
+    end
+
+    it { is_expected.to be_falsy }
+
+    it "adds an error" do
+      expect(date_form.errors[field.to_s]).to eq(
+        ["Enter a month for their #{field_name(field)}, formatted as a number"]
+      )
+    end
+  end
+end
+
+RSpec.shared_examples "form with a date of birth validator" do |field|
+  subject(:save) { date_form.save(params) }
+
+  let(:date_field) { referral.send(field) }
+
+  before { save }
+
+  context "when the date is in the future" do
+    let(:params) do
+      {
+        "#{field}(1i)" => 1.year.from_now.year,
+        "#{field}(2i)" => "01",
+        "#{field}(3i)" => "01"
+      }
+    end
+
+    it { is_expected.to be_falsy }
+
+    it "adds an error" do
+      expect(date_form.errors[field.to_s]).to eq(
+        ["Their #{field_name(field)} must be in the past"]
+      )
+    end
+  end
+
+  context "with a date less than 16 years ago" do
+    let(:params) do
+      {
+        "#{field}(1i)" => 15.years.ago.year,
+        "#{field}(2i)" => Time.zone.today.month,
+        "#{field}(3i)" => Time.zone.today.day
+      }
+    end
+
+    it { is_expected.to be_falsy }
+
+    it "adds an error" do
+      expect(date_form.errors[field.to_s]).to eq(
+        ["You must be 16 or over to use this service"]
+      )
+    end
+  end
+
+  context "with a date before 1900" do
+    let(:params) do
+      { "#{field}(1i)" => "1899", "#{field}(2i)" => "1", "#{field}(3i)" => "1" }
+    end
+
+    it { is_expected.to be_falsy }
+
+    it "adds an error" do
+      expect(date_form.errors[field.to_s]).to eq(
+        ["Enter a year later than 1900"]
+      )
+    end
+  end
+end
+
+def field_name(field)
+  field.humanize.downcase
+end


### PR DESCRIPTION
### Context

Date validation were being used in multiple places and more date inputs are going to be added to the app.

### Changes proposed in this pull request

Move validations for date and date of birth inputs into shared examples.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
