### PR TITLE
Add Redis dump.rdb to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .vscode
 config/master.key
 db/*.sqlite3
+dump.rdb
 node_modules
 public/assets
 storage/


### PR DESCRIPTION
Bit of housekeeping — this will get created when running redis-server, and shouldn't be committed.