### PR TITLE
Add cache option to prettier

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 bin/bundle exec rubocop --autocorrect-all
-yarn prettier --write --ignore-unknown '**/*'
+yarn prettier --write --cache --ignore-unknown '**/*'


### PR DESCRIPTION
### Context

A quality of life improvement. Adding the cache option drops the linting script's local execution time from ~30s to ~5s.

### Guidance to review

Run `bin/lint` twice to test the speed improvement.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
