### PR TITLE
Remove redundant 'true' return values

### DIFF
--- a/app/forms/referrals/allegation/details_form.rb
+++ b/app/forms/referrals/allegation/details_form.rb
@@ -43,7 +43,6 @@ module Referrals
         end
 
         referral.update(attrs)
-        true
       end
     end
   end

--- a/app/forms/referrals/personal_details/age_form.rb
+++ b/app/forms/referrals/personal_details/age_form.rb
@@ -36,7 +36,6 @@ module Referrals
         end
 
         referral.update(age_known:, date_of_birth:)
-        true
       end
     end
   end


### PR DESCRIPTION
### Context

Spotted by @vassyz in another PR review, we don't need to explicitly return `true` from form `#save` methods.

### Changes proposed in this pull request

Remove any redundant form `#save` return values
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
