### PR TITLE
Add worker app container instance

### DIFF
--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -19,10 +19,7 @@ inputs:
 outputs:
   environment_url:
     description: The base URL for the deployed environment
-    value: ${{ steps.terraform.outputs.url }}
-  postgres_server_name:
-    description: The name of the postgres server deployed
-    value: ${{ steps.terraform.outputs.postgres_server_name }}
+    value: ${{ steps.terraform.outputs.app_fqdn }}
 
 runs:
   using: composite
@@ -117,9 +114,13 @@ runs:
         else
           make ci ${{ inputs.environment_name }} terraform-apply
         fi
-        cd terraform && echo "url=https://$(terraform output -raw app_fqdn)" >> $GITHUB_ENV
-        echo "postgres_server_name=$(terraform output -raw postgres_server_name)" >> $GITHUB_ENV
-        echo "slot_name=$(terraform output -raw web_app_slot_name)" >> $GITHUB_ENV
+        cd terraform
+        OUTPUTS=($(terraform output --json | jq -r 'keys | @sh' | tr -d \'))
+        for o in "${OUTPUTS[@]}"
+        do
+          echo "${o}=$(terraform output -raw ${o})" >> $GITHUB_ENV
+        done
+        echo "app_fqdn=$(terraform output -raw app_fqdn)" >>$GITHUB_OUTPUT
       env:
         ARM_ACCESS_KEY: ${{ env.TFSTATE_CONTAINER_ACCESS_KEY }}
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure_credentials }}
@@ -129,13 +130,13 @@ runs:
       with:
         app-name: ${{ env.resource_prefix }}-${{ inputs.environment_name}}${{ env.review_app_suffix }}-app
         images: ${{ inputs.image_name_tag }}
-        slot-name: ${{ env.slot_name }}
+        slot-name: ${{ env.web_app_slot_name }}
 
     - uses: azure/CLI@v1
-      if: ${{ env.slot_name != 'production' }}
+      if: ${{ env.web_app_slot_name != 'production' }}
       with:
         inlineScript: |
-          az webapp deployment slot swap  -g ${{ env.app_resource_group_name }} -n ${{ env.resource_prefix }}-${{ inputs.environment_name}}-app --slot ${{ env.slot_name}} --target-slot production
+          az webapp deployment slot swap -g ${{ env.app_resource_group_name }} -n ${{ env.web_app_name }} --slot ${{ env.web_app_slot_name }} --target-slot production
 
     # Check new site is up
     - run: |
@@ -143,7 +144,7 @@ runs:
         attempt_counter=0
         max_attempts=$RETRIES
 
-        SHA_URL="${{ env.url }}/_sha"
+        SHA_URL="${{ env.app_fqdn }}/_sha"
         APP_SHA=$(curl $SHA_URL --silent)
         until [[ "$EXPECTED_SHA" == "$APP_SHA" ]]; do
             if [ ${attempt_counter} -eq ${max_attempts} ];then

--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -124,6 +124,7 @@ runs:
       env:
         ARM_ACCESS_KEY: ${{ env.TFSTATE_CONTAINER_ACCESS_KEY }}
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure_credentials }}
+        TF_VAR_rsm_docker_image: ${{ inputs.image_name_tag }}
       shell: bash
 
     - uses: azure/webapps-deploy@v2

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -7,6 +7,9 @@ inputs:
   azure_credentials:
     description: JSON object containing a service principal that can read from Azure Key Vault
     required: true
+  url:
+    description: Sets the HOSTING_DOMAIN environment variable
+    required: true
 
 runs:
   using: composite
@@ -35,7 +38,7 @@ runs:
     # Run deployment smoke test
     - run: bin/smoke
       env:
-        HOSTING_DOMAIN: ${{ env.url }}
+        HOSTING_DOMAIN: ${{ inputs.url }}
         GOVUK_NOTIFY_API_KEY: ${{ steps.keyvault-yaml-secret.outputs.GOVUK_NOTIFY_API_KEY }}
         SUPPORT_USERNAME: ${{ steps.keyvault-yaml-secret.outputs.SUPPORT_USERNAME }}
         SUPPORT_PASSWORD: ${{ steps.keyvault-yaml-secret.outputs.SUPPORT_PASSWORD }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -39,9 +39,6 @@ jobs:
     needs: [build_image]
     environment:
       name: review
-      url: ${{ steps.deploy.outputs.environment_url }}
-    outputs:
-      environment_url: ${{ steps.deploy.outputs.environment_url }}
 
     steps:
       - uses: actions/checkout@v3
@@ -54,6 +51,12 @@ jobs:
           image_tag: ${{ github.sha }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           site_up_retries: 150
+
+      - name: Post URL to Pull Request comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            Review app deployed to <${{ steps.deploy.outputs.environment_url }}>
 
       - uses: ./.github/actions/smoke-test
         id: smoke-test
@@ -75,8 +78,6 @@ jobs:
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy.outputs.environment_url }}
-    outputs:
-      environment_url: ${{ steps.deploy.outputs.environment_url }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           environment: review
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          url: ${{ steps.deploy.outputs.environment_url }}
 
   deploy:
     name: Deploy to ${{ matrix.environment }} environment
@@ -94,3 +95,4 @@ jobs:
         with:
           environment: ${{ matrix.environment }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          url: ${{ steps.deploy.outputs.environment_url }}

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -14,6 +14,7 @@ locals {
       AZURE_STORAGE_ACCOUNT_NAME            = azurerm_storage_account.allegations.name,
       AZURE_STORAGE_ACCESS_KEY              = azurerm_storage_account.allegations.primary_access_key,
       AZURE_STORAGE_CONTAINER               = azurerm_storage_container.uploads.name
+      REDIS_URL                             = "rediss://:${azurerm_redis_cache.redis.primary_access_key}@${azurerm_redis_cache.redis.hostname}:${azurerm_redis_cache.redis.ssl_port}/0"
     }
   )
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -15,7 +15,7 @@ output "blue_green" {
 }
 
 output "web_app_name" {
-  value = local.rsm_app_name
+  value = local.rsm_web_app_name
 }
 
 output "web_app_slot_name" {

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,12 +1,21 @@
 output "app_fqdn" {
-  value = var.domain != null ? var.domain : azurerm_linux_web_app.rsm-app.default_hostname
+  value = "https://${var.domain != null ? var.domain : azurerm_linux_web_app.rsm-app.default_hostname}"
 }
+
+output "app_resource_group_name" {
+  value = data.azurerm_resource_group.group.name
+}
+
 output "postgres_server_name" {
   value = azurerm_postgresql_flexible_server.postgres-server.name
 }
 
 output "blue_green" {
   value = var.enable_blue_green
+}
+
+output "web_app_name" {
+  value = local.rsm_app_name
 }
 
 output "web_app_slot_name" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,7 +3,7 @@ variable "environment_name" {
 }
 
 variable "resource_prefix" {
-  type    = string
+  type = string
 }
 
 variable "app_suffix" {
@@ -41,8 +41,8 @@ variable "key_vault_name" {
 
 variable "key_vault_resource_group" {
   description = "Only required for review apps which use the dev KeyVault"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "resource_group_name" {
@@ -51,8 +51,8 @@ variable "resource_group_name" {
 
 variable "resource_group_tags" {
   description = "Only required for review apps which are deployed into their own, tempoarary, resource group"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "redis_service_sku" {
@@ -141,12 +141,18 @@ variable "region_name" {
 
 variable "create_env_resource_group" {
   default = false
-  type = bool
+  type    = bool
+}
+
+variable "rsm_docker_image" {
+  type = string
 }
 
 locals {
   hosting_environment          = var.environment_name
-  rsm_app_name                = "${var.resource_prefix}-${var.environment_name}${var.app_suffix}-app"
+  rsm_web_app_name             = "${var.resource_prefix}-${var.environment_name}${var.app_suffix}-app"
+  rsm_worker_app_name          = "${var.resource_prefix}-${var.environment_name}${var.app_suffix}-wkr-aci"
+  rsm_worker_group_name        = "${var.resource_prefix}-${var.environment_name}${var.app_suffix}-wkr-cg"
   postgres_server_name         = "${var.resource_prefix}-${var.environment_name}${var.app_suffix}-psql"
   postgres_database_name       = "refer_serious_misconduct_production"
   redis_database_name          = "${var.resource_prefix}-${var.environment_name}${var.app_suffix}-redis"


### PR DESCRIPTION
### Context

We require a worker app to run sidekiq jobs.  The worker will collect jobs from Redis cache so requires no external network connectivity.

### Changes proposed in this pull request

- Adds an Azure Container Instance resource
- Deploys a copy the app container and overrides the startup command
- Dynamically assign terraform outputs to GitHub env vars

### Guidance to review

- The sidekiq logs can be reviewed by navigating the container instance in the Azure Portal
  - Search for `s165d01-rsm-review-pr-206-wkr-cg`
  - Click `Containers` then `Logs`

### Link to Trello card

https://trello.com/c/oDMVS1eu

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
