### PR TITLE
About their role forms - Add job title page

### DIFF
--- a/app/controllers/referrals/teacher_role/employment_status_controller.rb
+++ b/app/controllers/referrals/teacher_role/employment_status_controller.rb
@@ -18,8 +18,7 @@ module Referrals
           )
 
         if @employment_status_form.save(end_date_params)
-          # TODO: redirect to job title page
-          redirect_to edit_referral_path(current_referral)
+          redirect_to referrals_edit_teacher_job_title_path(current_referral)
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/job_title_controller.rb
+++ b/app/controllers/referrals/teacher_role/job_title_controller.rb
@@ -1,0 +1,32 @@
+module Referrals
+  module TeacherRole
+    class JobTitleController < Referrals::BaseController
+      def edit
+        @job_title_form =
+          JobTitleForm.new(
+            referral: current_referral,
+            job_title: current_referral.job_title
+          )
+      end
+
+      def update
+        @job_title_form =
+          JobTitleForm.new(job_title_params.merge(referral: current_referral))
+
+        if @job_title_form.save
+          redirect_to edit_referral_path(current_referral)
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def job_title_params
+        params.require(:referrals_teacher_role_job_title_form).permit(
+          :job_title
+        )
+      end
+    end
+  end
+end

--- a/app/forms/referrals/teacher_role/employment_status_form.rb
+++ b/app/forms/referrals/teacher_role/employment_status_form.rb
@@ -38,7 +38,6 @@ module Referrals
           role_end_date:,
           reason_leaving_role:
         )
-        true
       end
 
       private

--- a/app/forms/referrals/teacher_role/job_title_form.rb
+++ b/app/forms/referrals/teacher_role/job_title_form.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module Referrals
+  module TeacherRole
+    class JobTitleForm
+      include ActiveModel::Model
+
+      attr_accessor :referral, :job_title
+
+      validates :referral, presence: true
+      validates :job_title, presence: true
+
+      def save
+        return false if invalid?
+
+        referral.update(job_title:)
+      end
+    end
+  end
+end

--- a/app/forms/referrals/teacher_role/start_date_form.rb
+++ b/app/forms/referrals/teacher_role/start_date_form.rb
@@ -24,7 +24,6 @@ module Referrals
         end
 
         referral.update(role_start_date:, role_start_date_known:)
-        true
       end
     end
   end

--- a/app/views/referrals/teacher_role/job_title/edit.html.erb
+++ b/app/views/referrals/teacher_role/job_title/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, "#{'Error: ' if @job_title_form.errors.any?}What’s their job title?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <%= form_with model: @job_title_form, url: referrals_update_teacher_job_title_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field :job_title,
+        label: { text: "What’s their job title?", size: "xl" },
+        hint: { text: "For example, ‘Teacher’" }
+      %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,6 +150,10 @@ en:
               missing_day: Enter a day for their role end date, formatted as a number
               missing_month: Enter a month for their role end date, formatted as a number
               missing_year: Enter a year with 4 digits
+        "referrals/teacher_role/job_title_form":
+          attributes:
+            job_title:
+              blank: Enter their job title
         referrer_job_title_form:
           attributes:
             job_title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,6 +202,12 @@ Rails.application.routes.draw do
     put "/:referral_id/teacher-role/employment-status",
         to: "teacher_role/employment_status#update",
         as: "update_teacher_employment_status"
+    get "/:referral_id/teacher-role/job-title",
+        to: "teacher_role/job_title#edit",
+        as: "edit_teacher_job_title"
+    put "/:referral_id/teacher-role/job-title",
+        to: "teacher_role/job_title#update",
+        as: "update_teacher_job_title"
   end
 
   get "/performance", to: "performance#index"

--- a/db/migrate/20221118125850_add_job_title_to_referral.rb
+++ b/db/migrate/20221118125850_add_job_title_to_referral.rb
@@ -1,0 +1,5 @@
+class AddJobTitleToReferral < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrals, :job_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_17_142815) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_18_125850) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -113,6 +113,7 @@ unique: true
     t.string "employment_status"
     t.date "role_end_date"
     t.string "reason_leaving_role"
+    t.string "job_title"
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 

--- a/spec/forms/referrals/teacher_role/job_title_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/job_title_form_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Referrals::TeacherRole::JobTitleForm, type: :model do
+  let(:referral) { build(:referral) }
+
+  subject(:form) { described_class.new(referral:, job_title:) }
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    before { valid }
+
+    context "when job_title is not blank" do
+      let(:job_title) { "Teacher" }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when job_title is blank" do
+      let(:job_title) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:job_title]).to eq(["Enter their job title"])
+      end
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    before { save }
+
+    context "when job_title is present" do
+      let(:job_title) { "Teacher" }
+
+      it { is_expected.to be_truthy }
+
+      it "saves job_title" do
+        expect(referral.job_title).to eq("Teacher")
+      end
+    end
+
+    context "when job_title is blank" do
+      let(:job_title) { "" }
+
+      it { is_expected.to be_falsy }
+    end
+  end
+end

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -38,12 +38,12 @@ RSpec.feature "Teacher role", type: :system do
 
     when_i_choose_yes
     and_i_click_save_and_continue
-    then_i_see_the_referral_summary
+    then_i_see_the_job_title_page
 
     when_i_visit_the_employment_status_page
     when_i_choose_employed
     and_i_click_save_and_continue
-    then_i_see_the_referral_summary
+    then_i_see_the_job_title_page
 
     when_i_visit_the_employment_status_page
     when_i_choose_left
@@ -54,13 +54,20 @@ RSpec.feature "Teacher role", type: :system do
     when_i_choose_left
     when_i_choose_resigned
     and_i_click_save_and_continue
-    then_i_see_the_referral_summary
+    then_i_see_the_job_title_page
 
     when_i_visit_the_employment_status_page
     when_i_choose_left
     when_i_fill_out_the_role_end_date_fields
     when_i_choose_resigned
     and_i_click_save_and_continue
+    then_i_see_the_job_title_page
+
+    when_i_click_save_and_continue
+    then_i_see_job_title_field_validation_errors
+
+    when_i_fill_in_the_job_title_field
+    when_i_click_save_and_continue
     then_i_see_the_referral_summary
   end
 
@@ -88,6 +95,10 @@ RSpec.feature "Teacher role", type: :system do
     visit referrals_edit_teacher_employment_status_path(@referral)
   end
 
+  def when_i_visit_the_job_title_page
+    visit referrals_edit_teacher_job_title_path(@referral)
+  end
+
   def when_i_edit_teacher_role_details
     within(all(".app-task-list__section")[1]) { click_on "About their role" }
   end
@@ -111,6 +122,14 @@ RSpec.feature "Teacher role", type: :system do
     )
     expect(page).to have_title("Are they still employed in that job?")
     expect(page).to have_content("Are they still employed in that job?")
+  end
+
+  def then_i_see_the_job_title_page
+    expect(page).to have_current_path(
+      "/referrals/#{@referral.id}/teacher-role/job-title"
+    )
+    expect(page).to have_title("What’s their job title?")
+    expect(page).to have_content("What’s their job title?")
   end
 
   def and_i_click_save_and_continue
@@ -172,5 +191,13 @@ RSpec.feature "Teacher role", type: :system do
     expect(page).to have_content(
       "Enter their role end date in the correct format"
     )
+  end
+
+  def then_i_see_job_title_field_validation_errors
+    expect(page).to have_content("Enter their job title")
+  end
+
+  def when_i_fill_in_the_job_title_field
+    fill_in "What’s their job title?", with: "Teacher"
   end
 end


### PR DESCRIPTION
### Context

Employer can add the job title of the person they are referring.
An error message will be shown when trying to submit a blank value.

https://trello.com/c/1S0zRnDB/958-about-their-role-forms-add-job-title-page
https://teacher-misconduct.herokuapp.com/report/teacher-role/job-title

### Changes proposed in this pull request

Adds the following page:
<img width="701" alt="Screenshot 2022-11-21 at 11 18 11" src="https://user-images.githubusercontent.com/1636476/203037601-d826af9e-dd6a-47a8-844c-6395b4601531.png">


- Update the routes
- Generate a migration for adding the job title field to the referrals table.
- Add the form, including validation
- Link the form to the employment status page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
