### PR TITLE
Downgrade Sidekiq from 7.0.1 to 6.5.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "puma", "~> 5.0"
 gem "rails", "~> 7.0.3"
 gem "rotp"
 gem "sentry-rails"
-gem "sidekiq"
+gem "sidekiq", "< 7"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "uk_postcode"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,8 +286,7 @@ GEM
     rake (13.0.6)
     rbs (2.6.0)
     redcarpet (3.5.1)
-    redis-client (0.11.1)
-      connection_pool
+    redis (4.8.0)
     regexp_parser (2.6.0)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -353,11 +352,10 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.2.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.0.1)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.9.0)
+    sidekiq (6.5.7)
+      connection_pool (>= 2.2.5)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     solargraph (0.44.3)
       backport (~> 1.2)
       benchmark
@@ -450,7 +448,7 @@ DEPENDENCIES
   rubocop-govuk
   sentry-rails
   shoulda-matchers
-  sidekiq
+  sidekiq (< 7)
   solargraph-rails
   syntax_tree
   syntax_tree-haml


### PR DESCRIPTION



### Context

<!-- Why are you making this change? -->
We need Redis 6.2+ in order to use Sidekiq 7.

Azure currently supports Redis 6.0.x. It has no plans to support 6.2, instead jumping straight to 7.x

### Changes proposed in this pull request
Resolve this for now by downgrading Sidekiq.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
See:
https://learn.microsoft.com/en-us/answers/questions/768958/redis-backups-and-62-roadmap.html

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

Relevant card is https://trello.com/c/oDMVS1eu/971-deploy-the-rsm-worker-app . Specifically, we need to a functioning Sidekiq instance to send emails out of band.
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
