### PR TITLE
Add a declaration page

### DIFF
--- a/app/controllers/referrals/declaration_controller.rb
+++ b/app/controllers/referrals/declaration_controller.rb
@@ -1,0 +1,25 @@
+module Referrals
+  class DeclarationController < BaseController
+    def show
+      @declaration_form = DeclarationForm.new(referral: current_referral)
+    end
+
+    def create
+      @declaration_form =
+        DeclarationForm.new(
+          declaration_form_params.merge(referral: current_referral)
+        )
+      if @declaration_form.save
+        redirect_to referral_confirmation_path(current_referral)
+      else
+        render :show
+      end
+    end
+
+    private
+
+    def declaration_form_params
+      params.require(:declaration_form).permit(:declaration_agreed)
+    end
+  end
+end

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -22,7 +22,7 @@ class ReferralsController < Referrals::BaseController
     @referral_form = ReferralForm.new(referral:)
 
     if @referral_form.save
-      redirect_to referral_confirmation_path(referral)
+      redirect_to referral_declaration_path(referral)
     else
       render :edit
     end

--- a/app/forms/declaration_form.rb
+++ b/app/forms/declaration_form.rb
@@ -1,0 +1,14 @@
+class DeclarationForm
+  include ActiveModel::Model
+
+  attr_accessor :declaration_agreed, :referral
+
+  validates :declaration_agreed, acceptance: true
+  validates :referral, presence: true
+
+  def save
+    return false unless valid?
+
+    referral.update(submitted_at: Time.current)
+  end
+end

--- a/app/views/referrals/declaration/show.html.erb
+++ b/app/views/referrals/declaration/show.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, "#{'Error: ' if @declaration_form.errors.any?}Before you send your referral" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-xl">Before you send your referral</h1>
+    <p>You must confirm that:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you want TRA to investigate this allegation, which could result in the person you’re referring being stopped from teaching</li>
+      <li>all your answers are true to the best of your knowledge and belief</li>
+      <li>you give consent for this referral and any supporting documents to be shared with the person you’re referring and any employer (only your name will be shared with them)</li>
+      <li>you have permission from the relevant third parties for any supporting documents to be shared, for example the police or DBS</li>
+      <li>you understand that you might need to attend a hearing of a professional conduct panel to give evidence should this allegation reach that stage</li>
+    </ul>
+    <p>This declaration is required by law and won’t affect any existing GDPR or other workplace regulations.</p>
+    <%= form_with model: @declaration_form, url: referral_declaration_path(current_referral), method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_check_boxes_fieldset :declaration_agreed, multiple: false, legend: { text: 'Do you agree to this declaration?', size: 'm' } do %>
+        <%= f.govuk_check_box :declaration_agreed, 1, 0, multiple: false, link_errors: true, label: { text: "Yes, I agree" } %>
+      <% end %>
+      <%= f.govuk_submit "Send referral" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,10 @@ en:
   activemodel:
     errors:
       models:
+        declaration_form:
+          attributes:
+            declaration_agreed:
+              accepted: You must agree to the declaration
         have_complained_form:
           attributes:
             complained:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,10 @@ Rails.application.routes.draw do
 
     resource :confirmation, only: %i[show], controller: "referrals/confirmation"
 
+    resource :declaration,
+             only: %i[show create],
+             controller: "referrals/declaration"
+
     resource :organisation,
              only: %i[show update],
              controller: "referrals/organisation"

--- a/db/migrate/20221129112522_add_submitted_at_to_referral.rb
+++ b/db/migrate/20221129112522_add_submitted_at_to_referral.rb
@@ -1,0 +1,5 @@
+class AddSubmittedAtToReferral < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrals, :submitted_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_24_172606) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_29_112522) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -130,6 +130,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_24_172606) do
     t.string "duties_format"
     t.string "duties_details"
     t.boolean "teacher_role_complete"
+    t.datetime "submitted_at", precision: nil
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 

--- a/spec/forms/declaration_form_spec.rb
+++ b/spec/forms/declaration_form_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe DeclarationForm, type: :model do
+  it { is_expected.to validate_presence_of(:referral) }
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:form) { described_class.new(declaration_agreed:, referral:) }
+    let(:referral) { build(:referral) }
+
+    context "when the form is valid" do
+      let(:declaration_agreed) { "1" }
+
+      it "updates the referral's submitted_at timestamp" do
+        form.save
+
+        expect(referral.submitted_at).to be_present
+      end
+    end
+
+    context "when the form is invalid" do
+      let(:declaration_agreed) { "0" }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end

--- a/spec/system/user_submits_referral_spec.rb
+++ b/spec/system/user_submits_referral_spec.rb
@@ -12,6 +12,13 @@ RSpec.feature "User submits a referral", type: :system do
 
     when_i_have_a_complete_referral
     and_i_click_review_and_send
+    then_i_see_the_declaration_page
+
+    when_i_click_send_referral
+    then_i_see_the_missing_declaration_error
+
+    when_i_complete_the_declaration
+    and_i_click_send_referral
     then_i_see_the_confirmation_page
   end
 
@@ -44,8 +51,27 @@ RSpec.feature "User submits a referral", type: :system do
     expect(page).to have_content("We have received your referral")
   end
 
+  def then_i_see_the_declaration_page
+    expect(page).to have_current_path("/referrals/#{@referral.id}/declaration")
+    expect(page).to have_title("Before you send your referral")
+    expect(page).to have_content("Before you send your referral")
+  end
+
+  def then_i_see_the_missing_declaration_error
+    expect(page).to have_content("You must agree to the declaration")
+  end
+
   def then_i_see_the_missing_sections_error
     expect(page).to have_content("Please complete all sections of the referral")
+  end
+
+  def when_i_click_send_referral
+    click_on "Send referral"
+  end
+  alias_method :and_i_click_send_referral, :when_i_click_send_referral
+
+  def when_i_complete_the_declaration
+    check "Yes, I agree", allow_label_click: true
   end
 
   def when_i_have_a_complete_referral


### PR DESCRIPTION
In order for someone to submit a referral, they need to agree to a
declaration statement.

This change introduces the new screen and a timestamp field to represent
when the agreement occurred.

I opted for the timestamp due to the extra dimension of data it
provides, which is particularly useful for calculating how long it took
to create a referral, from creation to submission.

### Link to Trello card

https://trello.com/c/Syyiy9IL/1001-before-you-send-your-referral-page

### Link to screencast

https://www.loom.com/share/08051e555f68486eafec4954fb449d9c

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally

### Screenshots

<img width="1043" alt="Screenshot 2022-11-29 at 12 27 57 pm" src="https://user-images.githubusercontent.com/3126/204531191-8b073cc8-1b4b-4d41-a318-bce4d7eab66a.png">
<img width="1040" alt="Screenshot 2022-11-29 at 12 28 03 pm" src="https://user-images.githubusercontent.com/3126/204531207-47f7382c-ea2c-4712-94d5-669f3044a43d.png">
