### PR TITLE
Override startup-command to schema:load

### DIFF
--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -15,6 +15,8 @@ inputs:
   site_up_retries:
     description: The number of times that the site up test will be retried
     default: 60
+  startup_command:
+    required: false
 
 outputs:
   environment_url:
@@ -128,10 +130,19 @@ runs:
       shell: bash
 
     - uses: azure/webapps-deploy@v2
+      if: ${{ inputs.environment_name }} != "review"
       with:
         app-name: ${{ env.resource_prefix }}-${{ inputs.environment_name}}${{ env.review_app_suffix }}-app
         images: ${{ inputs.image_name_tag }}
         slot-name: ${{ env.web_app_slot_name }}
+
+    - uses: azure/webapps-deploy@v2
+      if: ${{ inputs.environment_name }} == "review"
+      with:
+        app-name: ${{ env.resource_prefix }}-${{ inputs.environment_name}}${{ env.review_app_suffix }}-app
+        images: ${{ inputs.image_name_tag }}
+        slot-name: ${{ env.web_app_slot_name }}
+        startup-command: ${{ inputs.startup_command }}
 
     - uses: azure/CLI@v1
       if: ${{ env.web_app_slot_name != 'production' }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -51,6 +51,7 @@ jobs:
           image_tag: ${{ github.sha }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           site_up_retries: 150
+          startup_command: "sh /app/bin/start-review-app.sh"
 
       - name: Post URL to Pull Request comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/bin/start-review-app.sh
+++ b/bin/start-review-app.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+/usr/sbin/sshd
+export DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+bundle exec rails db:schema_load_or_migrate && bundle exec rails server -b 0.0.0.0

--- a/lib/tasks/schema_load_or_migrate.rake
+++ b/lib/tasks/schema_load_or_migrate.rake
@@ -1,0 +1,19 @@
+db_namespace =
+  namespace(:db) do
+    desc "Runs schema:load if database does not exist, or runs migrations if it does"
+    task schema_load_or_migrate: :load_config do
+      ActiveRecord::Base
+        .configurations
+        .configs_for(env_name: Rails.env)
+        .each do |db_config|
+          ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+          if ActiveRecord::SchemaMigration.table_exists?
+            puts "Invoking db:migrate"
+            db_namespace["migrate"].invoke
+          else
+            puts "Invoking db:schema:load"
+            db_namespace["schema:load"].invoke
+          end
+        end
+    end
+  end


### PR DESCRIPTION
### Context

We have the option to deploy review apps with a fresh database instance.  On startup our app runs the database migrations.  Overtime these will become more prone to failure when running from scratch.  We require the option to load the schema directly for review apps.

### Changes proposed in this pull request

- Implements the ability to override the startup command for the web application container in the deployment workflow for review apps only
- This enables us to change the startup command from `db:migrate:ignore_concurrent_migration_exceptions` to `db:schema_load_or_migrate`

### Guidance to review

- What is the chance that this change is inadvertently modified in the future and changes the startup command for prod?
- What is the impact of inadvertently changing the startup behaviour in prod?
- The deployment process for the review app and the permanent environments was tested [here](https://github.com/DFE-Digital/refer-serious-misconduct/actions/runs/3639874807/jobs/6143879695).  In the `Run azure/webapps-deploy@v2` step you can see the `startup-command:` getting passed in for the review app but not for the dev app as expected

### Link to Trello card

https://trello.com/c/VQyOErf1

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running manually
