### PR TITLE
Design review evidence section amendments

### DIFF
--- a/app/controllers/referrals/evidence/confirm_controller.rb
+++ b/app/controllers/referrals/evidence/confirm_controller.rb
@@ -26,7 +26,9 @@ module Referrals
 
         redirect_to(
           referrals_edit_evidence_confirm_path(current_referral),
-          notice: "#{filename} deleted"
+          flash: {
+            success: "#{filename} deleted"
+          }
         )
       end
 

--- a/app/views/referrals/evidence/confirm/edit.html.erb
+++ b/app/views/referrals/evidence/confirm/edit.html.erb
@@ -17,7 +17,7 @@
     rows = [
       {
         actions: [
-          { text: "Change", href: "#", visually_hidden_text: "evidence" },
+          { text: "Change", href: referrals_edit_evidence_start_path(current_referral), visually_hidden_text: "evidence" },
         ],
         key: { text: "Documents" },
         value: { text: "No evidence uploaded" },

--- a/app/views/referrals/evidence/upload/show.html.erb
+++ b/app/views/referrals/evidence/upload/show.html.erb
@@ -11,7 +11,9 @@
 
     <ul class="govuk-list govuk-!-margin-bottom-6">
       <% current_referral.evidences.each do |evidence| %>
-        <li><a href="#"><%= evidence.filename %></a></li>
+        <li>
+          <%= govuk_link_to(evidence.filename, rails_blob_path(evidence.document, disposition: "attachment")) %>
+        </li>
       <% end %>
     </ul>
     <%= govuk_link_to "Save and continue", referrals_edit_evidence_categories_path(current_referral, current_referral.evidences.first), class: "govuk-button" %>


### PR DESCRIPTION
### Context

A few amendments from design review.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/93511/204559198-228cd239-12a1-46c8-8f7d-19e73370f706.png)

- Use flash success message for evidence deletion.
- Provide download link for uploaded evidence.
- _Change_ link should go back to the start of the section if no evidence is uploaded.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/eb2uigM5/988-rsm-employer-form-delete-evidence

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
