### PR TITLE
Pluralise the uploaded files heading depending on number of files

### DIFF
--- a/app/views/referrals/evidence/upload/show.html.erb
+++ b/app/views/referrals/evidence/upload/show.html.erb
@@ -4,10 +4,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">
     <h1 class="govuk-heading-xl">
-      You uploaded <%= current_referral.evidences.size %> files
+      You uploaded <%= pluralize(current_referral.evidences.size, "file") %>
     </h1>
 
-    <p>Your files:</p>
+    <p>Your <%= "file".pluralize(current_referral.evidences.size) %>:</p>
 
     <ul class="govuk-list govuk-!-margin-bottom-6">
       <% current_referral.evidences.each do |evidence| %>


### PR DESCRIPTION
### Context

Feedback from design review: https://trello.com/c/lBYEXqLc/980-employer-form-evidence-upload-page
The heading on the uploaded evidence page should only be pluralised when multiple files have been uploaded.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

#### Single file
![image](https://user-images.githubusercontent.com/93511/204255885-342cae7b-d675-43d1-8ff6-b91b1ae33b6e.png)


#### Multiple files
![image](https://user-images.githubusercontent.com/93511/204254677-125978f5-6372-48d5-b769-12b33ecd7a59.png)

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
