### PR TITLE
About their role forms - Add same organisation page

### DIFF
--- a/app/controllers/referrals/teacher_role/job_title_controller.rb
+++ b/app/controllers/referrals/teacher_role/job_title_controller.rb
@@ -14,7 +14,9 @@ module Referrals
           JobTitleForm.new(job_title_params.merge(referral: current_referral))
 
         if @job_title_form.save
-          redirect_to edit_referral_path(current_referral)
+          redirect_to referrals_edit_teacher_same_organisation_path(
+                        current_referral
+                      )
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/same_organisation_controller.rb
+++ b/app/controllers/referrals/teacher_role/same_organisation_controller.rb
@@ -1,0 +1,34 @@
+module Referrals
+  module TeacherRole
+    class SameOrganisationController < Referrals::BaseController
+      def edit
+        @same_organisation_form =
+          SameOrganisationForm.new(
+            referral: current_referral,
+            same_organisation: current_referral.same_organisation
+          )
+      end
+
+      def update
+        @same_organisation_form =
+          SameOrganisationForm.new(
+            same_organisation_params.merge(referral: current_referral)
+          )
+
+        if @same_organisation_form.save
+          redirect_to edit_referral_path(current_referral)
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def same_organisation_params
+        params.require(:referrals_teacher_role_same_organisation_form).permit(
+          :same_organisation
+        )
+      end
+    end
+  end
+end

--- a/app/forms/referrals/teacher_role/same_organisation_form.rb
+++ b/app/forms/referrals/teacher_role/same_organisation_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module Referrals
+  module TeacherRole
+    class SameOrganisationForm
+      include ActiveModel::Model
+
+      attr_accessor :referral
+      attr_reader :same_organisation
+
+      validates :referral, presence: true
+      validates :same_organisation, inclusion: { in: [true, false] }
+
+      def same_organisation=(value)
+        @same_organisation = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save
+        return false if invalid?
+
+        referral.update(same_organisation:)
+      end
+    end
+  end
+end

--- a/app/views/referrals/teacher_role/same_organisation/edit.html.erb
+++ b/app/views/referrals/teacher_role/same_organisation/edit.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, "#{'Error: ' if @same_organisation_form.errors.any?}Do they work in the same organisation as you?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <%= form_with model: @same_organisation_form, url: referrals_update_teacher_same_organisation_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :same_organisation,
+        legend: { size: "l", text: "Do they work in the same organisation as you?" } do %>
+        <%= f.hidden_field :same_organisation %>
+        <%= f.govuk_radio_button :same_organisation, true, label: { text: "Yes, in the same organisation as me" } %>
+        <%= f.govuk_radio_button :same_organisation, false, label: { text: "No, in a different organisation" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,10 @@ en:
           attributes:
             job_title:
               blank: Enter their job title
+        "referrals/teacher_role/same_organisation_form":
+          attributes:
+            same_organisation:
+              inclusion: Tell us if they work in the same organisation as you
         referrer_job_title_form:
           attributes:
             job_title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,6 +204,12 @@ Rails.application.routes.draw do
     put "/:referral_id/teacher-role/job-title",
         to: "teacher_role/job_title#update",
         as: "update_teacher_job_title"
+    get "/:referral_id/teacher-role/same-organisation",
+        to: "teacher_role/same_organisation#edit",
+        as: "edit_teacher_same_organisation"
+    put "/:referral_id/teacher-role/same-organisation",
+        to: "teacher_role/same_organisation#update",
+        as: "update_teacher_same_organisation"
 
     get "/:referral_id/evidence/start",
         to: "evidence/start#edit",

--- a/db/migrate/20221121160810_add_same_organisation_to_referral.rb
+++ b/db/migrate/20221121160810_add_same_organisation_to_referral.rb
@@ -1,0 +1,5 @@
+class AddSameOrganisationToReferral < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrals, :same_organisation, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_22_134453) do
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", 
+unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
@@ -114,6 +115,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_22_134453) do
     t.date "role_end_date"
     t.string "reason_leaving_role"
     t.string "job_title"
+    t.boolean "same_organisation"
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 

--- a/spec/forms/referrals/teacher_role/same_organisation_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/same_organisation_form_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Referrals::TeacherRole::SameOrganisationForm, type: :model do
+  let(:referral) { build(:referral) }
+  let(:same_organisation) { true }
+  subject(:form) { described_class.new(referral:, same_organisation:) }
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    it { is_expected.to be_truthy }
+
+    before { valid }
+
+    context "when same_organisation is blank" do
+      let(:same_organisation) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:same_organisation]).to eq(
+          ["Tell us if they work in the same organisation as you"]
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when same_organisation is true" do
+      let(:same_organisation) { true }
+
+      it "updates the same_organisation to true" do
+        expect { form.save }.to change(referral, :same_organisation).from(
+          nil
+        ).to(true)
+      end
+    end
+
+    context "when same_organisation is false" do
+      let(:same_organisation) { false }
+
+      it "updates the same_organisation to false" do
+        expect { form.save }.to change(referral, :same_organisation).from(
+          nil
+        ).to(false)
+      end
+    end
+  end
+end

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -68,6 +68,18 @@ RSpec.feature "Teacher role", type: :system do
 
     when_i_fill_in_the_job_title_field
     when_i_click_save_and_continue
+    then_i_see_the_same_organisation_page
+
+    when_i_click_save_and_continue
+    then_i_see_same_organisation_field_validation_errors
+
+    when_i_choose_no
+    when_i_click_save_and_continue
+    then_i_see_the_referral_summary
+
+    when_i_visit_the_same_organisation_page
+    and_i_choose_yes
+    when_i_click_save_and_continue
     then_i_see_the_referral_summary
   end
 
@@ -97,6 +109,10 @@ RSpec.feature "Teacher role", type: :system do
 
   def when_i_visit_the_job_title_page
     visit referrals_edit_teacher_job_title_path(@referral)
+  end
+
+  def when_i_visit_the_same_organisation_page
+    visit referrals_edit_teacher_same_organisation_path(@referral)
   end
 
   def when_i_edit_teacher_role_details
@@ -132,6 +148,16 @@ RSpec.feature "Teacher role", type: :system do
     expect(page).to have_content("What’s their job title?")
   end
 
+  def then_i_see_the_same_organisation_page
+    expect(page).to have_current_path(
+      "/referrals/#{@referral.id}/teacher-role/same-organisation"
+    )
+    expect(page).to have_title("Do they work in the same organisation as you?")
+    expect(page).to have_content(
+      "Do they work in the same organisation as you?"
+    )
+  end
+
   def and_i_click_save_and_continue
     click_on "Save and continue"
   end
@@ -152,6 +178,7 @@ RSpec.feature "Teacher role", type: :system do
   def when_i_choose_yes
     choose "Yes", visible: false
   end
+  alias_method :and_i_choose_yes, :when_i_choose_yes
 
   def when_i_choose_no
     choose "No", visible: false
@@ -195,6 +222,12 @@ RSpec.feature "Teacher role", type: :system do
 
   def then_i_see_job_title_field_validation_errors
     expect(page).to have_content("Enter their job title")
+  end
+
+  def then_i_see_same_organisation_field_validation_errors
+    expect(page).to have_content(
+      "Tell us if they work in the same organisation as you"
+    )
   end
 
   def when_i_fill_in_the_job_title_field


### PR DESCRIPTION
### Context

Employer can select if the person they are referring works in the same organisation.
An error message will be shown when submitting without selecting a value.

https://trello.com/c/c46KiqWB/987-about-their-role-forms-add-same-organisation-page
https://teacher-misconduct.herokuapp.com/report/teacher-role/school

### Changes proposed in this pull request

Adds the following page:
<img width="652" alt="Screenshot 2022-11-21 at 17 32 38" src="https://user-images.githubusercontent.com/1636476/203122775-4628673e-71ce-4017-baed-9bc90e3433bd.png">

- Update the routes
- Generate a migration for adding the same organisation field to the referrals table.
- Add the form, including validation
- Link the form to the job title page

### Checklist

- [x] Attach to Trello card
- [] Rebased main
- [] Cleaned commit history
- [x] Tested by running locally
