### PR TITLE
Fixed database backup workflow

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule: # 01:00 UTC
     - cron: "0 1 * * *"
+
 jobs:
   backup:
     name: Backup Azure Database ( Production )
@@ -32,8 +33,8 @@ jobs:
       - name: Set postgres environment variables
         shell: bash
         run: |
-          echo "POSTGRES_SERVER_NAME=${{ env.RESOURCE_PREFIX }}rsm-${{ env.ENV }}-psql" >> $GITHUB_ENV
-          echo "POSTGRES_SERVER_HOST_NAME=${{ env.RESOURCE_PREFIX }}rsm-${{ env.ENV }}-psql.postgres.database.azure.com" >> $GITHUB_ENV
+          echo "POSTGRES_SERVER_NAME=${{ env.RESOURCE_PREFIX }}-${{ env.ENV }}-psql" >> $GITHUB_ENV
+          echo "POSTGRES_SERVER_HOST_NAME=${{ env.RESOURCE_PREFIX }}-${{ env.ENV }}-psql.postgres.database.azure.com" >> $GITHUB_ENV
           echo "POSTGRES_DATABASE_NAME=refer_serious_misconduct_production" >> $GITHUB_ENV
 
       - name: Get BACKUP_STORAGE_CONNECTION_STRING


### PR DESCRIPTION
### Context

Harcoded service identifiers were moved from the build-and-deploy workflow to the tfvars files, this has broken the backup workflow.

### Changes proposed in this pull request

Removed hardcoded service identifiers from workflow.

### Guidance to review

A test run can be reviewed [here](https://github.com/DFE-Digital/refer-serious-misconduct/actions/runs/3522970324).

### Checklist

- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running manually
