### PR TITLE
Add a question about reported previous misconduct

### DIFF
--- a/app/controllers/referrals/previous_misconduct_reported_controller.rb
+++ b/app/controllers/referrals/previous_misconduct_reported_controller.rb
@@ -1,0 +1,36 @@
+module Referrals
+  class PreviousMisconductReportedController < BaseController
+    def edit
+      @previous_misconduct_reported_form =
+        PreviousMisconductReportedForm.new(referral: current_referral)
+    end
+
+    def update
+      @previous_misconduct_reported_form =
+        PreviousMisconductReportedForm.new(
+          previous_misconduct_reported_form_params.merge(
+            referral: current_referral
+          )
+        )
+      if @previous_misconduct_reported_form.save
+        if current_referral.previous_misconduct_reported?
+          redirect_to edit_referral_previous_misconduct_summary_path(
+                        current_referral
+                      )
+        else
+          redirect_to referral_previous_misconduct_path(current_referral)
+        end
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def previous_misconduct_reported_form_params
+      params.require(:previous_misconduct_reported_form).permit(
+        :previous_misconduct_reported
+      )
+    end
+  end
+end

--- a/app/forms/previous_misconduct_reported_form.rb
+++ b/app/forms/previous_misconduct_reported_form.rb
@@ -1,0 +1,23 @@
+class PreviousMisconductReportedForm
+  include ActiveModel::Model
+
+  attr_accessor :referral
+  attr_writer :previous_misconduct_reported
+
+  validates :referral, presence: true
+  validates :previous_misconduct_reported,
+            inclusion: {
+              in: %w[true false i_dont_know]
+            }
+
+  def previous_misconduct_reported
+    @previous_misconduct_reported || referral&.previous_misconduct_reported
+  end
+
+  def save
+    return false unless valid?
+
+    referral.previous_misconduct_reported = previous_misconduct_reported
+    referral.save
+  end
+end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -85,7 +85,7 @@ class ReferralForm
         ),
         ReferralSectionItem.new(
           I18n.t("referral_form.previous_allegations"),
-          edit_referral_previous_misconduct_summary_path(referral),
+          edit_referral_previous_misconduct_reported_path(referral),
           referral.previous_misconduct_status
         ),
         ReferralSectionItem.new(

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,4 +68,10 @@ module ApplicationHelper
       end
     end
   end
+
+  def humanize_three_way_choice(choice)
+    { "true" => "Yes", "false" => "No", "i_dont_know" => "I don’t know" }[
+      choice
+    ]
+  end
 end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -10,6 +10,12 @@ class Referral < ApplicationRecord
     organisation.status
   end
 
+  def previous_misconduct_reported?
+    return true if previous_misconduct_reported == "true"
+
+    false
+  end
+
   def previous_misconduct_status
     return :complete if previous_misconduct_completed_at.present?
     return :incomplete if previous_misconduct_deferred_at.present?

--- a/app/views/referrals/previous_misconduct/show.html.erb
+++ b/app/views/referrals/previous_misconduct/show.html.erb
@@ -13,13 +13,22 @@
     <% rows = [
       {
         actions: [
+          { text: "Change", href: edit_referral_previous_misconduct_reported_path(current_referral), visually_hidden_text: "reported" },
+
+        ],
+        key: { text: "Has there been any previous misconduct?" },
+        value: { text: humanize_three_way_choice(current_referral.previous_misconduct_reported) },
+      }
+    ] %>
+    <% rows << {
+        actions: [
           { text: "Change", href: edit_referral_previous_misconduct_summary_path(current_referral), visually_hidden_text: "summary" },
 
         ],
         key: { text: "Summary" },
         value: { text: current_referral.previous_misconduct_summary },
-      },
-    ] %>
+      } if current_referral.previous_misconduct_reported?
+    %>
     <%= render(SummaryCardComponent.new(rows:)) do %>
       <%= render SummaryCardHeaderComponent.new(title: 'Previous allegations') %>
     <% end %>

--- a/app/views/referrals/previous_misconduct_reported/edit.html.erb
+++ b/app/views/referrals/previous_misconduct_reported/edit.html.erb
@@ -1,0 +1,32 @@
+<% content_for :page_title, "#{'Error: ' if @previous_misconduct_reported_form.errors.any?}Has there been any previous misconduct, disciplinary action or complaints?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @previous_misconduct_reported_form, url: referral_previous_misconduct_reported_url(current_referral), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_collection_radio_buttons(
+          :previous_misconduct_reported, 
+          [
+            OpenStruct.new(label: 'Yes', value: 'true'), 
+            OpenStruct.new(label: 'No', value: 'false'), 
+            OpenStruct.new(label: 'I don’t know', value: 'i_dont_know')
+          ],
+          :value, :label,
+          legend: { text: "Has there been any previous misconduct, disciplinary action or complaints?", size: "xl" }, 
+          hint: -> do %>
+            <p class="govuk-body">This includes:</p>
+            <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+              <li>internal investigations</li>
+              <li>disciplinary action by your organisation</li>
+              <li>reports to the Teaching Regulation Agency, National College for Teaching and Leadership, Teaching Agency or General Teaching Council for England</li>
+            </ul>
+          <% end
+        ) %>
+      </div>
+      <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,11 @@ en:
           attributes:
             complete:
               inclusion: Tell us if you have completed this section
+        previous_misconduct_reported_form:
+          attributes:
+            previous_misconduct_reported:
+              inclusion: Let us know if there has been any previous misconduct, disciplinary action or complaints
+
         previous_misconduct_summary_form:
           attributes:
             summary:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,10 @@ Rails.application.routes.draw do
              only: %i[show update],
              controller: "referrals/previous_misconduct"
 
+    resource :previous_misconduct_reported,
+             only: %i[edit update],
+             controller: "referrals/previous_misconduct_reported"
+
     resource :previous_misconduct_summary,
              only: %i[edit update],
              controller: "referrals/previous_misconduct_summary"

--- a/db/migrate/20221117125457_add_previous_misconduct_reported_to_referral.rb
+++ b/db/migrate/20221117125457_add_previous_misconduct_reported_to_referral.rb
@@ -1,0 +1,5 @@
+class AddPreviousMisconductReportedToReferral < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrals, :previous_misconduct_reported, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_17_104316) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_17_125457) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -109,6 +109,7 @@ unique: true
     t.datetime "previous_misconduct_completed_at", precision: nil
     t.datetime "previous_misconduct_deferred_at", precision: nil
     t.text "previous_misconduct_summary"
+    t.string "previous_misconduct_reported"
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 

--- a/spec/forms/previous_misconduct_reported_form_spec.rb
+++ b/spec/forms/previous_misconduct_reported_form_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe PreviousMisconductReportedForm, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:referral) }
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    let(:referral) { build(:referral) }
+    let(:form) { described_class.new(referral:, previous_misconduct_reported:) }
+    let(:previous_misconduct_reported) { "true" }
+
+    it { is_expected.to be_truthy }
+
+    context "when previous_misconduct_reported is blank" do
+      let(:previous_misconduct_reported) { "" }
+
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:referral) { build(:referral) }
+    let(:form) do
+      described_class.new(referral:, previous_misconduct_reported: "true")
+    end
+
+    it "saves the Referral" do
+      save
+      expect(referral.previous_misconduct_reported).to be_truthy
+    end
+  end
+end

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -69,4 +69,32 @@ RSpec.describe Referral, type: :model do
       it { is_expected.to eq(:complete) }
     end
   end
+
+  describe "#previous_misconduct_reported?" do
+    subject { referral.previous_misconduct_reported? }
+
+    let(:referral) { build(:referral) }
+
+    it { is_expected.to be_falsey }
+
+    context "when previous_misconduct_reported is true" do
+      let(:referral) { build(:referral, previous_misconduct_reported: "true") }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when previous_misconduct_reported is false" do
+      let(:referral) { build(:referral, previous_misconduct_reported: "false") }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when previous_misconduct_reported is i_dont_know" do
+      let(:referral) do
+        build(:referral, previous_misconduct_reported: "i_dont_know")
+      end
+
+      it { is_expected.to be_falsey }
+    end
+  end
 end

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -8,6 +8,22 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
     and_i_have_an_existing_referral
     and_i_am_on_the_referral_summary_page
     when_i_click_on_previous_misconduct
+    then_i_see_the_previous_misconduct_reported_page
+
+    when_i_click_save_and_continue
+    then_i_see_the_missing_reported_error
+
+    when_i_choose_no
+    and_i_click_save_and_continue
+    then_i_see_the_previous_misconduct_page
+    and_i_see_no_previous_misconduct_reported
+
+    when_i_click_change_previous_misconduct_reported
+    then_i_see_the_previous_misconduct_reported_page
+    and_i_see_no_previous_misconduct_is_prefilled
+
+    when_i_choose_yes
+    and_i_click_save_and_continue
     then_i_see_the_previous_misconduct_summary_page
 
     when_i_click_save_and_continue
@@ -52,6 +68,14 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
     @referral = create(:referral, user: @user)
   end
 
+  def and_i_see_no_previous_misconduct_is_prefilled
+    expect(page).to have_checked_field("No", visible: false)
+  end
+
+  def and_i_see_no_previous_misconduct_reported
+    expect(page).to have_content("No")
+  end
+
   def and_i_see_previous_misconduct_flagged_as_complete
     within(".app-task-list__item", text: "Previous allegations") do
       status_tag = find(".app-task-list__tag")
@@ -86,9 +110,28 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
     expect(page).to have_current_path(edit_referral_path(@referral))
   end
 
+  def then_i_see_the_previous_misconduct_reported_page
+    expect(page).to have_current_path(
+      edit_referral_previous_misconduct_reported_path(@referral)
+    )
+    expect(page).to have_title(
+      "Has there been any previous misconduct, disciplinary action or complaints? - Refer " \
+        "serious misconduct by a teacher in England"
+    )
+    expect(page).to have_content(
+      "Has there been any previous misconduct, disciplinary action or complaints?"
+    )
+  end
+
   def then_i_see_the_previous_misconduct_summary_page
     expect(page).to have_current_path(
       edit_referral_previous_misconduct_summary_path(@referral)
+    )
+  end
+
+  def then_i_see_the_missing_reported_error
+    expect(page).to have_content(
+      "Let us know if there has been any previous misconduct, disciplinary action or complaints"
     )
   end
 
@@ -101,8 +144,20 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
     expect(page).to have_content("Previous allegations")
   end
 
+  def when_i_choose_no
+    choose "No", visible: false
+  end
+
   def when_i_choose_no_come_back_later
     choose "No, I’ll come back to it later", visible: false
+  end
+
+  def when_i_choose_yes
+    choose "Yes", visible: false
+  end
+
+  def when_i_click_change_previous_misconduct_reported
+    click_on "Change reported"
   end
 
   def when_i_click_on_previous_misconduct


### PR DESCRIPTION
There is a question in the previous misconduct flow that asks if any
previous misconduct has been reported in the past.

This implements that question.

It follows a similar pattern to the other boolean style questions.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="993" alt="Screenshot 2022-11-17 at 2 11 07 pm" src="https://user-images.githubusercontent.com/3126/202468682-c4858c74-bd75-41f3-a3cf-f389eceff264.png">
<img width="1017" alt="Screenshot 2022-11-17 at 2 11 16 pm" src="https://user-images.githubusercontent.com/3126/202468688-f1932723-bde9-4e6a-a36c-5532ca87821b.png">
