### PR TITLE
Screener content update - report/refer wording

### DIFF
--- a/app/views/pages/no_jurisdiction_unsupervised.html.erb
+++ b/app/views/pages/no_jurisdiction_unsupervised.html.erb
@@ -22,7 +22,7 @@
     </p>
     <h2 class="govuk-heading-m">Reporting someone who is not a teacher</h2>
     <p class="govuk_body">
-      You should <a href="https://www.gov.uk/report-teacher-misconduct">make an informal complaint</a> to start with. If you’re not happy with the response, you should [not sure where we direct people here].
+      You will need to <a href="https://www.gov.uk/report-teacher-misconduct">make an informal complaint</a>.
     </p>
   </div>
 </div>

--- a/app/views/pages/you_should_know.html.erb
+++ b/app/views/pages/you_should_know.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title, "What completing this report means for you" %>
+<% content_for :page_title, "What completing this referral means for you" %>
 <% content_for :back_link_url, serious_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">
-    <h1 class="govuk-heading-xl">What completing this report means for you</h1>
+    <h1 class="govuk-heading-xl">What completing this referral means for you</h1>
     <p class="govuk_body">
-      If TRA decide to investigate this allegation, it could result in the person you’re reporting being banned from teaching.
+      If TRA decide to investigate this allegation, it could result in the person you’re referring being banned from teaching.
     </p>
 
     <p class="govuk_body">
@@ -13,10 +13,10 @@
     </p>
 
     <p class="govuk_body">
-      Your name and the allegation will be shared with the person you’re reporting, and any employer. Your contact details will not be shared.
+      Your name and the allegation will be shared with the person you’re referring, and any employer. Your contact details will not be shared.
     </p>
 
-    <p class="govuk_body">A submitted report is kept for 50 years.</p>
+    <p class="govuk_body">Once a referral is submitted, it’s kept for 50 years.</p>
 
     <%= govuk_button_link_to 'Continue', @continue_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9' %>
   </div>

--- a/app/views/reporting_as/new.html.erb
+++ b/app/views/reporting_as/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, 'Are you reporting as an employer or member of the public?' %>
+<% content_for :page_title, 'Are you making a referral as an employer or member of the public?' %>
 <% content_for :back_link_url, start_path %>
 
 <div class="govuk-grid-row">
@@ -6,10 +6,10 @@
     <%= form_with model: @reporting_as_form, url: who_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(:reporting_as,
-        [OpenStruct.new(label: "I’m reporting as an employer", value: 'employer'), OpenStruct.new(label: "I’m reporting as a member of the public", value: 'public')],
+        [OpenStruct.new(label: "I’m referring as an employer", value: 'employer'), OpenStruct.new(label: "I’m referring as a member of the public", value: 'public')],
         :value,
         :label,
-        legend: { size: 'xl', text: 'Are you reporting as an employer or member of the public?' }
+        legend: { size: 'xl', text: 'Are you making a referral as an employer or member of the public?' }
       ) %>
       <%= f.govuk_submit prevent_double_click: false %>
     <% end %>

--- a/app/views/serious_misconduct/new.html.erb
+++ b/app/views/serious_misconduct/new.html.erb
@@ -23,7 +23,7 @@
           </span>
         </summary>
         <div class="govuk-details__text">
-          
+
           <p class="govuk_body">Examples might include:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>committing a criminal offence that results in imprisonment (including a suspended sentence)</li>
@@ -54,7 +54,7 @@
         <%= f.govuk_radio_button :serious_misconduct, "no", label: { text: "No" } %>
         <%= f.govuk_radio_button :serious_misconduct, "not_sure", label: { text: "I’m not sure" } do %>
           <p class="govuk_body">
-            If you’re not sure, please continue to report your allegation and the Teaching Regulation Agency will assess it.
+            If you’re not sure, you should continue to make a referral and TRA will assess it.
           </p>
         <% end %>
       <% end %>

--- a/app/views/teaching_in_england/new.html.erb
+++ b/app/views/teaching_in_england/new.html.erb
@@ -11,7 +11,7 @@
         <%= f.govuk_radio_button :teaching_in_england, "no", label: { text: "No" } %>
         <%= f.govuk_radio_button :teaching_in_england, "not_sure", label: { text: "I’m not sure" } do %>
           <p class="govuk_body">
-            If you’re not sure, please continue to report your allegation and the Teaching Regulation Agency will assess it.
+            If you’re not sure, you should continue to make a referral and TRA will assess it.
           </p>
         <% end %>
       <% end %>

--- a/app/views/unsupervised_teaching/new.html.erb
+++ b/app/views/unsupervised_teaching/new.html.erb
@@ -22,7 +22,7 @@
         <%= f.govuk_radio_button :unsupervised_teaching, "no", label: { text: "No" } %>
         <%= f.govuk_radio_button :unsupervised_teaching, "not_sure", label: { text: "I’m not sure" } do %>
           <p class="govuk_body">
-            If you’re not sure, please continue to report your allegation and the Teaching Regulation Agency will assess it.
+            If you’re not sure, you should continue to make a referral and TRA will assess it.
           </p>
         <% end %>
       <% end %>

--- a/spec/system/eligibility_screener_spec.rb
+++ b/spec/system/eligibility_screener_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Eligibility screener", type: :system do
 
     when_i_press_continue
     then_i_see_a_validation_error
-    when_i_choose_reporting_as_public
+    when_i_choose_referring_as_public
     when_i_press_continue
     then_i_see_the_have_you_complained_page
 
@@ -110,10 +110,10 @@ RSpec.feature "Eligibility screener", type: :system do
   def then_i_see_the_employer_or_public_question
     expect(page).to have_current_path("/who")
     expect(page).to have_title(
-      "Are you reporting as an employer or member of the public? - Refer serious misconduct by a teacher in England"
+      "Are you making a referral as an employer or member of the public?"
     )
     expect(page).to have_content(
-      "Are you reporting as an employer or member of the public?"
+      "Are you making a referral as an employer or member of the public?"
     )
   end
 
@@ -160,7 +160,7 @@ RSpec.feature "Eligibility screener", type: :system do
 
   def then_i_see_the_not_sure_hint
     expect(page).to have_content(
-      "If you’re not sure, please continue to report your allegation and the Teaching Regulation Agency will assess it."
+      "If you’re not sure, you should continue to make a referral and TRA will assess it."
     )
   end
 
@@ -203,9 +203,9 @@ RSpec.feature "Eligibility screener", type: :system do
   def then_i_see_the_you_should_know_page
     expect(page).to have_current_path("/you-should-know")
     expect(page).to have_title(
-      "What completing this report means for you - Refer serious misconduct by a teacher in England"
+      "What completing this referral means for you - Refer serious misconduct by a teacher in England"
     )
-    expect(page).to have_content("What completing this report means for you")
+    expect(page).to have_content("What completing this referral means for you")
   end
 
   def then_i_see_the_serious_misconduct_question
@@ -246,12 +246,12 @@ RSpec.feature "Eligibility screener", type: :system do
     choose "I’m not sure", visible: false
   end
 
-  def when_i_choose_reporting_as_an_employer
-    choose "I’m reporting as an employer", visible: false
+  def when_i_choose_referring_as_an_employer
+    choose "I’m referring as an employer", visible: false
   end
 
-  def when_i_choose_reporting_as_public
-    choose "I’m reporting as a member of the public", visible: false
+  def when_i_choose_referring_as_public
+    choose "I’m referring as a member of the public", visible: false
   end
 
   def when_i_choose_yes

--- a/spec/system/question_order_spec.rb
+++ b/spec/system/question_order_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "Question order", type: :system do
   end
 
   def when_i_choose_employer
-    choose "I’m reporting as an employer", visible: false
+    choose "I’m referring as an employer", visible: false
   end
 
   def when_i_choose_yes


### PR DESCRIPTION
Further content updates to the screener, replacing use of 'report' with 'refer'.

https://trello.com/c/0CGU6XOn