### PR TITLE
Set the service launch date

### DIFF
--- a/app/models/performance_stats.rb
+++ b/app/models/performance_stats.rb
@@ -29,7 +29,13 @@ class PerformanceStats
               incomplete_count: 0
             }
         date_string =
-          day == Time.current ? "Today" : day.to_fs(:weekday_day_and_month)
+          (
+            if day == Time.current.beginning_of_day
+              "Today"
+            else
+              day.to_fs(:weekday_day_and_month)
+            end
+          )
 
         [date_string, requests]
       end
@@ -109,9 +115,9 @@ class PerformanceStats
           "unsupervised_teaching = 'no' then 1 else 0 end) as screened_out_count"
       ),
       Arel.sql(
-        "sum(case when (is_teacher is null or teaching_in_england is null or unsupervised_teaching is null or " \
-          "serious_misconduct is null) and (teaching_in_england <> 'no' or unsupervised_teaching <> 'no' " \
-          "or serious_misconduct <> 'no') then 1 else 0 end) as incomplete_count"
+        "sum(case when serious_misconduct is null and (teaching_in_england is null or teaching_in_england " \
+          "<> 'no') and (unsupervised_teaching is null or unsupervised_teaching <> 'no')" \
+          " then 1 else 0 end) as incomplete_count"
       ),
       Arel.sql("count(*) as total")
     ]

--- a/spec/models/performance_stats_spec.rb
+++ b/spec/models/performance_stats_spec.rb
@@ -7,19 +7,23 @@ RSpec.describe PerformanceStats, type: :model do
     let(:performance_stats) { described_class.new }
 
     before do
+      travel_to Time.zone.local(2022, 11, 22, 12, 0, 0)
       create(:eligibility_check, :complete)
       create(:eligibility_check, :not_unsupervised)
       create(:eligibility_check)
+      travel_to Time.zone.local(2022, 11, 29, 12, 0, 0)
     end
+
+    after { travel_back }
 
     it "returns the request counts for the last 8 days" do
       expect(request_counts_by_day.size).to eq(8)
     end
 
     it "returns the correct number of requests for today" do
-      expect(request_counts_by_day.first).to eq(
+      expect(request_counts_by_day.last).to eq(
         [
-          Time.current.to_fs(:weekday_day_and_month),
+          7.days.ago.to_fs(:weekday_day_and_month),
           {
             complete_count: 1,
             screened_out_count: 1,
@@ -66,6 +70,7 @@ RSpec.describe PerformanceStats, type: :model do
         create(:eligibility_check, :complete)
         create(:eligibility_check, :not_unsupervised)
         create(:eligibility_check)
+        create(:eligibility_check, is_teacher: "yes")
       end
 
       it "returns the totals for the period" do
@@ -73,8 +78,8 @@ RSpec.describe PerformanceStats, type: :model do
           {
             complete_count: 1,
             screened_out_count: 1,
-            incomplete_count: 1,
-            total: 3
+            incomplete_count: 2,
+            total: 4
           }
         )
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,6 +84,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include ViewComponent::TestHelpers, type: :component
   config.include ActiveJob::TestHelper
+  config.include ActiveSupport::Testing::TimeHelpers
 
   Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 end


### PR DESCRIPTION
We know the launch date of the service now, so can set the value for the
performance stats page.

The tests fail with the change of date, so I added the Rails time helpers
to ensure we can deterministically test the stats.

The performance stats are incorrectly calculating the incomplete
screener journeys.

Also, there is a bug in calculating the 'Today' value. It is being
compared against a different time of day, meaning it will never match.

Assumptions:
* a value for serious_misconduct is the key around determining
  whether the journey was complete
* the screened out questions should not be null or 'no' to count towards
  an incomplete journey

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
