### PR TITLE
Change redis .tool-versions 6.2.6 -> 6.0.16

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 nodejs 18.1.0
 postgres 13.5
-redis 6.2.6
+redis 6.0.16
 ruby 3.1.2
 yarn 1.22.19


### PR DESCRIPTION
Switch to the latest 6.0.x version, as 6.2.x isn't supported by Azure in production.
