### PR TITLE
Add user sign in error interstitial

### DIFF
--- a/app/views/users/otp/retry.html.erb
+++ b/app/views/users/otp/retry.html.erb
@@ -1,0 +1,18 @@
+<h1 class="govuk-heading-l">There was a problem signing in</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% case @error %>
+    <% when 'expired' %>
+      <p>
+        Your security code has expired. Try signing in again.
+      </p>
+    <% when 'exhausted' %>
+      <p>
+        You've had too many incorrect login attempts. Try signing in again.
+      </p>
+    <% end %>
+
+    <%= govuk_button_link_to('Continue', new_user_session_path, method: :get) %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,12 @@ Rails.application.routes.draw do
     post "/users/session", to: "users/sessions#create", as: "user_session"
     get "/users/otp/new", to: "users/otp#new", as: "new_user_otp"
     post "/users/otp", to: "users/otp#create", as: "user_otp"
+    get "/users/otp/retry/:error",
+        to: "users/otp#retry",
+        as: "retry_user_sign_in",
+        constraints: {
+          error: /(expired)|(exhausted)/
+        }
 
     get "/users/sign_out", to: "users/sessions#destroy"
   end

--- a/spec/system/user_auth/user_reaches_max_otp_guesses_spec.rb
+++ b/spec/system/user_auth/user_reaches_max_otp_guesses_spec.rb
@@ -10,7 +10,9 @@ RSpec.feature "User accounts" do
 
     when_i_start_the_signin_flow
     and_max_out_my_otp_guesses
-    then_i_am_sent_back_to_the_email_screen_with_an_error
+    then_i_see_an_error_screen
+    and_can_return_to_the_email_screen
+    and_my_otp_state_is_reset
   end
 
   def given_the_service_is_open
@@ -43,14 +45,21 @@ RSpec.feature "User accounts" do
     end
   end
 
-  def then_i_am_sent_back_to_the_email_screen_with_an_error
+  def then_i_see_an_error_screen
+    expect(page).to have_content "There was a problem signing in"
+    expect(
+      page
+    ).to have_content "You've had too many incorrect login attempts. Try signing in again."
+  end
+
+  def and_can_return_to_the_email_screen
+    click_link "Continue"
     expect(page).to have_content "Enter your email address"
-    expect(page).to have_content "Too many incorrect login attempts. Try again."
   end
 
   def and_my_otp_state_is_reset
     user = User.last
     expect(user.secret_key).to be_nil
-    expect(user.otp_guesses).to be_nil
+    expect(user.otp_guesses).to eq 0
   end
 end

--- a/spec/system/user_auth/user_tries_signing_in_with_expired_otp_spec.rb
+++ b/spec/system/user_auth/user_tries_signing_in_with_expired_otp_spec.rb
@@ -13,7 +13,9 @@ RSpec.feature "User accounts" do
     when_i_start_the_signin_flow
     and_my_otp_has_expired
     when_i_try_to_sign_in
-    then_i_am_sent_back_to_the_email_screen_with_an_error
+    then_i_see_an_error_screen
+    and_can_return_to_the_email_screen
+    and_my_otp_state_is_reset
   end
 
   def given_the_service_is_open
@@ -50,8 +52,21 @@ RSpec.feature "User accounts" do
     within("main") { click_on "Sign in" }
   end
 
-  def then_i_am_sent_back_to_the_email_screen_with_an_error
+  def then_i_see_an_error_screen
+    expect(page).to have_content "There was a problem signing in"
+    expect(
+      page
+    ).to have_content "Your security code has expired. Try signing in again."
+  end
+
+  def and_can_return_to_the_email_screen
+    click_link "Continue"
     expect(page).to have_content "Enter your email address"
-    expect(page).to have_content("Security code has expired. Try again.")
+  end
+
+  def and_my_otp_state_is_reset
+    user = User.last
+    expect(user.secret_key).to be_nil
+    expect(user.otp_guesses).to eq 0
   end
 end


### PR DESCRIPTION



### Context
Design review identified the need for some improvement in the user journey when the user fails to sign in and their OTP state is reset.

<!-- Why are you making this change? -->

### Changes proposed in this pull request
Add an error page that prompts the user to try signing in again when either of the following error states arise:
- Expired OTP
- Exhausted number of guesses
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->
#### Expired

![Screenshot_20221124_141832](https://user-images.githubusercontent.com/519250/203806310-61ebe942-3ffc-46e3-8768-f17b32f077bc.png)

#### Exhausted

![Screenshot_20221124_141911](https://user-images.githubusercontent.com/519250/203806384-a292257a-1b03-44f4-847c-c9bed2a65873.png)


### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
