### PR TITLE
Add OTP validations and guess limit

### DIFF
--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -25,6 +25,7 @@ class Users::OtpController < DeviseController
       sign_in(resource_name, resource)
       yield resource if block_given?
       redirect_to after_sign_in_path_for(resource)
+      resource.after_successful_otp_authentication
     elsif @otp_form.maximum_guesses?
       @otp_form.user.after_failed_otp_authentication
       flash[:warning] = "Please try signing in again"

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -25,6 +25,10 @@ class Users::OtpController < DeviseController
       sign_in(resource_name, resource)
       yield resource if block_given?
       redirect_to after_sign_in_path_for(resource)
+    elsif @otp_form.maximum_guesses?
+      @otp_form.user.after_failed_otp_authentication
+      flash[:warning] = "Please try signing in again"
+      redirect_to new_user_session_path
     else
       render :new
     end

--- a/app/forms/users/otp_form.rb
+++ b/app/forms/users/otp_form.rb
@@ -1,4 +1,5 @@
 class Users::OtpForm
+  MAX_GUESSES = 5
   include ActiveModel::Model
 
   attr_accessor :otp, :id
@@ -9,7 +10,15 @@ class Users::OtpForm
 
   def expected_otp_submitted
     expected_otp = Devise::Otp.derive_otp(user.secret_key)
-    errors.add(:otp, "Enter a correct security code") unless otp == expected_otp
+
+    if otp != expected_otp
+      errors.add(:otp, "Enter a correct security code")
+      user.increment!(:otp_guesses)
+    end
+  end
+
+  def maximum_guesses?
+    user.otp_guesses >= MAX_GUESSES
   end
 
   def user

--- a/app/forms/users/otp_form.rb
+++ b/app/forms/users/otp_form.rb
@@ -1,0 +1,22 @@
+class Users::OtpForm
+  include ActiveModel::Model
+
+  attr_accessor :otp, :id
+  attr_writer :email
+
+  validates :otp, length: { minimum: 6, maximum: 6, allow_blank: true }
+  validate :expected_otp_submitted
+
+  def expected_otp_submitted
+    expected_otp = Devise::Otp.derive_otp(user.secret_key)
+    errors.add(:otp, "Enter a correct security code") unless otp == expected_otp
+  end
+
+  def user
+    @user ||= User.find(id)
+  end
+
+  def email
+    @email ||= user.email
+  end
+end

--- a/app/lib/devise/strategies/otp_authenticatable.rb
+++ b/app/lib/devise/strategies/otp_authenticatable.rb
@@ -24,8 +24,6 @@ class Devise::Strategies::OtpAuthenticatable < Devise::Strategies::Authenticatab
       return
     end
 
-    # TODO: handle expired OTPs
-
     unless Devise::Otp.valid?(resource.secret_key, otp)
       fail!(:otp_invalid)
       return

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,14 @@ class User < ApplicationRecord
   end
 
   def after_failed_otp_authentication
+    clear_otp_state
+  end
+
+  def after_successful_otp_authentication
+    clear_otp_state
+  end
+
+  def clear_otp_state
     update(secret_key: nil, otp_guesses: nil)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ApplicationRecord
   def latest_referral
     referrals.order(created_at: :desc).first
   end
+
+  def after_failed_otp_authentication
+    update(secret_key: nil, otp_guesses: nil)
+  end
 end

--- a/app/views/users/otp/new.html.erb
+++ b/app/views/users/otp/new.html.erb
@@ -6,9 +6,10 @@
       <%= "Expected OTP: #{@derived_otp}" %>
     <% end %>
 
-    <%= form_for(resource, as: resource_name, url: user_otp_path, method: :post) do |f| %>
-      <%= f.hidden_field :email, value: resource.email %>
-      <h3><%= resource.email %></h3>
+    <%= form_with(model: @otp_form, scope: resource_name, url: user_otp_path, method: :post) do |f| %>
+      <%= f.hidden_field :id, value: @otp_form.id %>
+      <%= f.hidden_field :email, value: @otp_form.email %>
+      <h3><%= @otp_form.email %></h3>
 
       <%= f.govuk_text_field :otp, size: 'm', label: { text: "Enter your code" }, class: 'govuk-!-width-one-quarter' %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,11 @@ en:
           attributes:
             unsupervised_teaching:
               blank: Tell us if they were teaching unsupervised
+        "users/otp_form":
+          attributes:
+            otp:
+              too_short: "You’ve not entered enough numbers, the code must be 6 numbers"
+              too_long: "You’ve entered too many numbers, the code must be 6 numbers"
         "referrals/personal_details/age_form":
           attributes:
             date_of_birth:

--- a/db/migrate/20221117142815_add_otp_guesses_to_users.rb
+++ b/db/migrate/20221117142815_add_otp_guesses_to_users.rb
@@ -1,0 +1,5 @@
+class AddOtpGuessesToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :otp_guesses, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_17_125457) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_17_142815) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -175,6 +175,7 @@ unique: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "secret_key"
+    t.integer "otp_guesses"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,4 +23,15 @@ RSpec.describe User, type: :model do
       expect(user.otp_guesses).to be_nil
     end
   end
+
+  describe "#after_successful_otp_authentication" do
+    it "clears OTP-related fields" do
+      user = create(:user, secret_key: "some_key", otp_guesses: 3)
+
+      user.after_successful_otp_authentication
+
+      expect(user.secret_key).to be_nil
+      expect(user.otp_guesses).to be_nil
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,4 +12,15 @@ RSpec.describe User, type: :model do
       expect(user.latest_referral).to eq expected_referral
     end
   end
+
+  describe "#after_failed_otp_authentication" do
+    it "clears OTP-related fields" do
+      user = create(:user, secret_key: "some_key", otp_guesses: 3)
+
+      user.after_failed_otp_authentication
+
+      expect(user.secret_key).to be_nil
+      expect(user.otp_guesses).to be_nil
+    end
+  end
 end

--- a/spec/system/user_auth/user_reaches_max_otp_guesses_spec.rb
+++ b/spec/system/user_auth/user_reaches_max_otp_guesses_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 RSpec.feature "User accounts" do
   scenario "User signs in" do
     given_the_service_is_open
+    and_the_eligibility_screener_is_enabled
     and_the_employer_form_feature_is_active
     and_the_user_accounts_feature_is_active
 
@@ -14,6 +15,10 @@ RSpec.feature "User accounts" do
 
   def given_the_service_is_open
     FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_the_eligibility_screener_is_enabled
+    FeatureFlags::FeatureFlag.activate(:eligibility_screener)
   end
 
   def and_the_employer_form_feature_is_active

--- a/spec/system/user_auth/user_reaches_max_otp_guesses_spec.rb
+++ b/spec/system/user_auth/user_reaches_max_otp_guesses_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "User accounts" do
+  scenario "User signs in" do
+    given_the_service_is_open
+    and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
+
+    when_i_start_the_signin_flow
+    and_max_out_my_otp_guesses
+    then_i_am_sent_back_to_the_email_screen_with_an_error
+  end
+
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_the_employer_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
+  end
+
+  def when_i_start_the_signin_flow
+    visit root_path
+    click_on "Start now"
+    fill_in "Enter your email address", with: "test@example.com"
+    click_on "Send code"
+  end
+
+  def and_max_out_my_otp_guesses
+    Users::OtpForm::MAX_GUESSES.times do
+      fill_in "Enter your code", with: "123456"
+      within("main") { click_on "Sign in" }
+    end
+  end
+
+  def then_i_am_sent_back_to_the_email_screen_with_an_error
+    expect(page).to have_content "Enter your email address"
+    expect(page).to have_content "Please try signing in again"
+  end
+
+  def and_my_otp_state_is_reset
+    user = User.last
+    expect(user.secret_key).to be_nil
+    expect(user.otp_guesses).to be_nil
+  end
+end

--- a/spec/system/user_auth/user_signs_in_spec.rb
+++ b/spec/system/user_auth/user_signs_in_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature "User accounts" do
     when_i_provide_the_expected_otp
     then_i_am_signed_in
     and_i_am_not_prompted_to_sign_in_again
+    and_my_otp_state_is_reset
 
     when_i_have_a_referral_in_progress
     and_i_sign_out
@@ -137,5 +138,11 @@ RSpec.feature "User accounts" do
     expect(page).to have_current_path(
       referrals_edit_contact_details_email_path(@referral)
     )
+  end
+
+  def and_my_otp_state_is_reset
+    user = User.last
+    expect(user.secret_key).to be_nil
+    expect(user.otp_guesses).to be_nil
   end
 end

--- a/spec/system/user_auth/user_signs_in_spec.rb
+++ b/spec/system/user_auth/user_signs_in_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature "User accounts" do
 
   def then_i_see_an_error_about_otp_length
     expect(
-      page,
+      page
     ).to have_content "You’ve not entered enough numbers, the code must be 6 numbers"
   end
 
@@ -135,7 +135,7 @@ RSpec.feature "User accounts" do
 
   def then_i_see_my_current_page_before_logging_in
     expect(page).to have_current_path(
-      referrals_edit_contact_details_email_path(@referral),
+      referrals_edit_contact_details_email_path(@referral)
     )
   end
 end

--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -12,10 +12,11 @@ RSpec.feature "User accounts" do
     when_i_visit_the_root_page
     and_click_start_now
     and_i_submit_my_email
+    when_i_provide_a_short_otp
+    then_i_see_an_error_about_otp_length
     when_i_provide_the_wrong_otp
-    then_i_see_an_error
-    when_i_submit_my_email
-    and_i_provide_the_expected_otp
+    then_i_see_an_error_about_a_wrong_code
+    when_i_provide_the_expected_otp
     then_i_am_signed_in
     and_i_am_not_prompted_to_sign_in_again
 
@@ -27,7 +28,7 @@ RSpec.feature "User accounts" do
     when_i_am_signed_out
     and_i_visit_a_page
     and_i_submit_my_email
-    and_i_provide_the_expected_otp
+    when_i_provide_the_expected_otp
     then_i_see_my_current_page_before_logging_in
   end
 
@@ -67,16 +68,27 @@ RSpec.feature "User accounts" do
   end
   alias_method :when_i_submit_my_email, :and_i_submit_my_email
 
-  def when_i_provide_the_wrong_otp
-    fill_in "Enter your code", with: "wrong_value"
+  def when_i_provide_a_short_otp
+    fill_in "Enter your code", with: "123"
     within("main") { click_on "Sign in" }
   end
 
-  def then_i_see_an_error
-    expect(page).to have_content "Invalid code"
+  def when_i_provide_the_wrong_otp
+    fill_in "Enter your code", with: "123456"
+    within("main") { click_on "Sign in" }
   end
 
-  def and_i_provide_the_expected_otp
+  def then_i_see_an_error_about_otp_length
+    expect(
+      page,
+    ).to have_content "You’ve not entered enough numbers, the code must be 6 numbers"
+  end
+
+  def then_i_see_an_error_about_a_wrong_code
+    expect(page).to have_content "Enter a correct security code"
+  end
+
+  def when_i_provide_the_expected_otp
     perform_enqueued_jobs
 
     user = User.find_by(email: "test@example.com")
@@ -110,7 +122,7 @@ RSpec.feature "User accounts" do
   def when_i_sign_back_in
     within(".govuk-header") { click_on "Sign in" }
     and_i_submit_my_email
-    and_i_provide_the_expected_otp
+    when_i_provide_the_expected_otp
   end
 
   def then_i_see_my_referral
@@ -123,7 +135,7 @@ RSpec.feature "User accounts" do
 
   def then_i_see_my_current_page_before_logging_in
     expect(page).to have_current_path(
-      referrals_edit_contact_details_email_path(@referral)
+      referrals_edit_contact_details_email_path(@referral),
     )
   end
 end


### PR DESCRIPTION
### Context

For user sign in, currently we redirect the user back to the email page on an incorrect guess. We also don't limit the number of attempts.
https://trello.com/c/kV9YjeYJ
### Changes proposed in this pull request

- Add validations around OTP length and correctness
- Limit the number of guesses to 5 before sending the user back to the email screen

### Guidance to review

Can be tested locally with the `user_accounts` feature flag switched on.

### Checklist

- [x] Attach to Trello card
- [ ] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
