### PR TITLE
Add a lint check for RSpec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_gem:
   rubocop-govuk:
     - config/default.yml
     - config/rails.yml
+    - config/rspec.yml
 
 inherit_from:
   - node_modules/@prettier/plugin-ruby/rubocop.yml
@@ -16,6 +17,14 @@ Rails/ApplicationController:
 
 Rails/SaveBang:
   Enabled: false
+
+RSpec/Capybara/FeatureMethods:
+  Exclude:
+    - spec/system/**/*
+
+RSpec/InstanceVariable:
+  Exclude:
+    - spec/system/**/*
 
 Style/NumericLiterals:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ group :development, :test do
   gem "pry"
   gem "pry-nav"
   gem "rspec-rails"
-  gem "timecop"
 end
 
 group :development do
@@ -51,9 +50,6 @@ end
 group :test do
   gem "capybara"
   gem "cuprite"
-end
-
-group :test do
   gem "rspec"
   gem "shoulda-matchers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,7 +387,6 @@ GEM
     temple (0.8.2)
     thor (1.2.1)
     tilt (2.0.11)
-    timecop (0.9.6)
     timeout (0.3.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
@@ -454,7 +453,6 @@ DEPENDENCIES
   syntax_tree
   syntax_tree-haml
   syntax_tree-rbs
-  timecop
   tzinfo-data
   uk_postcode
   web-console

--- a/app/forms/referrals/personal_details/name_form.rb
+++ b/app/forms/referrals/personal_details/name_form.rb
@@ -16,14 +16,14 @@ module Referrals
                 if: -> { name_has_changed == "yes" }
 
       def save
-        if valid?
-          referral.update(
-            first_name:,
-            last_name:,
-            name_has_changed:,
-            previous_name:
-          )
-        end
+        return false if invalid?
+
+        referral.update(
+          first_name:,
+          last_name:,
+          name_has_changed:,
+          previous_name:
+        )
       end
     end
   end

--- a/app/forms/referrals/teacher_role/employment_status_form.rb
+++ b/app/forms/referrals/teacher_role/employment_status_form.rb
@@ -21,6 +21,7 @@ module Referrals
                   in: %w[resigned dismissed retired unknown]
                 },
                 if: -> { left_role? }
+      validates :date_params, presence: true, if: :left_role?
 
       def save
         return false if invalid?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,10 +3,9 @@ class User < ApplicationRecord
   include Devise::Models::OtpAuthenticatable
 
   has_many :referrals
-
-  def latest_referral
-    referrals.order(created_at: :desc).first
-  end
+  has_one :latest_referral,
+          -> { order(created_at: :desc) },
+          class_name: "Referral"
 
   def after_failed_otp_authentication
     clear_otp_state

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,7 +108,7 @@ en:
             name_has_changed:
               inclusion: Tell us if you know their name has changed
             previous_name:
-              blank: Previous name can't be blank
+              blank: Tell us their previous name
         "referrals/personal_details/trn_form":
           attributes:
             trn_known:

--- a/spec/components/task_list_component_spec.rb
+++ b/spec/components/task_list_component_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe TaskListComponent, type: :component do
+  subject(:rendered) { render_inline(described_class.new(sections:)) }
+
   let(:sections) do
     [
       OpenStruct.new(
@@ -38,56 +40,83 @@ RSpec.describe TaskListComponent, type: :component do
     ]
   end
 
-  subject(:rendered) { render_inline(described_class.new(sections:)) }
-
-  it "renders numbered sections" do
+  it "renders the first numbered section" do
     expect(rendered.css(".app-task-list__section-number")[0].text).to eq("1.")
+  end
+
+  it "renders the title in the first numbered section" do
     expect(rendered.css(".app-task-list__section-heading")[0].text).to include(
       "Do laundry"
     )
+  end
 
+  it "renders the second numbered section" do
     expect(rendered.css(".app-task-list__section-number")[1].text).to eq("2.")
+  end
+
+  it "renders the title in the second numbered section" do
     expect(rendered.css(".app-task-list__section-heading")[1].text).to include(
       "Make a sandwich"
     )
   end
 
-  it "renders section items" do
+  it "renders the first section title" do
     expect(rendered.css(".app-task-list__item")[0].text).to include(
       "Light wash"
     )
+  end
+
+  it "renders the second section title" do
     expect(rendered.css(".app-task-list__item")[1].text).to include("Dark wash")
+  end
+
+  it "renders the third section title" do
     expect(rendered.css(".app-task-list__item")[2].text).to include(
       "Butter bread"
     )
+  end
+
+  it "renders the fourth section title" do
     expect(rendered.css(".app-task-list__item")[3].text).to include(
       "Add filling"
     )
   end
 
-  it "renders section item links" do
+  it "renders the first link" do
     expect(rendered.css(".app-task-list__item a")[0][:href]).to eq(
       "/light-wash"
     )
+  end
+
+  it "renders the second link" do
     expect(rendered.css(".app-task-list__item a")[1][:href]).to eq("/dark-wash")
+  end
+
+  it "renders the third link" do
     expect(rendered.css(".app-task-list__item a")[2][:href]).to eq(
       "/butter-bread"
     )
+  end
+
+  it "renders the fourth link" do
     expect(rendered.css(".app-task-list__item a")[3][:href]).to eq(
       "/add-filling"
     )
   end
 
-  it "renders section item status" do
+  it "renders the tag with the correct status" do
     expect(rendered.css(".app-task-list__tag")[0].text).to include("Completed")
+  end
+
+  it "renders the Not started yet tag with the correct colour" do
     expect(
       rendered.css(".app-task-list__tag.govuk-tag--grey")[0].text
     ).to include("Not started yet")
+  end
+
+  it "renders the Incomplete tag with the correct colour" do
     expect(
       rendered.css(".app-task-list__tag.govuk-tag--grey")[1].text
     ).to include("Incomplete")
-    expect(
-      rendered.css(".app-task-list__tag.govuk-tag--grey")[2].text
-    ).to include("Not started yet")
   end
 end

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :organisation do
     referral
+
+    trait :complete do
+      completed_at { Time.current }
+    end
   end
 end

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -9,6 +9,11 @@ FactoryBot.define do
       personal_details_complete { true }
       teacher_role_complete { true }
       previous_misconduct_completed_at { Time.current }
+
+      after(:create) do |referral|
+        create(:organisation, :complete, referral:)
+        create(:referrer, :complete, referral:)
+      end
     end
   end
 end

--- a/spec/factories/referrers.rb
+++ b/spec/factories/referrers.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     trait :incomplete do
       name { nil }
     end
+
+    trait :complete do
+      completed_at { Time.current }
+    end
   end
 end

--- a/spec/forms/is_teacher_form_spec.rb
+++ b/spec/forms/is_teacher_form_spec.rb
@@ -2,9 +2,12 @@ require "rails_helper"
 
 RSpec.describe IsTeacherForm, type: :model do
   describe "validations" do
+    subject(:form) { described_class.new }
+
     it { is_expected.to validate_presence_of(:eligibility_check) }
-    it do
-      is_expected.to validate_inclusion_of(:is_teacher).in_array(
+
+    specify do
+      expect(form).to validate_inclusion_of(:is_teacher).in_array(
         %w[yes no not_sure]
       )
     end

--- a/spec/forms/organisation_address_form_spec.rb
+++ b/spec/forms/organisation_address_form_spec.rb
@@ -15,20 +15,23 @@ RSpec.describe OrganisationAddressForm, type: :model do
   describe "#valid?" do
     subject(:valid) { form.valid? }
 
-    let(:city) { "London" }
-    let(:form) do
-      described_class.new(referral:, street_1:, street_2:, city:, postcode:)
+    let(:form) { described_class.new(params) }
+    let(:params) do
+      {
+        city: "London",
+        postcode: "W1 1CW",
+        referral:,
+        street_1: "1 Street",
+        street_2: ""
+      }
     end
     let(:organisation) { build(:organisation) }
-    let(:postcode) { "W1 1CW" }
     let(:referral) { organisation.referral }
-    let(:street_1) { "1 Street" }
-    let(:street_2) { "" }
 
     it { is_expected.to be_truthy }
 
     context "when one of the validations is failing" do
-      let(:street_1) { "" }
+      let(:params) { super().merge(street_1: "") }
 
       it { is_expected.to be_falsy }
     end
@@ -37,21 +40,24 @@ RSpec.describe OrganisationAddressForm, type: :model do
   describe "#save" do
     subject(:save) { form.save }
 
-    let(:city) { "London" }
-    let(:form) do
-      described_class.new(referral:, street_1:, street_2:, city:, postcode:)
+    let(:form) { described_class.new(params) }
+    let(:params) do
+      {
+        city: "London",
+        postcode: "W1 1CW",
+        referral:,
+        street_1: "1 Street",
+        street_2: "Extra"
+      }
     end
     let(:organisation) { build(:organisation) }
-    let(:postcode) { "W1 1CW" }
     let(:referral) { organisation.referral }
-    let(:street_1) { "1 Street" }
-    let(:street_2) { "Extra" }
 
     before { save }
 
-    it { expect(organisation.city).to eq(city) }
-    it { expect(organisation.postcode).to eq(postcode) }
-    it { expect(organisation.street_1).to eq(street_1) }
-    it { expect(organisation.street_2).to eq(street_2) }
+    it { expect(organisation.city).to eq("London") }
+    it { expect(organisation.postcode).to eq("W1 1CW") }
+    it { expect(organisation.street_1).to eq("1 Street") }
+    it { expect(organisation.street_2).to eq("Extra") }
   end
 end

--- a/spec/forms/previous_misconduct_detailed_account_form_spec.rb
+++ b/spec/forms/previous_misconduct_detailed_account_form_spec.rb
@@ -2,12 +2,16 @@ require "rails_helper"
 
 RSpec.describe PreviousMisconductDetailedAccountForm, type: :model do
   describe "validations" do
+    subject(:form) { described_class.new }
+
     it { is_expected.to validate_presence_of(:referral) }
-    it do
-      is_expected.to validate_inclusion_of(:format).in_array(
+
+    specify do
+      expect(form).to validate_inclusion_of(:format).in_array(
         %w[details incomplete]
       )
     end
+
     it { is_expected.not_to validate_presence_of(:details) }
 
     context "when format is details" do

--- a/spec/forms/referral_form_spec.rb
+++ b/spec/forms/referral_form_spec.rb
@@ -2,52 +2,17 @@ require "rails_helper"
 
 RSpec.describe ReferralForm do
   describe "save" do
-    let(:sections) do
-      [
-        OpenStruct.new(
-          items: [
-            OpenStruct.new(status: :incomplete),
-            OpenStruct.new(status: :completed)
-          ]
-        ),
-        OpenStruct.new(
-          items: [
-            OpenStruct.new(status: :completed),
-            OpenStruct.new(status: :completed)
-          ]
-        )
-      ]
-    end
+    subject(:save) { form.save }
 
-    subject(:form) { described_class.new(referral: Referral.new) }
+    let(:form) { described_class.new(referral:) }
+    let(:referral) { create(:referral) }
 
-    before { allow(form).to receive(:sections).and_return(sections) }
-
-    it "checks statuses of referral sections" do
-      expect(form.save).to be false
-    end
+    it { is_expected.to be_falsy }
 
     context "when statuses are all complete" do
-      let(:sections) do
-        [
-          OpenStruct.new(
-            items: [
-              OpenStruct.new(status: :completed),
-              OpenStruct.new(status: :completed)
-            ]
-          ),
-          OpenStruct.new(
-            items: [
-              OpenStruct.new(status: :completed),
-              OpenStruct.new(status: :completed)
-            ]
-          )
-        ]
-      end
+      let(:referral) { create(:referral, :complete) }
 
-      it "checks statuses of referral sections" do
-        expect(form.save).to be true
-      end
+      it { is_expected.to be_truthy }
     end
   end
 end

--- a/spec/forms/referrals/allegation/confirm_form_spec.rb
+++ b/spec/forms/referrals/allegation/confirm_form_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 
 RSpec.describe Referrals::Allegation::ConfirmForm, type: :model do
   describe "#save" do
-    let(:referral) { build(:referral) }
-    let(:allegation_details_complete) { "false" }
     subject(:save) { confirm_form.save }
 
+    let(:referral) { build(:referral) }
     let(:confirm_form) do
       described_class.new(referral:, allegation_details_complete:)
     end
+    let(:allegation_details_complete) { "false" }
 
     context "with a valid value" do
       it "saves the value on the referral" do
@@ -20,6 +20,7 @@ RSpec.describe Referrals::Allegation::ConfirmForm, type: :model do
 
     context "with no values" do
       let(:allegation_details_complete) { nil }
+
       it "adds an error" do
         save
         expect(confirm_form.errors[:allegation_details_complete]).to eq(

--- a/spec/forms/referrals/allegation/dbs_form_spec.rb
+++ b/spec/forms/referrals/allegation/dbs_form_spec.rb
@@ -5,14 +5,17 @@ RSpec.describe Referrals::Allegation::DbsForm, type: :model do
   let(:referral) { build(:referral) }
 
   describe "#save" do
-    let(:dbs_notified) { nil }
-    let(:form) { described_class.new(referral:, dbs_notified:) }
-
     subject(:save) { form.save }
 
+    let(:form) { described_class.new(referral:, dbs_notified:) }
+
     context "with no answer" do
-      it "returns false and adds an error" do
-        expect(save).to be false
+      let(:dbs_notified) { nil }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        save
         expect(form.errors[:dbs_notified]).to eq(
           ["Tell us if you have notified DBS about the case"]
         )
@@ -21,9 +24,8 @@ RSpec.describe Referrals::Allegation::DbsForm, type: :model do
 
     context "with an answer" do
       let(:dbs_notified) { "true" }
-      it "returns true" do
-        expect(save).to be true
-      end
+
+      it { is_expected.to be_truthy }
 
       it "saves the answer on the referral" do
         save

--- a/spec/forms/referrals/contact_details/address_form_spec.rb
+++ b/spec/forms/referrals/contact_details/address_form_spec.rb
@@ -2,38 +2,43 @@ require "rails_helper"
 
 RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
   let(:referral) { create(:referral) }
-  let(:form) do
-    described_class.new(
-      referral:,
-      address_known:,
-      address_line_1:,
-      address_line_2:,
-      town_or_city:,
-      postcode:,
-      country:
-    )
-  end
+  let(:form) { described_class.new(params) }
 
-  let(:address_known) { true }
-  let(:address_line_1) { "1428 Elm Street" }
-  let(:address_line_2) { "Sunset Boulevard" }
-  let(:town_or_city) { "London" }
-  let(:postcode) { "NW1 4NP" }
-  let(:country) { "United Kingdom" }
+  let(:params) do
+    {
+      address_known: true,
+      address_line_1: "1428 Elm Street",
+      address_line_2: "Sunset Boulevard",
+      country: "United Kingdom",
+      postcode: "NW1 4NP",
+      referral:,
+      town_or_city: "London"
+    }
+  end
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:referral) }
+
+    context "when address is known" do
+      subject { form }
+
+      let(:params) { { address_known: true } }
+
+      it { is_expected.to validate_presence_of(:address_line_1) }
+      it { is_expected.to validate_presence_of(:town_or_city) }
+      it { is_expected.to validate_presence_of(:postcode) }
+    end
   end
 
   describe "#valid?" do
     subject(:valid) { form.valid? }
 
-    it { is_expected.to be_truthy }
-
     before { valid }
 
+    it { is_expected.to be_truthy }
+
     context "when address_known is blank" do
-      let(:address_known) { "" }
+      let(:params) { super().merge(address_known: "") }
 
       it { is_expected.to be_falsy }
 
@@ -45,7 +50,7 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
     end
 
     context "when address_line_1 is blank" do
-      let(:address_line_1) { "" }
+      let(:params) { super().merge(address_line_1: "") }
 
       it { is_expected.to be_falsy }
 
@@ -57,7 +62,7 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
     end
 
     context "when town_or_city is blank" do
-      let(:town_or_city) { "" }
+      let(:params) { super().merge(town_or_city: "") }
 
       it { is_expected.to be_falsy }
 
@@ -67,7 +72,7 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
     end
 
     context "when postcode is blank" do
-      let(:postcode) { "" }
+      let(:params) { super().merge(postcode: "") }
 
       it { is_expected.to be_falsy }
 
@@ -77,7 +82,7 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
     end
 
     context "when postcode is invalid" do
-      let(:postcode) { "Postcode" }
+      let(:params) { super().merge(postcode: "Invalid") }
 
       it { is_expected.to be_falsy }
 
@@ -115,7 +120,7 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
     end
 
     context "when the address is not known" do
-      let(:address_known) { false }
+      let(:params) { super().merge(address_known: false) }
 
       it "sets the address_known to false" do
         expect(referral.address_known).to be_falsy

--- a/spec/forms/referrals/contact_details/check_answers_form_spec.rb
+++ b/spec/forms/referrals/contact_details/check_answers_form_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Referrals::ContactDetails::CheckAnswersForm, type: :model do
   describe "#valid?" do
     subject(:valid) { form.valid? }
 
-    it { is_expected.to be_truthy }
-
     before { valid }
+
+    it { is_expected.to be_truthy }
 
     context "when contact_details_complete is blank" do
       let(:contact_details_complete) { "" }

--- a/spec/forms/referrals/contact_details/email_form_spec.rb
+++ b/spec/forms/referrals/contact_details/email_form_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Referrals::ContactDetails::EmailForm, type: :model do
   describe "#valid?" do
     subject(:valid) { form.valid? }
 
-    it { is_expected.to be_truthy }
-
     before { valid }
+
+    it { is_expected.to be_truthy }
 
     context "when email_known is blank" do
       let(:email_known) { "" }

--- a/spec/forms/referrals/contact_details/telephone_form_spec.rb
+++ b/spec/forms/referrals/contact_details/telephone_form_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Referrals::ContactDetails::TelephoneForm, type: :model do
   describe "#valid?" do
     subject(:valid) { form.valid? }
 
-    it { is_expected.to be_truthy }
-
     before { valid }
+
+    it { is_expected.to be_truthy }
 
     context "when phone_known is blank" do
       let(:phone_known) { "" }

--- a/spec/forms/referrals/evidence/confirm_form_spec.rb
+++ b/spec/forms/referrals/evidence/confirm_form_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 
 RSpec.describe Referrals::Evidence::ConfirmForm, type: :model do
   describe "#save" do
-    let(:referral) { build(:referral) }
-    let(:evidence_details_complete) { "false" }
     subject(:save) { confirm_form.save }
 
+    let(:referral) { build(:referral) }
     let(:confirm_form) do
       described_class.new(referral:, evidence_details_complete:)
     end
+    let(:evidence_details_complete) { "false" }
 
     context "with a valid value" do
       it "saves the value on the referral" do
@@ -20,6 +20,7 @@ RSpec.describe Referrals::Evidence::ConfirmForm, type: :model do
 
     context "with no values" do
       let(:evidence_details_complete) { nil }
+
       it "adds an error" do
         save
         expect(confirm_form.errors[:evidence_details_complete]).to eq(

--- a/spec/forms/referrals/evidence/start_form_spec.rb
+++ b/spec/forms/referrals/evidence/start_form_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 
 RSpec.describe Referrals::Evidence::StartForm, type: :model do
   describe "#save" do
-    let(:referral) { build(:referral) }
-    let(:has_evidence) { "false" }
     subject(:save) { start_form.save }
 
+    let(:referral) { build(:referral) }
     let(:start_form) { described_class.new(referral:, has_evidence:) }
+    let(:has_evidence) { "false" }
 
     context "with a valid value" do
       it "saves the value on the referral" do
@@ -18,6 +18,7 @@ RSpec.describe Referrals::Evidence::StartForm, type: :model do
 
     context "with no values" do
       let(:has_evidence) { nil }
+
       it "adds an error" do
         save
         expect(start_form.errors[:has_evidence]).to eq(

--- a/spec/forms/referrals/personal_details/age_form_spec.rb
+++ b/spec/forms/referrals/personal_details/age_form_spec.rb
@@ -2,6 +2,7 @@
 require "rails_helper"
 
 RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
+  let(:age_known) { "false" }
   let(:date_params) { {} }
   let(:form) { described_class.new(referral:, age_known:, date_params:) }
   let(:referral) { build(:referral) }
@@ -9,8 +10,10 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
   context "with invalid age_known" do
     let(:age_known) { "" }
 
+    it { is_expected.to be_invalid }
+
     it "adds an error message" do
-      expect(form.valid?).to be false
+      form.valid?
       expect(form.errors[:age_known]).to eq(
         ["Tell us if you know their date of birth"]
       )
@@ -29,9 +32,13 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
 
     let(:age_known) { "false" }
 
-    it "saves the age_known value without a date of birth" do
-      save
-      expect(referral.date_of_birth).to be nil
+    before { save }
+
+    it "does not update the date_of_birth" do
+      expect(referral.date_of_birth).to be_nil
+    end
+
+    it "saves the age_known value" do
       expect(referral.age_known).to eq(false)
     end
   end

--- a/spec/forms/referrals/personal_details/confirm_form_spec.rb
+++ b/spec/forms/referrals/personal_details/confirm_form_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 
 RSpec.describe Referrals::PersonalDetails::ConfirmForm, type: :model do
   describe "#save" do
-    let(:referral) { build(:referral) }
-    let(:personal_details_complete) { false }
     subject(:save) { confirm_form.save }
 
+    let(:referral) { build(:referral) }
     let(:confirm_form) do
       described_class.new(referral:, personal_details_complete:)
     end
+    let(:personal_details_complete) { false }
 
     context "with a valid value" do
       it "saves the value on the referral" do
@@ -20,6 +20,7 @@ RSpec.describe Referrals::PersonalDetails::ConfirmForm, type: :model do
 
     context "with no values" do
       let(:personal_details_complete) { nil }
+
       it "adds an error" do
         save
         expect(confirm_form.errors[:personal_details_complete]).to eq(

--- a/spec/forms/referrals/personal_details/name_form_spec.rb
+++ b/spec/forms/referrals/personal_details/name_form_spec.rb
@@ -1,56 +1,70 @@
 require "rails_helper"
 
 RSpec.describe Referrals::PersonalDetails::NameForm do
-  describe "#save (names)" do
-    let(:referral) { build(:referral) }
-    let(:first_name) { "Jane" }
-    let(:last_name) { "Smith" }
-    let(:name_has_changed) { "yes" }
-    let(:previous_name) { "Janet Jones" }
+  describe "#save" do
+    subject(:save) { form.save }
 
-    subject(:form) do
-      described_class.new(
-        referral:,
-        first_name:,
-        last_name:,
-        name_has_changed:,
-        previous_name:
-      )
-    end
+    let(:form) { described_class.new(params) }
+    let(:params) { { referral: } }
+    let(:referral) { build(:referral) }
+
+    before { save }
 
     context "with valid values" do
-      it "updates the names on the referral record" do
-        form.save
+      let(:params) do
+        {
+          first_name: "Jane",
+          last_name: "Smith",
+          name_has_changed: "yes",
+          previous_name: "Janet Jones",
+          referral:
+        }
+      end
 
+      it "saves the first_name" do
         expect(referral.first_name).to eq("Jane")
+      end
+
+      it "saves the last_name" do
         expect(referral.last_name).to eq("Smith")
+      end
+
+      it "saves the name_has_changed" do
         expect(referral.name_has_changed).to eq("yes")
+      end
+
+      it "saves the previous_name" do
         expect(referral.previous_name).to eq("Janet Jones")
       end
     end
 
-    context "with invalid values" do
-      let(:first_name) { "" }
-      let(:last_name) { "" }
-      let(:name_has_changed) { "" }
-      let(:previous_name) { "" }
-
-      it "fails form validation" do
-        form.save
-
+    context "when first name is blank" do
+      it "raises an error on first name" do
         expect(form.errors[:first_name]).to include "First name can't be blank"
+      end
+    end
+
+    context "when last name is blank" do
+      it "raises an error on last name" do
         expect(form.errors[:last_name]).to include "Last name can't be blank"
+      end
+    end
+
+    context "when name_has_changed is blank" do
+      it "raises an error on name has changed" do
         expect(form.errors[:name_has_changed]).to include(
           "Tell us if you know their name has changed"
         )
       end
+    end
 
-      it "validates previous name conditionally" do
-        form.name_has_changed = "yes"
-        form.save
-        expect(
-          form.errors[:previous_name]
-        ).to include "Previous name can't be blank"
+    context "when name has changed is yes" do
+      let(:params) { { name_has_changed: "yes", referral: } }
+
+      it "raises an error on previous name" do
+        expect(form.errors[:previous_name]).to include(
+          "Tell us their previous name"
+        )
       end
     end
   end

--- a/spec/forms/referrals/personal_details/qts_form_spec.rb
+++ b/spec/forms/referrals/personal_details/qts_form_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 
 RSpec.describe Referrals::PersonalDetails::QtsForm, type: :model do
   describe "#save" do
-    let(:referral) { build(:referral) }
-    let(:has_qts) { "yes" }
     subject(:save) { qts_form.save }
 
+    let(:referral) { build(:referral) }
     let(:qts_form) { described_class.new(referral:, has_qts:) }
+    let(:has_qts) { "yes" }
 
     context "with a valid value" do
       it "saves the value on the referral" do
@@ -18,6 +18,7 @@ RSpec.describe Referrals::PersonalDetails::QtsForm, type: :model do
 
     context "with no values" do
       let(:has_qts) { nil }
+
       it "adds an error" do
         save
         expect(qts_form.errors[:has_qts]).to eq(
@@ -28,6 +29,7 @@ RSpec.describe Referrals::PersonalDetails::QtsForm, type: :model do
 
     context "with an invalid value" do
       let(:has_qts) { "eh?" }
+
       it "adds an error" do
         save
         expect(qts_form.errors[:has_qts]).to eq(

--- a/spec/forms/referrals/personal_details/trn_form_spec.rb
+++ b/spec/forms/referrals/personal_details/trn_form_spec.rb
@@ -11,9 +11,7 @@ RSpec.describe Referrals::PersonalDetails::TrnForm, type: :model do
     let(:trn_known) { "true" }
     let(:trn) { "RP99/12345" }
 
-    it "passes validation" do
-      is_expected.to be_truthy
-    end
+    it { is_expected.to be_truthy }
 
     it "updates the trn attribute on the referral" do
       expect { save }.to change(referral, :trn).from(nil).to("9912345")
@@ -23,9 +21,7 @@ RSpec.describe Referrals::PersonalDetails::TrnForm, type: :model do
       let(:trn) { nil }
       let(:trn_known) { nil }
 
-      it "fails validation" do
-        is_expected.to be_falsy
-      end
+      it { is_expected.to be_falsey }
 
       it "adds an error" do
         save
@@ -37,16 +33,15 @@ RSpec.describe Referrals::PersonalDetails::TrnForm, type: :model do
 
     context "when TRN is not known" do
       let(:trn_known) { "false" }
-      it "passes validation" do
-        is_expected.to be_truthy
-      end
+
+      it { is_expected.to be_truthy }
     end
 
     context "when TRN is known but empty input submitted" do
       let(:trn) { "" }
-      it "fails validation" do
-        is_expected.to be_falsy
-      end
+
+      it { is_expected.to be_falsey }
+
       it "adds an error" do
         save
         expect(trn_form.errors[:trn]).to include("Enter their TRN number")
@@ -55,9 +50,9 @@ RSpec.describe Referrals::PersonalDetails::TrnForm, type: :model do
 
     context "when a value too short for a TRN is submitted" do
       let(:trn) { "RP99/123" }
-      it "fails validation" do
-        is_expected.to be_falsy
-      end
+
+      it { is_expected.to be_falsey }
+
       it "adds an error" do
         save
         expect(trn_form.errors[:trn]).to eq(
@@ -68,9 +63,9 @@ RSpec.describe Referrals::PersonalDetails::TrnForm, type: :model do
 
     context "when a value too long for a TRN is submitted" do
       let(:trn) { "RP99/123456" }
-      it "fails validation" do
-        is_expected.to be_falsy
-      end
+
+      it { is_expected.to be_falsey }
+
       it "adds an error" do
         save
         expect(trn_form.errors[:trn]).to eq(
@@ -81,9 +76,9 @@ RSpec.describe Referrals::PersonalDetails::TrnForm, type: :model do
 
     context "when a TRN includes non numeric characters" do
       let(:trn) { "RP/99-123-67" }
-      it "passes validation" do
-        is_expected.to be_truthy
-      end
+
+      it { is_expected.to be_truthy }
+
       it "strips all non numeric characters from the TRN" do
         expect { save }.to change(referral, :trn).from(nil).to("9912367")
       end

--- a/spec/forms/referrals/teacher_role/check_answers_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/check_answers_form_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Referrals::TeacherRole::CheckAnswersForm, type: :model do
   describe "#valid?" do
     subject(:valid) { form.valid? }
 
-    it { is_expected.to be_truthy }
-
     before { valid }
+
+    it { is_expected.to be_truthy }
 
     context "when teacher_role_complete is blank" do
       let(:teacher_role_complete) { "" }

--- a/spec/forms/referrals/teacher_role/duties_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/duties_form_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Referrals::TeacherRole::DutiesForm, type: :model do
   let(:referral) { build(:referral) }
 
   describe "#save" do
+    subject(:save) { form.save }
+
     let(:duties_format) { nil }
     let(:duties_details) { nil }
     let(:duties_upload) { nil }
@@ -16,8 +18,6 @@ RSpec.describe Referrals::TeacherRole::DutiesForm, type: :model do
         duties_upload:
       )
     end
-
-    subject(:save) { form.save }
 
     context "with no duties format" do
       it { is_expected.to be_falsey }
@@ -105,7 +105,7 @@ RSpec.describe Referrals::TeacherRole::DutiesForm, type: :model do
       end
     end
 
-    context "not yet complete" do
+    context "when format is incomplete" do
       let(:duties_details) { "Something something" }
       let(:duties_upload) { fixture_file_upload("upload.pdf") }
       let(:duties_format) { "incomplete" }

--- a/spec/forms/referrals/teacher_role/job_title_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/job_title_form_spec.rb
@@ -2,9 +2,9 @@
 require "rails_helper"
 
 RSpec.describe Referrals::TeacherRole::JobTitleForm, type: :model do
-  let(:referral) { build(:referral) }
-
   subject(:form) { described_class.new(referral:, job_title:) }
+
+  let(:referral) { build(:referral) }
 
   describe "#valid?" do
     subject(:valid) { form.valid? }

--- a/spec/forms/referrals/teacher_role/same_organisation_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/same_organisation_form_spec.rb
@@ -2,16 +2,17 @@
 require "rails_helper"
 
 RSpec.describe Referrals::TeacherRole::SameOrganisationForm, type: :model do
+  subject(:form) { described_class.new(referral:, same_organisation:) }
+
   let(:referral) { build(:referral) }
   let(:same_organisation) { true }
-  subject(:form) { described_class.new(referral:, same_organisation:) }
 
   describe "#valid?" do
     subject(:valid) { form.valid? }
 
-    it { is_expected.to be_truthy }
-
     before { valid }
+
+    it { is_expected.to be_truthy }
 
     context "when same_organisation is blank" do
       let(:same_organisation) { "" }

--- a/spec/forms/referrals/teacher_role/start_date_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/start_date_form_spec.rb
@@ -2,19 +2,20 @@
 require "rails_helper"
 
 RSpec.describe Referrals::TeacherRole::StartDateForm, type: :model do
-  let(:date_params) { {} }
-  let(:referral) { build(:referral) }
-  let(:role_start_date_known) { true }
   subject(:form) do
     described_class.new(date_params:, referral:, role_start_date_known:)
   end
 
+  let(:date_params) { nil }
+  let(:referral) { build(:referral) }
+  let(:role_start_date_known) { true }
+
   describe "#valid?" do
     subject(:valid) { form.valid? }
 
-    it { is_expected.to be_truthy }
-
     before { valid }
+
+    it { is_expected.to be_truthy }
 
     context "when role_start_date_known is blank" do
       let(:role_start_date_known) { "" }

--- a/spec/forms/referrer_form_spec.rb
+++ b/spec/forms/referrer_form_spec.rb
@@ -2,13 +2,14 @@ require "rails_helper"
 
 RSpec.describe ReferrerForm, type: :model do
   describe "validations" do
-    subject { described_class.new(referrer:) }
+    subject(:form) { described_class.new(referrer:) }
 
     let(:referrer) { build(:referrer) }
 
-    it do
-      is_expected.to validate_inclusion_of(:complete).in_array(%w[true false])
+    specify do
+      expect(form).to validate_inclusion_of(:complete).in_array(%w[true false])
     end
+
     it { is_expected.to validate_presence_of(:referrer) }
   end
 

--- a/spec/forms/reporting_as_form_spec.rb
+++ b/spec/forms/reporting_as_form_spec.rb
@@ -26,10 +26,8 @@ RSpec.describe ReportingAsForm, type: :model do
 
       it "returns an informative error message" do
         save
-        expect(reporting_as_form.errors["reporting_as"]).to eq(
-          [
-            "Tell us if you are reporting as an employer or a member of the public"
-          ]
+        expect(reporting_as_form.errors["reporting_as"]).to include(
+          "Tell us if you are reporting as an employer or a member of the public"
         )
       end
     end

--- a/spec/forms/serious_misconduct_form_spec.rb
+++ b/spec/forms/serious_misconduct_form_spec.rb
@@ -2,9 +2,12 @@ require "rails_helper"
 
 RSpec.describe SeriousMisconductForm, type: :model do
   describe "validations" do
+    subject(:form) { described_class.new }
+
     it { is_expected.to validate_presence_of(:eligibility_check) }
-    it do
-      is_expected.to validate_inclusion_of(:serious_misconduct).in_array(
+
+    specify do
+      expect(form).to validate_inclusion_of(:serious_misconduct).in_array(
         %w[yes no not_sure]
       )
     end

--- a/spec/forms/teaching_in_england_form_spec.rb
+++ b/spec/forms/teaching_in_england_form_spec.rb
@@ -2,9 +2,12 @@ require "rails_helper"
 
 RSpec.describe TeachingInEnglandForm, type: :model do
   describe "validations" do
+    subject(:form) { described_class.new }
+
     it { is_expected.to validate_presence_of(:eligibility_check) }
-    it do
-      is_expected.to validate_inclusion_of(:teaching_in_england).in_array(
+
+    specify do
+      expect(form).to validate_inclusion_of(:teaching_in_england).in_array(
         %w[yes no not_sure]
       )
     end

--- a/spec/forms/unsupervised_teaching_form_spec.rb
+++ b/spec/forms/unsupervised_teaching_form_spec.rb
@@ -2,9 +2,12 @@ require "rails_helper"
 
 RSpec.describe UnsupervisedTeachingForm, type: :model do
   describe "validations" do
+    subject(:form) { described_class.new }
+
     it { is_expected.to validate_presence_of(:eligibility_check) }
-    it do
-      is_expected.to validate_inclusion_of(:unsupervised_teaching).in_array(
+
+    specify do
+      expect(form).to validate_inclusion_of(:unsupervised_teaching).in_array(
         %w[yes no not_sure]
       )
     end

--- a/spec/forms/users/otp_form_spec.rb
+++ b/spec/forms/users/otp_form_spec.rb
@@ -4,33 +4,30 @@ require "rails_helper"
 
 RSpec.describe Users::OtpForm do
   describe "#otp_expired?" do
-    it "is true if user otp is expired" do
-      Timecop.freeze do
-        user =
-          create(:user, otp_created_at: Users::OtpForm::EXPIRY_IN_MINUTES.ago)
-        form = described_class.new(id: user.id)
+    subject { form.otp_expired? }
 
-        expect(form.otp_expired?).to eq true
-      end
+    let(:form) { described_class.new(id: user.id) }
+    let(:user) { create(:user, otp_created_at:) }
+
+    before { freeze_time }
+    after { travel_back }
+
+    context "when the OTP is 30 minutes old" do
+      let(:otp_created_at) { 30.minutes.ago }
+
+      it { is_expected.to be_truthy }
     end
 
-    it "is false is user otp is not yet expired" do
-      unexpired_time = Users::OtpForm::EXPIRY_IN_MINUTES.ago + 1.minute
-      Timecop.freeze do
-        user = create(:user, otp_created_at: unexpired_time)
-        form = described_class.new(id: user.id)
+    context "when the OTP is 29 minutes old" do
+      let(:otp_created_at) { 29.minutes.ago }
 
-        expect(form.otp_expired?).to eq false
-      end
+      it { is_expected.to be_falsey }
     end
 
-    it "is false if no otp_created_at is set" do
-      Timecop.freeze do
-        user = create(:user, otp_created_at: nil)
-        form = described_class.new(id: user.id)
+    context "when the OTP has not been created" do
+      let(:otp_created_at) { nil }
 
-        expect(form.otp_expired?).to eq false
-      end
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/spec/helpers/referral_helper_spec.rb
+++ b/spec/helpers/referral_helper_spec.rb
@@ -1,55 +1,51 @@
 require "rails_helper"
 
 RSpec.describe ReferralHelper, type: :helper do
-  let(:referral) { create(:referral) }
   let(:evidence) { create(:referral_evidence, referral:) }
-  let(:evidences) { [] }
+  let(:referral) { create(:referral) }
 
   before { referral.evidences = evidences }
 
-  describe "evidence_categories_back_link" do
+  describe "#evidence_categories_back_link" do
+    subject(:link) { helper.evidence_categories_back_link(form) }
+
     let(:form) { Referrals::Evidence::CategoriesForm.new(referral:, evidence:) }
 
     context "with previous evidence" do
-      let(:previous_evidence) { create(:referral_evidence, referral:) }
       let(:evidences) { [previous_evidence, evidence] }
+      let(:previous_evidence) { create(:referral_evidence, referral:) }
 
-      it "returns edit categories path for the previous evidence" do
-        expect(helper.evidence_categories_back_link(form)).to eq(
-          referrals_edit_evidence_categories_path(
-            form.referral,
-            previous_evidence
-          )
+      it do
+        expect(link).to eq(
+          "/referrals/#{referral.id}/evidence/#{previous_evidence.id}/categories"
         )
       end
     end
+
     context "without previous evidence" do
       let(:evidences) { [evidence] }
 
-      it "returns evidence uploaded path" do
-        expect(helper.evidence_categories_back_link(form)).to eq(
-          referrals_evidence_uploaded_path(form.referral)
-        )
-      end
+      it { is_expected.to eq("/referrals/#{referral.id}/evidence/uploaded") }
     end
   end
 
-  describe "evidence_categories_back_link" do
+  describe "#evidence_confirm_back_link" do
+    subject(:link) { helper.evidence_confirm_back_link(referral) }
+
     context "with evidence" do
       let(:evidences) { [evidence] }
 
-      it "returns edit evidence categories path" do
-        expect(helper.evidence_confirm_back_link(referral)).to eq(
-          referrals_edit_evidence_categories_path(referral, evidence)
+      it do
+        expect(link).to eq(
+          "/referrals/#{referral.id}/evidence/#{evidence.id}/categories"
         )
       end
     end
+
     context "without evidence" do
-      it "returns edit evidence start path" do
-        expect(helper.evidence_confirm_back_link(referral)).to eq(
-          referrals_edit_evidence_start_path(referral)
-        )
-      end
+      let(:evidences) { [] }
+
+      it { is_expected.to eq("/referrals/#{referral.id}/evidence/start") }
     end
   end
 end

--- a/spec/lib/devise/strategies/otp_authenticatable_spec.rb
+++ b/spec/lib/devise/strategies/otp_authenticatable_spec.rb
@@ -1,35 +1,35 @@
 require "rails_helper"
 
 RSpec.describe Devise::Strategies::OtpAuthenticatable do
-  def build_rack_env(params)
+  let(:env) do
     env = Rack::MockRequest.env_for("/strategy-test", params)
     env["devise.allow_params_authentication"] = true
     env
   end
 
-  let(:valid_params) do
-    { params: { user: { email: "test@example.com", otp: "123456" } } }
-  end
-
   describe "#valid?" do
-    it "is true when given a rack env with the expected data" do
-      env = build_rack_env(valid_params)
-      strategy = described_class.new(env, :user)
-      expect(strategy.valid?).to eq true
+    subject { strategy.valid? }
+
+    let(:strategy) { described_class.new(env, :user) }
+
+    context "with valid params" do
+      let(:params) do
+        { params: { user: { email: "test@example.com", otp: "123456" } } }
+      end
+
+      it { is_expected.to be_truthy }
     end
 
-    it "is false when otp param is missing" do
-      params = { params: { user: { email: "test@example.com" } } }
-      env = build_rack_env(params)
-      strategy = described_class.new(env, :user)
-      expect(strategy.valid?).to eq false
+    context "when the otp param is missing" do
+      let(:params) { { params: { user: { email: "test@example.com" } } } }
+
+      it { is_expected.to be_falsey }
     end
 
-    it "is false when email param is missing" do
-      params = { params: { user: { email: "test@example.com" } } }
-      env = build_rack_env(params)
-      strategy = described_class.new(env, :user)
-      expect(strategy.valid?).to eq false
+    context "when the email param is missing" do
+      let(:params) { { params: { user: { otp: "123456" } } } }
+
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/spec/lib/staff_http_basic_auth_strategy_spec.rb
+++ b/spec/lib/staff_http_basic_auth_strategy_spec.rb
@@ -34,12 +34,15 @@ RSpec.describe StaffHttpBasicAuthStrategy do
   describe "#authenticate!" do
     before { staff_http_basic_auth_strategy.authenticate! }
 
-    it "should halt the strategy" do
-      expect(staff_http_basic_auth_strategy.halted?).to eq(true)
+    it "halts the strategy" do
+      expect(staff_http_basic_auth_strategy).to be_halted
     end
 
-    it "should not be successful" do
-      expect(staff_http_basic_auth_strategy.successful?).to eq(false)
+    it "is not successful" do
+      expect(staff_http_basic_auth_strategy).not_to be_successful
+    end
+
+    it "sets a custom response" do
       expect(staff_http_basic_auth_strategy.custom_response).to eq(
         [
           401,
@@ -52,14 +55,15 @@ RSpec.describe StaffHttpBasicAuthStrategy do
         ]
       )
     end
+    # rubocop:enable RSpec/ExampleLength
 
     context "with valid credentials" do
       let(:env) do
         { "HTTP_AUTHORIZATION" => "Basic #{Base64.encode64("test:test")}" }
       end
 
-      it "should be successful" do
-        expect(staff_http_basic_auth_strategy.successful?).to eq(true)
+      it "is successful" do
+        expect(staff_http_basic_auth_strategy).to be_successful
       end
     end
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -2,15 +2,22 @@ require "rails_helper"
 
 RSpec.describe UserMailer, type: :mailer do
   describe ".send_otp" do
-    it "sends a one-time password to the user" do
-      secret_key = Devise::Otp.generate_key
-      user = build(:user, secret_key:)
-      email = described_class.send_otp(user)
-      expected_otp = Devise::Otp.derive_otp(secret_key)
+    subject(:email) { described_class.send_otp(user) }
 
+    let(:secret_key) { Devise::Otp.generate_key }
+    let(:user) { build(:user, secret_key:) }
+
+    it "sends a one-time password to the user" do
       expect(email.to).to include user.email
-      expect(email.subject).to eq "Confirm your email address"
+    end
+
+    it "includes the one-time password in the email body" do
+      expected_otp = Devise::Otp.derive_otp(secret_key)
       expect(email.body).to include(expected_otp)
+    end
+
+    it "sets the subject" do
+      expect(email.subject).to eq "Confirm your email address"
     end
   end
 end

--- a/spec/models/performance_stats_spec.rb
+++ b/spec/models/performance_stats_spec.rb
@@ -20,32 +20,48 @@ RSpec.describe PerformanceStats, type: :model do
       expect(request_counts_by_day.size).to eq(8)
     end
 
-    it "returns the correct number of requests for today" do
-      expect(request_counts_by_day.last).to eq(
-        [
-          7.days.ago.to_fs(:weekday_day_and_month),
-          {
-            complete_count: 1,
-            screened_out_count: 1,
-            incomplete_count: 1,
-            total: 3
-          }
-        ]
-      )
+    context "when the day has requests" do
+      subject(:day) { request_counts_by_day.last }
+
+      it "returns the date" do
+        expect(day.first).to eq(7.days.ago.to_fs(:weekday_day_and_month))
+      end
+
+      it "returns the complete count" do
+        expect(day.second[:complete_count]).to eq(1)
+      end
+
+      it "returns the incomplete count" do
+        expect(day.second[:incomplete_count]).to eq(1)
+      end
+
+      it "returns the screened out count" do
+        expect(day.second[:screened_out_count]).to eq(1)
+      end
+
+      it "returns the total" do
+        expect(day.second[:total]).to eq(3)
+      end
     end
 
-    it "returns default values for days without a request" do
-      expect(request_counts_by_day.second).to eq(
-        [
-          1.day.ago.to_fs(:weekday_day_and_month),
-          {
-            complete_count: 0,
-            screened_out_count: 0,
-            incomplete_count: 0,
-            total: 0
-          }
-        ]
-      )
+    context "when the day has no requests" do
+      subject(:day) { request_counts_by_day.second }
+
+      it "returns the default complete value" do
+        expect(day.second[:complete_count]).to eq(0)
+      end
+
+      it "returns the default screened out value" do
+        expect(day.second[:screened_out_count]).to eq(0)
+      end
+
+      it "returns the default incomplete value" do
+        expect(day.second[:incomplete_count]).to eq(0)
+      end
+
+      it "returns the default total value" do
+        expect(day.second[:total]).to eq(0)
+      end
     end
   end
 
@@ -54,15 +70,20 @@ RSpec.describe PerformanceStats, type: :model do
 
     let(:performance_stats) { described_class.new }
 
-    it "returns zero values by default" do
-      expect(total_requests_by_day).to eq(
-        {
-          complete_count: 0,
-          screened_out_count: 0,
-          incomplete_count: 0,
-          total: 0
-        }
-      )
+    it "returns zero complete by default" do
+      expect(total_requests_by_day[:complete_count]).to eq(0)
+    end
+
+    it "returns zero screened out by default" do
+      expect(total_requests_by_day[:screened_out_count]).to eq(0)
+    end
+
+    it "returns zero incomplete by default" do
+      expect(total_requests_by_day[:incomplete_count]).to eq(0)
+    end
+
+    it "returns zero total by default" do
+      expect(total_requests_by_day[:total]).to eq(0)
     end
 
     context "when there have been checks" do
@@ -73,15 +94,20 @@ RSpec.describe PerformanceStats, type: :model do
         create(:eligibility_check, is_teacher: "yes")
       end
 
-      it "returns the totals for the period" do
-        expect(total_requests_by_day).to eq(
-          {
-            complete_count: 1,
-            screened_out_count: 1,
-            incomplete_count: 2,
-            total: 4
-          }
-        )
+      it "returns the complete total for the period" do
+        expect(total_requests_by_day).to include(complete_count: 1)
+      end
+
+      it "returns the screened out total for the period" do
+        expect(total_requests_by_day).to include(screened_out_count: 1)
+      end
+
+      it "returns the incomplete total for the period" do
+        expect(total_requests_by_day).to include(incomplete_count: 2)
+      end
+
+      it "returns the total for the period" do
+        expect(total_requests_by_day).to include(total: 4)
       end
     end
   end
@@ -93,15 +119,20 @@ RSpec.describe PerformanceStats, type: :model do
 
     let(:performance_stats) { described_class.new }
 
-    it "returns zero values by default" do
-      expect(total_requests_by_month).to eq(
-        {
-          complete_count: 0,
-          screened_out_count: 0,
-          incomplete_count: 0,
-          total: 0
-        }
-      )
+    it "returns zero complete for the month" do
+      expect(total_requests_by_month).to include(complete_count: 0)
+    end
+
+    it "returns zero incomplete for the month" do
+      expect(total_requests_by_month).to include(incomplete_count: 0)
+    end
+
+    it "returns zero screened out for the month" do
+      expect(total_requests_by_month).to include(screened_out_count: 0)
+    end
+
+    it "returns zero total for the month" do
+      expect(total_requests_by_month).to include(total: 0)
     end
 
     context "when there have been checks" do
@@ -111,15 +142,20 @@ RSpec.describe PerformanceStats, type: :model do
         create(:eligibility_check)
       end
 
-      it "returns the totals for the period" do
-        expect(total_requests_by_month).to eq(
-          {
-            complete_count: 1,
-            screened_out_count: 1,
-            incomplete_count: 1,
-            total: 3
-          }
-        )
+      it "returns the correct complete total for the period" do
+        expect(total_requests_by_month).to include(complete_count: 1)
+      end
+
+      it "returns the correct screened out total for the period" do
+        expect(total_requests_by_month).to include(screened_out_count: 1)
+      end
+
+      it "returns the correct incomplete total for the period" do
+        expect(total_requests_by_month).to include(incomplete_count: 1)
+      end
+
+      it "returns the correct total for the period" do
+        expect(total_requests_by_month).to include(total: 3)
       end
     end
   end

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -1,4 +1,1 @@
 require "rails_helper"
-
-RSpec.describe Staff, type: :model do
-end

--- a/spec/support/shared_examples/validating_date.rb
+++ b/spec/support/shared_examples/validating_date.rb
@@ -80,8 +80,9 @@ RSpec.shared_examples "form with a date validator" do |field, optional = true|
       { "#{field}(1i)" => "", "#{field}(2i)" => "", "#{field}(3i)" => "" }
     end
 
+    it { is_expected.to be_falsey }
+
     it "adds an error" do
-      expect(save).to be_false
       expect(form.errors[field.to_s]).to eq(
         ["Enter their #{field_name(field)}"]
       )

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -63,11 +63,11 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
   private
 
   def and_i_choose_complete
-    choose "Yes, I’ve completed this section", visible: false
+    choose "Yes, I’ve completed this section", visible: :all
   end
 
   def and_i_see_no_previous_misconduct_is_prefilled
-    expect(page).to have_checked_field("No", visible: false)
+    expect(page).to have_checked_field("No", visible: :all)
   end
 
   def and_i_see_no_previous_misconduct_reported
@@ -146,15 +146,15 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
   end
 
   def when_i_choose_no
-    choose "No", visible: false
+    choose "No", visible: :all
   end
 
   def when_i_choose_no_come_back_later
-    choose "No, I’ll come back to it later", visible: false
+    choose "No, I’ll come back to it later", visible: :all
   end
 
   def when_i_choose_yes
-    choose "Yes", visible: false
+    choose "Yes", visible: :all
   end
 
   def when_i_click_change_details
@@ -170,7 +170,7 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
   end
 
   def when_i_enter_details_as_text
-    choose "I’ll give details of the previous allegations", visible: false
+    choose "I’ll give details of the previous allegations", visible: :all
     fill_in "Details of previous allegations", with: "Some details"
   end
 
@@ -179,7 +179,7 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
   end
 
   def when_i_upload_a_file
-    choose "I’ll upload the previous allegation details", visible: false
+    choose "I’ll upload the previous allegation details", visible: :all
     attach_file "Upload details of previous allegations",
                 Rails.root.join("spec/support/upload.txt")
   end

--- a/spec/system/staff/staff_user_sends_account_invitation_spec.rb
+++ b/spec/system/staff/staff_user_sends_account_invitation_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature "Staff invitations", type: :system do
 
   def then_i_see_an_invitation_email
     message = ActionMailer::Base.deliveries.last
-    expect(message).to_not be_nil
+    expect(message).not_to be_nil
     expect(message.subject).to eq("Invitation instructions")
     expect(message.to).to include("test@example.com")
   end

--- a/spec/system/user_auth/user_tries_signing_in_with_expired_otp_spec.rb
+++ b/spec/system/user_auth/user_tries_signing_in_with_expired_otp_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.feature "User accounts" do
-  around { |example| Timecop.freeze { example.run } }
+  around { |example| freeze_time { example.run } }
 
   scenario "User signs in" do
     given_the_service_is_open
@@ -42,7 +42,7 @@ RSpec.feature "User accounts" do
   end
 
   def and_my_otp_has_expired
-    Timecop.travel(Users::OtpForm::EXPIRY_IN_MINUTES.from_now)
+    travel_to(Users::OtpForm::EXPIRY_IN_MINUTES.from_now)
   end
 
   def when_i_try_to_sign_in

--- a/spec/system/user_views_a_referral_when_user_accounts_feature_is_disabled_spec.rb
+++ b/spec/system/user_views_a_referral_when_user_accounts_feature_is_disabled_spec.rb
@@ -26,6 +26,6 @@ RSpec.feature "User accounts disabled, user views a referral summary",
   end
 
   def then_i_am_redirected_to_the_start_page
-    expect(current_path).to eq(start_path)
+    expect(page).to have_current_path(start_path, ignore_query: true)
   end
 end

--- a/spec/validators/file_upload_validator_spec.rb
+++ b/spec/validators/file_upload_validator_spec.rb
@@ -1,17 +1,16 @@
 require "rails_helper"
 
 RSpec.describe FileUploadValidator do
+  subject(:model) { Validatable.new }
+
   before do
     stub_const("Validatable", Class.new).class_eval do
       include ActiveModel::Validations
       attr_accessor :file
       validates :file, file_upload: true
     end
+    model.file = file
   end
-
-  subject(:model) { Validatable.new }
-
-  before { model.file = file }
 
   context "with a valid file" do
     let(:file) { fixture_file_upload("upload.pdf", "application/pdf") }
@@ -28,13 +27,13 @@ RSpec.describe FileUploadValidator do
   context "with an invalid content type" do
     let(:file) { fixture_file_upload("upload.pl", "application/x-perl") }
 
-    it { is_expected.to_not be_valid }
+    it { is_expected.not_to be_valid }
   end
 
   context "with an invalid extension" do
     let(:file) { fixture_file_upload("upload.txt", "application/pdf") }
 
-    it { is_expected.to_not be_valid }
+    it { is_expected.not_to be_valid }
   end
 
   context "with a large file" do
@@ -42,6 +41,6 @@ RSpec.describe FileUploadValidator do
 
     before { allow(file).to receive(:size).and_return(25 * 1024 * 1024) }
 
-    it { is_expected.to_not be_valid }
+    it { is_expected.not_to be_valid }
   end
 end


### PR DESCRIPTION
There are variations in how we write our specs, which will likely
continue to vary as other people contribute to the project.

To reduce the cognitive load on the author when writing and the
maintainer when reading, we can auto-format our specs using the RSpec
cops for Rubocop.

These cops mostly follow the style described in `https://betterspecs.org`.

The exceptions added to `rubocop.yml` are to ensure the cops match the
testing styleguide we already have written.

Feel free to modify the cops if you have a strong opinion on any of
them.

This change brings in the default cops and ensures our codebase doesn't
have any violations.

Also, while there I noticed we have 2 time helpers included in the
project. Seeing as Rails provides this already, it makes sense to ditch
Timecop.