### PR TITLE
Update the static pages

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -36,7 +36,7 @@
       <%= govuk_back_link(href: yield(:back_link_url)) if content_for?(:back_link_url) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= render(FlashMessageComponent.new(flash: flash)) %>
-        <%= yield %>
+        <%= yield :content %>
       </main>
     </div>
 

--- a/app/views/static/accessibility.html.md
+++ b/app/views/static/accessibility.html.md
@@ -82,9 +82,12 @@ this service.
 This accessibility statement will be updated based on any issues we identify or
 any changes we make to address any issues raised.
 
+We're also planning a full accessibility audit on the service by the Digital
+Accessibility Centre (DAC) before March 2023.
+
 ## Preparation of this accessibility statement
 
-This statement was prepared on Tuesday 25 October 2022. It was last reviewed on
-Wednesday 26 October 2022.
+This statement was prepared on Monday 21 November 2022. It was last reviewed on
+Monday 21 November 2022.
 
-Last updated: Wednesday 26 October 2022
+Last updated: Monday 21 November 2022


### PR DESCRIPTION
The static pages should use the two thirds width styling to stay
consistent with the rest of the service.

This also ensures the prepared and last reviewed dates are correct.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
