### PR TITLE
Redirect to start page from referrals flow

### DIFF
--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -4,6 +4,7 @@ module Referrals
     before_action :authenticate_user!,
                   if: -> { FeatureFlags::FeatureFlag.active?(:user_accounts) }
     before_action :redirect_if_feature_flag_disabled
+    before_action :redirect_referrals_requests_if_user_accounts_disabled
 
     private
 
@@ -29,6 +30,13 @@ module Referrals
 
     def go_to_check_answers?
       params["go_to_check_answers"] == "true"
+    end
+
+    def redirect_referrals_requests_if_user_accounts_disabled
+      return if request.path !~ %r{^/referral}
+      return if FeatureFlags::FeatureFlag.active?(:user_accounts)
+
+      redirect_to root_path
     end
   end
 end

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -1,0 +1,51 @@
+module CommonSteps
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_i_am_signed_in
+    @user = create(:user)
+    sign_in(@user)
+  end
+
+  def and_the_employer_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
+  end
+
+  def and_the_eligbility_screener_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:eligibility_screener)
+  end
+
+  def and_i_have_an_existing_referral
+    @referral = create(:referral, user: @user)
+  end
+  alias_method :when_i_have_an_existing_referral,
+               :and_i_have_an_existing_referral
+
+  def and_i_visit_the_referral
+    visit edit_referral_path(@referral)
+  end
+  alias_method :when_i_visit_the_referral, :and_i_visit_the_referral
+
+  def then_i_see_the_referral_summary
+    expect(page).to have_current_path(edit_referral_path(@referral))
+    expect(page).to have_title(
+      "Refer serious misconduct by a teacher in England"
+    )
+    expect(page).to have_content("Your allegation of serious misconduct")
+  end
+
+  def when_i_click_save_and_continue
+    click_on "Save and continue"
+  end
+  alias_method :and_i_click_save_and_continue, :when_i_click_save_and_continue
+
+  def when_i_click_back
+    click_on "Back"
+  end
+  alias_method :and_i_click_back, :when_i_click_back
+end

--- a/spec/system/referrals/user_adds_an_allegation_spec.rb
+++ b/spec/system/referrals/user_adds_an_allegation_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Allegation", type: :system do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
     and_i_visit_a_referral
     then_i_see_the_referral_summary
 
@@ -48,6 +49,10 @@ RSpec.feature "Allegation", type: :system do
 
   def and_the_employer_form_feature_is_active
     FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
   def and_i_visit_a_referral

--- a/spec/system/referrals/user_adds_an_allegation_spec.rb
+++ b/spec/system/referrals/user_adds_an_allegation_spec.rb
@@ -2,12 +2,15 @@
 require "rails_helper"
 
 RSpec.feature "Allegation", type: :system do
+  include CommonSteps
+
   scenario "User adds an allegation to a referral" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_the_user_accounts_feature_is_active
-    and_i_visit_a_referral
+    and_i_have_an_existing_referral
+    and_i_visit_the_referral
     then_i_see_the_referral_summary
 
     when_i_edit_the_allegation
@@ -38,32 +41,6 @@ RSpec.feature "Allegation", type: :system do
 
   private
 
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
-  end
-
-  def and_the_user_accounts_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:user_accounts)
-  end
-
-  def and_i_visit_a_referral
-    @referral = create(:referral, user: @user)
-    visit edit_referral_path(@referral)
-  end
-
-  def then_i_see_the_referral_summary
-    expect(page).to have_content("Your allegation of serious misconduct")
-  end
-
   def when_i_edit_the_allegation
     within(all(".app-task-list__section")[2]) do
       click_on "Details of the allegation"
@@ -75,11 +52,6 @@ RSpec.feature "Allegation", type: :system do
       "How do you want to tell us about your allegation?"
     )
   end
-
-  def when_i_click_save_and_continue
-    click_on "Save and continue"
-  end
-  alias_method :and_i_click_save_and_continue, :when_i_click_save_and_continue
 
   def then_i_see_allegation_form_validation_errors
     expect(page).to have_content(

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Contact details", type: :system do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
     and_i_have_an_existing_referral
     when_i_visit_the_referral_summary
     then_i_see_the_status_section_in_the_referral_summary(
@@ -128,6 +129,10 @@ RSpec.feature "Contact details", type: :system do
 
   def and_the_employer_form_feature_is_active
     FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
   def and_i_have_an_existing_referral

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -2,13 +2,15 @@
 require "rails_helper"
 
 RSpec.feature "Contact details", type: :system do
+  include CommonSteps
+
   scenario "User submits contact details for the referred person" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_the_user_accounts_feature_is_active
     and_i_have_an_existing_referral
-    when_i_visit_the_referral_summary
+    when_i_visit_the_referral
     then_i_see_the_status_section_in_the_referral_summary(
       status: "NOT STARTED YET"
     )
@@ -19,21 +21,21 @@ RSpec.feature "Contact details", type: :system do
 
     # Email address invalid
     when_i_select_yes
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_a_missing_email_error
 
     when_i_select_yes_with_an_invalid_email
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_an_invalid_email_error
 
     # Email address unknown
     when_i_select_no
-    and_i_press_continue
+    and_i_click_save_and_continue
 
     # Email address known
     when_i_go_back
     when_i_select_yes_with_a_valid_email
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_the_contact_number_page
 
     # Do you know their main contact number
@@ -41,107 +43,82 @@ RSpec.feature "Contact details", type: :system do
 
     # Phone number errors
     when_i_select_yes
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_a_missing_phone_number_error
 
     when_i_select_yes_with_an_invalid_phone_number
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_an_invalid_phone_number_error
 
     # Phone number known
     when_i_select_no
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_the_home_address_page
 
     # Phone number unknown
     when_i_go_back
     when_i_select_yes_with_a_valid_phone_number
-    and_i_press_continue
+    and_i_click_save_and_continue
 
     # Do you know their home address?
     then_i_see_the_home_address_page
 
     # Address errors
     when_i_select_yes
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_a_missing_address_fields_error
 
     when_i_fill_in_an_incorrect_postcode
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_a_invalid_postcode_error
 
     # Address unknown
     when_i_select_no
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_the_check_answers_page
 
     # Address known
     when_i_go_back
     when_i_select_yes
     when_i_fill_in_the_address_details
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_the_check_answers_page
     and_i_see_a_summary_list
 
     # Have you completed this section?
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_a_completed_error
 
     when_i_select_yes
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_get_redirected_to_the_referral_summary
     then_i_see_the_status_section_in_the_referral_summary
 
     # Not completed
     when_i_visit_the_check_answers_page
     when_i_select_no
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_get_redirected_to_the_referral_summary
     then_i_see_the_status_section_in_the_referral_summary(status: "INCOMPLETE")
 
     # Editing single answers
     when_i_visit_the_check_answers_page
     and_i_click_the_change_email_link
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_the_check_answers_page
 
     when_i_visit_the_check_answers_page
     and_i_click_the_change_phone_link
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_the_check_answers_page
 
     when_i_visit_the_check_answers_page
     and_i_click_the_change_address_link
-    and_i_press_continue
+    and_i_click_save_and_continue
     then_i_see_the_check_answers_page
   end
 
   private
-
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
-  end
-
-  def and_the_user_accounts_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:user_accounts)
-  end
-
-  def and_i_have_an_existing_referral
-    @referral = create(:referral, user: @user)
-  end
-
-  def when_i_visit_the_referral_summary
-    visit edit_referral_path(@referral)
-  end
 
   def when_i_visit_the_check_answers_page
     visit referrals_update_contact_details_check_answers_path(@referral)
@@ -185,10 +162,6 @@ RSpec.feature "Contact details", type: :system do
 
   def when_i_select_yes
     choose "Yes", visible: false
-  end
-
-  def and_i_press_continue
-    click_on "Save and continue"
   end
 
   def then_i_see_a_missing_email_error

--- a/spec/system/referrals/user_adds_evidence_spec.rb
+++ b/spec/system/referrals/user_adds_evidence_spec.rb
@@ -2,12 +2,15 @@
 require "rails_helper"
 
 RSpec.feature "Evidence", type: :system do
+  include CommonSteps
+
   scenario "User adds evidence to a referral" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_the_user_accounts_feature_is_active
-    and_i_visit_a_referral
+    and_i_have_an_existing_referral
+    and_i_visit_the_referral
     then_i_see_the_referral_summary
 
     when_i_edit_the_evidence
@@ -71,33 +74,6 @@ RSpec.feature "Evidence", type: :system do
 
   private
 
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
-  end
-
-  def and_the_user_accounts_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:user_accounts)
-  end
-
-  def and_i_visit_a_referral
-    @referral = create(:referral, user: @user)
-
-    visit edit_referral_path(@referral)
-  end
-
-  def then_i_see_the_referral_summary
-    expect(page).to have_content("Your allegation of serious misconduct")
-  end
-
   def when_i_edit_the_evidence
     within(all(".app-task-list__section")[2]) do
       click_on "Evidence and supporting information"
@@ -107,11 +83,6 @@ RSpec.feature "Evidence", type: :system do
   def then_i_am_asked_if_i_have_evidence_to_upload
     expect(page).to have_content("Evidence and supporting information")
   end
-
-  def when_i_click_save_and_continue
-    click_on "Save and continue"
-  end
-  alias_method :and_i_click_save_and_continue, :when_i_click_save_and_continue
 
   def then_i_see_evidence_start_form_validation_errors
     expect(page).to have_content("Tell us if you have evidence to upload")
@@ -175,10 +146,6 @@ RSpec.feature "Evidence", type: :system do
     expect(page).to have_content(
       "Select all the categories that describe this file"
     )
-  end
-
-  def when_i_click_back
-    click_on "Back"
   end
 
   def when_i_choose_categories_for_the_second_item

--- a/spec/system/referrals/user_adds_evidence_spec.rb
+++ b/spec/system/referrals/user_adds_evidence_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Evidence", type: :system do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
     and_i_visit_a_referral
     then_i_see_the_referral_summary
 
@@ -81,6 +82,10 @@ RSpec.feature "Evidence", type: :system do
 
   def and_the_employer_form_feature_is_active
     FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
   def and_i_visit_a_referral

--- a/spec/system/referrals/user_adds_organisation_details_spec.rb
+++ b/spec/system/referrals/user_adds_organisation_details_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
     and_i_have_an_existing_referral
     and_i_am_on_the_referral_summary_page
     when_i_click_on_your_organisation
@@ -80,6 +81,10 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
 
   def given_the_service_is_open
     FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
   def and_i_am_signed_in

--- a/spec/system/referrals/user_adds_organisation_details_spec.rb
+++ b/spec/system/referrals/user_adds_organisation_details_spec.rb
@@ -1,13 +1,15 @@
 require "rails_helper"
 
 RSpec.feature "Employer Referral: Organisation", type: :system do
+  include CommonSteps
+
   scenario "User provides the organisation details" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_the_user_accounts_feature_is_active
     and_i_have_an_existing_referral
-    and_i_am_on_the_referral_summary_page
+    and_i_visit_the_referral
     when_i_click_on_your_organisation
 
     then_i_am_on_the_organisation_name_page
@@ -79,36 +81,11 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
     expect(your_organisation_row).to have_content("INCOMPLETE")
   end
 
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
-  def and_the_user_accounts_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:user_accounts)
-  end
-
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
-  def and_i_am_on_the_referral_summary_page
-    visit edit_referral_path(@referral)
-  end
-
-  def and_i_have_an_existing_referral
-    @referral = create(:referral, user: @user)
-  end
-
   def and_i_see_your_organisation_flagged_as_complete
     within(".app-task-list__item", text: "Your organisation") do
       status_tag = find(".app-task-list__tag")
       expect(status_tag.text).to match(/^COMPLETE/)
     end
-  end
-
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
   end
 
   def then_i_am_asked_to_make_a_choice
@@ -174,11 +151,6 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
   def when_i_click_on_your_organisation
     click_on "Your organisation"
   end
-
-  def when_i_click_save_and_continue
-    click_on "Save and continue"
-  end
-  alias_method :and_i_click_save_and_continue, :when_i_click_save_and_continue
 
   def when_i_complete_the_address
     fill_in "Address line 1", with: "1 Street"

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -2,12 +2,15 @@
 require "rails_helper"
 
 RSpec.feature "Personal details", type: :system do
+  include CommonSteps
+
   scenario "User adds personal details to a referral" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_the_user_accounts_feature_is_active
-    and_i_visit_a_referral
+    and_i_have_an_existing_referral
+    and_i_visit_the_referral
     then_i_see_the_referral_summary
 
     when_i_edit_personal_details
@@ -76,28 +79,6 @@ RSpec.feature "Personal details", type: :system do
 
   private
 
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
-  end
-
-  def and_the_user_accounts_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:user_accounts)
-  end
-
-  def and_i_visit_a_referral
-    @referral = create(:referral, user: @user)
-    visit edit_referral_path(@referral)
-  end
-
   def when_i_edit_personal_details
     within(all(".app-task-list__section")[1]) { click_on "Personal details" }
   end
@@ -106,15 +87,6 @@ RSpec.feature "Personal details", type: :system do
     expect(page).to have_content(
       "What is the name of the person you’re referring?"
     )
-  end
-
-  def when_i_click_back
-    click_on "Back"
-  end
-  alias_method :and_i_click_back, :when_i_click_back
-
-  def then_i_see_the_referral_summary
-    expect(page).to have_content("Your allegation of serious misconduct")
   end
 
   def then_i_see_name_field_validation_errors
@@ -127,10 +99,6 @@ RSpec.feature "Personal details", type: :system do
     fill_in "Last name", with: "Smith"
     choose "Yes", visible: false
     fill_in "Previous name", with: "Jane Jones"
-  end
-
-  def and_i_click_save_and_continue
-    click_on "Save and continue"
   end
 
   def then_i_am_asked_their_date_of_birth

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Personal details", type: :system do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
     and_i_visit_a_referral
     then_i_see_the_referral_summary
 
@@ -86,6 +87,10 @@ RSpec.feature "Personal details", type: :system do
 
   def and_the_employer_form_feature_is_active
     FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
   def and_i_visit_a_referral

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -1,13 +1,15 @@
 require "rails_helper"
 
 RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
+  include CommonSteps
+
   scenario "User provides details of previous misconduct" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_the_user_accounts_feature_is_active
     and_i_have_an_existing_referral
-    and_i_am_on_the_referral_summary_page
+    and_i_visit_the_referral
     when_i_click_on_previous_misconduct
     then_i_see_the_previous_misconduct_reported_page
 
@@ -48,33 +50,20 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
 
     when_i_choose_no_come_back_later
     and_i_click_save_and_continue
-    then_i_am_on_the_referral_summary_page
+    then_i_see_the_referral_summary
     and_i_see_previous_misconduct_flagged_as_incomplete
 
     when_i_go_back
     and_i_choose_complete
     and_i_click_save_and_continue
-    then_i_am_on_the_referral_summary_page
+    then_i_see_the_referral_summary
     and_i_see_previous_misconduct_flagged_as_complete
   end
 
   private
 
-  def and_i_am_on_the_referral_summary_page
-    visit edit_referral_path(@referral)
-  end
-
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
   def and_i_choose_complete
     choose "Yes, I’ve completed this section", visible: false
-  end
-
-  def and_i_have_an_existing_referral
-    @referral = create(:referral, user: @user)
   end
 
   def and_i_see_no_previous_misconduct_is_prefilled
@@ -109,24 +98,8 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
     expect(page).to have_content("upload.txt")
   end
 
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
-  end
-
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
-  def and_the_user_accounts_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:user_accounts)
-  end
-
   def then_i_am_asked_to_make_a_choice
     expect(page).to have_content("Tell us if you have completed this section")
-  end
-
-  def then_i_am_on_the_referral_summary_page
-    expect(page).to have_current_path(edit_referral_path(@referral))
   end
 
   def then_i_see_the_details_prefilled
@@ -195,11 +168,6 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
   def when_i_click_on_previous_misconduct
     click_on "Previous allegations"
   end
-
-  def when_i_click_save_and_continue
-    click_on "Save and continue"
-  end
-  alias_method :and_i_click_save_and_continue, :when_i_click_save_and_continue
 
   def when_i_enter_details_as_text
     choose "I’ll give details of the previous allegations", visible: false

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
     and_i_have_an_existing_referral
     and_i_am_on_the_referral_summary_page
     when_i_click_on_previous_misconduct
@@ -114,6 +115,10 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
 
   def given_the_service_is_open
     FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
   def then_i_am_asked_to_make_a_choice

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Teacher role", type: :system do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
     and_i_visit_a_referral
     then_i_see_the_referral_summary
 
@@ -126,6 +127,10 @@ RSpec.feature "Teacher role", type: :system do
 
   def and_the_employer_form_feature_is_active
     FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
   # Visit URLs

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -2,12 +2,15 @@
 require "rails_helper"
 
 RSpec.feature "Teacher role", type: :system do
+  include CommonSteps
+
   scenario "User adds teacher role details to a referral" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_the_user_accounts_feature_is_active
-    and_i_visit_a_referral
+    and_i_have_an_existing_referral
+    and_i_visit_the_referral
     then_i_see_the_referral_summary
 
     when_i_edit_teacher_role_details
@@ -116,30 +119,6 @@ RSpec.feature "Teacher role", type: :system do
 
   private
 
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
-  end
-
-  def and_the_user_accounts_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:user_accounts)
-  end
-
-  # Visit URLs
-
-  def and_i_visit_a_referral
-    @referral = create(:referral, user: @user)
-    visit edit_referral_path(@referral)
-  end
-
   def when_i_visit_the_employment_status_page
     visit referrals_edit_teacher_employment_status_path(@referral)
   end
@@ -157,14 +136,6 @@ RSpec.feature "Teacher role", type: :system do
   end
 
   # Page URL/Title
-
-  def then_i_see_the_referral_summary
-    expect(page).to have_current_path("/referrals/#{@referral.id}/edit")
-    expect(page).to have_title(
-      "Refer serious misconduct by a teacher in England"
-    )
-    expect(page).to have_content("Your allegation of serious misconduct")
-  end
 
   def then_i_see_the_employed_status_page
     expect(page).to have_current_path(
@@ -217,16 +188,6 @@ RSpec.feature "Teacher role", type: :system do
   def when_i_edit_teacher_role_details
     within(all(".app-task-list__section")[1]) { click_on "About their role" }
   end
-
-  def and_i_click_save_and_continue
-    click_on "Save and continue"
-  end
-  alias_method :when_i_click_save_and_continue, :and_i_click_save_and_continue
-
-  def when_i_click_back
-    click_on "Back"
-  end
-  alias_method :and_i_click_back, :when_i_click_back
 
   # Radios
 

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
     and_i_have_an_existing_referral
     and_i_am_on_the_referral_summary_page
     when_i_click_on_your_details
@@ -61,6 +62,10 @@ RSpec.feature "Employer Referral: About You", type: :system do
 
   def given_the_service_is_open
     FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
   def and_i_am_signed_in

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -1,13 +1,15 @@
 require "rails_helper"
 
 RSpec.feature "Employer Referral: About You", type: :system do
+  include CommonSteps
+
   scenario "User provides their details" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_the_user_accounts_feature_is_active
     and_i_have_an_existing_referral
-    and_i_am_on_the_referral_summary_page
+    and_i_visit_the_referral
     when_i_click_on_your_details
     then_i_am_on_the_your_details_page
 
@@ -40,7 +42,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
     when_i_click_back
     and_i_choose_no_come_back_later
     and_i_click_save_and_continue
-    then_i_am_on_the_referral_summary_page
+    then_i_see_the_referral_summary
     and_i_see_your_details_flagged_as_incomplete
 
     when_i_click_on_your_details
@@ -60,33 +62,12 @@ RSpec.feature "Employer Referral: About You", type: :system do
 
   private
 
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
-  def and_the_user_accounts_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:user_accounts)
-  end
-
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
-  def and_i_am_on_the_referral_summary_page
-    visit edit_referral_path(@referral)
-  end
-
   def and_i_choose_complete
     choose "Yes, I’ve completed this section", visible: false
   end
 
   def and_i_choose_no_come_back_later
     choose "No, I’ll come back to it later", visible: false
-  end
-
-  def and_i_have_an_existing_referral
-    @referral = create(:referral, user: @user)
   end
 
   def and_i_see_my_name_in_the_form_field
@@ -103,14 +84,6 @@ RSpec.feature "Employer Referral: About You", type: :system do
       status_tag = find(".app-task-list__tag")
       expect(status_tag.text).to have_content("INCOMPLETE")
     end
-  end
-
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
-  end
-
-  def then_i_am_on_the_referral_summary_page
-    expect(page).to have_current_path(edit_referral_path(@referral))
   end
 
   def then_i_am_on_the_your_details_page
@@ -185,10 +158,6 @@ RSpec.feature "Employer Referral: About You", type: :system do
     end
   end
 
-  def when_i_click_back
-    click_on "Back"
-  end
-
   def when_i_click_on_change_name
     click_on "Change name"
   end
@@ -196,11 +165,6 @@ RSpec.feature "Employer Referral: About You", type: :system do
   def when_i_click_on_your_details
     click_link "Your details"
   end
-
-  def when_i_click_save_and_continue
-    click_button "Save and continue"
-  end
-  alias_method :and_i_click_save_and_continue, :when_i_click_save_and_continue
 
   def when_i_enter_my_job_title
     fill_in "What is your job title?", with: "Teacher"

--- a/spec/system/user_deletes_a_draft_referral_spec.rb
+++ b/spec/system/user_deletes_a_draft_referral_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "User deletes a draft referral", type: :system do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
 
     when_i_make_a_new_referral
     and_i_dont_want_to_continue
@@ -32,6 +33,10 @@ RSpec.feature "User deletes a draft referral", type: :system do
 
   def and_the_employer_form_feature_is_active
     FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
   def when_i_have_an_existing_referral

--- a/spec/system/user_deletes_a_draft_referral_spec.rb
+++ b/spec/system/user_deletes_a_draft_referral_spec.rb
@@ -2,6 +2,8 @@
 require "rails_helper"
 
 RSpec.feature "User deletes a draft referral", type: :system do
+  include CommonSteps
+
   scenario "User deletes a draft referral" do
     given_the_service_is_open
     and_i_am_signed_in
@@ -14,38 +16,13 @@ RSpec.feature "User deletes a draft referral", type: :system do
     then_the_new_referral_is_discarded
 
     when_i_have_an_existing_referral
-    and_i_visit_the_referral_summary
+    and_i_visit_the_referral
     and_i_dont_want_to_continue
     and_i_confirm_deletion
     then_the_draft_referral_is_deleted
   end
 
   private
-
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
-  end
-
-  def and_the_user_accounts_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:user_accounts)
-  end
-
-  def when_i_have_an_existing_referral
-    @referral = create(:referral, user: @user)
-  end
-
-  def and_i_visit_the_referral_summary
-    visit edit_referral_path(@referral)
-  end
 
   def when_i_make_a_new_referral
     visit new_referral_path

--- a/spec/system/user_submits_referral_spec.rb
+++ b/spec/system/user_submits_referral_spec.rb
@@ -1,13 +1,15 @@
 require "rails_helper"
 
 RSpec.feature "User submits a referral", type: :system do
+  include CommonSteps
+
   scenario "happy path" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_the_user_accounts_feature_is_active
     and_i_have_an_incomplete_referral
-    when_i_visit_the_referral_summary
+    when_i_visit_the_referral
     and_i_click_review_and_send
     then_i_see_the_missing_sections_error
 
@@ -18,29 +20,12 @@ RSpec.feature "User submits a referral", type: :system do
 
   private
 
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
   def and_i_click_review_and_send
     click_on "Review and send"
   end
 
   def and_i_have_an_incomplete_referral
     @referral = create(:referral, user: @user)
-  end
-
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
-  end
-
-  def and_the_user_accounts_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:user_accounts)
-  end
-
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
   end
 
   def then_i_see_the_confirmation_page
@@ -57,9 +42,5 @@ RSpec.feature "User submits a referral", type: :system do
     @referral.update(attributes_for(:referral, :complete))
     create(:organisation, completed_at: Time.current, referral: @referral)
     create(:referrer, completed_at: Time.current, referral: @referral)
-  end
-
-  def when_i_visit_the_referral_summary
-    visit edit_referral_path(@referral)
   end
 end

--- a/spec/system/user_submits_referral_spec.rb
+++ b/spec/system/user_submits_referral_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "User submits a referral", type: :system do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
     and_i_have_an_incomplete_referral
     when_i_visit_the_referral_summary
     and_i_click_review_and_send
@@ -32,6 +33,10 @@ RSpec.feature "User submits a referral", type: :system do
 
   def and_the_employer_form_feature_is_active
     FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
   def given_the_service_is_open

--- a/spec/system/user_views_a_referral_summary_spec.rb
+++ b/spec/system/user_views_a_referral_summary_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "User views an existing referral summary", type: :system do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
     and_i_have_an_existing_referral
     when_i_visit_the_referral_summary
     then_i_see_the_referral_as_sections
@@ -24,6 +25,10 @@ RSpec.feature "User views an existing referral summary", type: :system do
 
   def and_the_employer_form_feature_is_active
     FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_the_user_accounts_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
   def given_the_service_is_open

--- a/spec/system/user_views_a_referral_summary_spec.rb
+++ b/spec/system/user_views_a_referral_summary_spec.rb
@@ -2,38 +2,19 @@
 require "rails_helper"
 
 RSpec.feature "User views an existing referral summary", type: :system do
+  include CommonSteps
+
   scenario "Views referral summary sections" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_employer_form_feature_is_active
     and_the_user_accounts_feature_is_active
     and_i_have_an_existing_referral
-    when_i_visit_the_referral_summary
+    when_i_visit_the_referral
     then_i_see_the_referral_as_sections
   end
 
   private
-
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
-  def and_i_have_an_existing_referral
-    @referral = create(:referral, user: @user)
-  end
-
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
-  end
-
-  def and_the_user_accounts_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:user_accounts)
-  end
-
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
 
   def then_i_see_the_referral_as_sections
     expect(page).to have_content("Your allegation of serious misconduct")
@@ -49,9 +30,5 @@ RSpec.feature "User views an existing referral summary", type: :system do
     within(all(".app-task-list__section").last) do
       expect(page).to have_content("3. The allegation")
     end
-  end
-
-  def when_i_visit_the_referral_summary
-    visit edit_referral_path(@referral)
   end
 end

--- a/spec/system/user_views_a_referral_when_user_accounts_feature_is_disabled_spec.rb
+++ b/spec/system/user_views_a_referral_when_user_accounts_feature_is_disabled_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "User accounts disabled, user views a referral summary",
     and_the_eligbility_screener_feature_is_active
     and_the_user_accounts_feature_is_inactive
     and_there_is_an_existing_referral
-    when_i_visit_the_referral_summary
+    when_i_visit_the_referral
     then_i_am_redirected_to_the_start_page
   end
 
@@ -21,24 +21,8 @@ RSpec.feature "User accounts disabled, user views a referral summary",
     @referral = create(:referral, user: create(:user))
   end
 
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
-  end
-
-  def and_the_eligbility_screener_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:eligibility_screener)
-  end
-
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
   def and_the_user_accounts_feature_is_inactive
     FeatureFlags::FeatureFlag.deactivate(:user_accounts)
-  end
-
-  def when_i_visit_the_referral_summary
-    visit edit_referral_path(@referral)
   end
 
   def then_i_am_redirected_to_the_start_page

--- a/spec/system/user_views_a_referral_when_user_accounts_feature_is_disabled_spec.rb
+++ b/spec/system/user_views_a_referral_when_user_accounts_feature_is_disabled_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "User accounts disabled, user views a referral summary",
+              type: :system do
+  include CommonSteps
+
+  scenario "User views referral summary" do
+    given_the_service_is_open
+    and_the_employer_form_feature_is_active
+    and_the_eligbility_screener_feature_is_active
+    and_the_user_accounts_feature_is_inactive
+    and_there_is_an_existing_referral
+    when_i_visit_the_referral_summary
+    then_i_am_redirected_to_the_start_page
+  end
+
+  private
+
+  def and_there_is_an_existing_referral
+    @referral = create(:referral, user: create(:user))
+  end
+
+  def and_the_employer_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:employer_form)
+  end
+
+  def and_the_eligbility_screener_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:eligibility_screener)
+  end
+
+  def given_the_service_is_open
+    FeatureFlags::FeatureFlag.activate(:service_open)
+  end
+
+  def and_the_user_accounts_feature_is_inactive
+    FeatureFlags::FeatureFlag.deactivate(:user_accounts)
+  end
+
+  def when_i_visit_the_referral_summary
+    visit edit_referral_path(@referral)
+  end
+
+  def then_i_am_redirected_to_the_start_page
+    expect(current_path).to eq(start_path)
+  end
+end


### PR DESCRIPTION
### Context

If the employer form or user accounts features are not active we shouldn't allow users to access the referrals flow.
https://trello.com/c/OelDJYCH/993-redirect-away-from-referrals-flow-when-user-accounts-feature-flag-is-inactive

<!-- Why are you making this change? -->

### Changes proposed in this pull request

- Redirect to start path if either of the employer form or user accounts features are inactive.
- Refactor some common system spec steps into a support module.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

The last commit isn't relevant to the redirecting, just DRYing up system spec steps

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
