### PR TITLE
Amend referrals 'previous_misconduct_summary' column removal

### DIFF
--- a/db/migrate/20221122134453_remove_previous_misconduct_summary_from_referral.rb
+++ b/db/migrate/20221122134453_remove_previous_misconduct_summary_from_referral.rb
@@ -1,5 +1,8 @@
 class RemovePreviousMisconductSummaryFromReferral < ActiveRecord::Migration[7.0]
   def change
-    remove_column :referrals, :previous_misconduct_summary, :text
+    remove_column :referrals,
+                  :previous_misconduct_summary,
+                  :text,
+                  if_exists: true
   end
 end


### PR DESCRIPTION
This is causing errors in the deployed environments because the column is already absent for some reason but the migration is being run. Try adding `if_exists` to get the migrations passing.
