### PR TITLE
Refactor redirecting from the confirm page

### DIFF
--- a/app/components/about_you_component.rb
+++ b/app/components/about_you_component.rb
@@ -11,7 +11,11 @@ class AboutYouComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: edit_referral_referrer_name_path(referral),
+            href:
+              edit_referral_referrer_name_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "name"
           }
         ],
@@ -35,7 +39,11 @@ class AboutYouComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: edit_referral_referrer_job_title_path(referral),
+            href:
+              edit_referral_referrer_job_title_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "job title"
           }
         ],
@@ -50,7 +58,11 @@ class AboutYouComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: edit_referral_referrer_phone_path(referral),
+            href:
+              edit_referral_referrer_phone_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "phone"
           }
         ],

--- a/app/components/contact_details_component.rb
+++ b/app/components/contact_details_component.rb
@@ -1,5 +1,6 @@
 class ContactDetailsComponent < ViewComponent::Base
   include ActiveModel::Model
+  include ReferrerHelper
 
   attr_accessor :referral
 
@@ -9,7 +10,11 @@ class ContactDetailsComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_contact_details_email_path(referral),
+            href:
+              referrals_edit_contact_details_email_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "email"
           }
         ],
@@ -24,7 +29,30 @@ class ContactDetailsComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_contact_details_address_path(referral),
+            href:
+              referrals_edit_contact_details_telephone_path(
+                referral,
+                return_to: request.url
+              ),
+            visually_hidden_text: "telephone"
+          }
+        ],
+        key: {
+          text: "Phone number"
+        },
+        value: {
+          text: referral.phone_known ? referral.phone_number : "Not known"
+        }
+      },
+      {
+        actions: [
+          {
+            text: "Change",
+            href:
+              referrals_edit_contact_details_address_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "address"
           }
         ],

--- a/app/components/organisation_component.rb
+++ b/app/components/organisation_component.rb
@@ -1,18 +1,10 @@
 class OrganisationComponent < ViewComponent::Base
   include ActiveModel::Model
+  include ReferrerHelper
 
   attr_accessor :referral
 
   delegate :organisation, to: :referral
-
-  def organisation_address
-    [
-      organisation.street_1,
-      organisation.street_2,
-      organisation.city,
-      organisation.postcode
-    ].compact_blank.join("<br />").html_safe
-  end
 
   def rows
     [
@@ -20,7 +12,11 @@ class OrganisationComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: edit_referral_organisation_name_path(referral),
+            href:
+              edit_referral_organisation_name_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "name"
           }
         ],
@@ -35,7 +31,11 @@ class OrganisationComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: edit_referral_organisation_address_path(referral),
+            href:
+              edit_referral_organisation_address_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "address"
           }
         ],
@@ -43,7 +43,7 @@ class OrganisationComponent < ViewComponent::Base
           text: "Address"
         },
         value: {
-          text: organisation_address
+          text: organisation_address(organisation)
         }
       }
     ]

--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -9,7 +9,11 @@ class PersonalDetailsComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_personal_details_name_path(referral),
+            href:
+              referrals_edit_personal_details_name_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "name"
           }
         ],
@@ -24,7 +28,11 @@ class PersonalDetailsComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_personal_details_age_path(referral),
+            href:
+              referrals_edit_personal_details_age_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "date of birth"
           }
         ],
@@ -39,7 +47,11 @@ class PersonalDetailsComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_personal_details_trn_path(referral),
+            href:
+              referrals_edit_personal_details_trn_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "teacher reference number (TRN)"
           }
         ],
@@ -54,7 +66,11 @@ class PersonalDetailsComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_personal_details_qts_path(referral),
+            href:
+              referrals_edit_personal_details_qts_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "do they have QTS?"
           }
         ],

--- a/app/components/previous_misconduct_component.rb
+++ b/app/components/previous_misconduct_component.rb
@@ -10,7 +10,11 @@ class PreviousMisconductComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: edit_referral_previous_misconduct_reported_path(referral),
+            href:
+              edit_referral_previous_misconduct_reported_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "reported"
           }
         ],
@@ -28,7 +32,10 @@ class PreviousMisconductComponent < ViewComponent::Base
           {
             text: "Change",
             href:
-              edit_referral_previous_misconduct_detailed_account_path(referral),
+              edit_referral_previous_misconduct_detailed_account_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "details"
           }
         ],

--- a/app/components/their_role_component.rb
+++ b/app/components/their_role_component.rb
@@ -1,5 +1,6 @@
 class TheirRoleComponent < ViewComponent::Base
   include ActiveModel::Model
+  include ReferralHelper
 
   attr_accessor :referral
 
@@ -14,7 +15,7 @@ class TheirRoleComponent < ViewComponent::Base
           }
         ],
         key: {
-          text: "Start date"
+          text: "Job start date"
         },
         value: {
           text:
@@ -62,6 +63,36 @@ class TheirRoleComponent < ViewComponent::Base
         },
         value: {
           text: referral.job_title || "Not known"
+        }
+      },
+      {
+        actions: [
+          {
+            text: "Change",
+            href: referrals_edit_teacher_same_organisation_path(referral),
+            visually_hidden_text: "working in the same organisation"
+          }
+        ],
+        key: {
+          text: "Do they work in the same organisation as you"
+        },
+        value: {
+          text: referral.same_organisation ? "Yes" : "No"
+        }
+      },
+      {
+        actions: [
+          {
+            text: "Change",
+            href: referrals_edit_teacher_duties_path(referral),
+            visually_hidden_text: "main duties"
+          }
+        ],
+        key: {
+          text: "About their main duties"
+        },
+        value: {
+          text: duties_details(referral)
         }
       }
     ]

--- a/app/components/what_happened_component.rb
+++ b/app/components/what_happened_component.rb
@@ -14,7 +14,11 @@ class WhatHappenedComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_allegation_details_path(referral),
+            href:
+              referrals_edit_allegation_details_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "summary"
           }
         ],
@@ -29,7 +33,11 @@ class WhatHappenedComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_allegation_dbs_path(referral),
+            href:
+              referrals_edit_allegation_dbs_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "DBS notified"
           }
         ],

--- a/app/controllers/referrals/allegation/dbs_controller.rb
+++ b/app/controllers/referrals/allegation/dbs_controller.rb
@@ -14,7 +14,7 @@ module Referrals
           DbsForm.new(allegation_dbs_params.merge(referral: current_referral))
 
         if @allegation_dbs_form.save
-          redirect_to referrals_edit_allegation_confirm_path(current_referral)
+          redirect_to next_page
         else
           render :edit
         end
@@ -24,6 +24,10 @@ module Referrals
 
       def allegation_dbs_params
         params.fetch(:referrals_allegation_dbs_form, {}).permit(:dbs_notified)
+      end
+
+      def next_path
+        referrals_edit_allegation_confirm_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/allegation/details_controller.rb
+++ b/app/controllers/referrals/allegation/details_controller.rb
@@ -12,7 +12,7 @@ module Referrals
           )
 
         if @allegation_details_form.save
-          redirect_to referrals_edit_allegation_dbs_path(current_referral)
+          redirect_to next_page
         else
           render :edit
         end
@@ -26,6 +26,10 @@ module Referrals
           :allegation_details,
           :allegation_upload
         )
+      end
+
+      def next_path
+        referrals_edit_allegation_dbs_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -5,6 +5,10 @@ module Referrals
                   if: -> { FeatureFlags::FeatureFlag.active?(:user_accounts) }
     before_action :redirect_if_feature_flag_disabled
     before_action :redirect_referrals_requests_if_user_accounts_disabled
+    before_action :set_return_to_url, only: :edit
+
+    def edit
+    end
 
     private
 
@@ -28,15 +32,24 @@ module Referrals
       store_location_for(:user, request.fullpath)
     end
 
-    def go_to_check_answers?
-      params["go_to_check_answers"] == "true"
-    end
-
     def redirect_referrals_requests_if_user_accounts_disabled
       return if request.path !~ %r{^/referral}
       return if FeatureFlags::FeatureFlag.active?(:user_accounts)
 
       redirect_to root_path
+    end
+
+    def set_return_to_url
+      session[:return_to] = params["return_to"]
+    end
+
+    def next_page
+      session.delete(:return_to) || next_path
+    end
+
+    # Overwrite this method with the path of the next page in the journey
+    def next_path
+      root_path
     end
   end
 end

--- a/app/controllers/referrals/contact_details/address_controller.rb
+++ b/app/controllers/referrals/contact_details/address_controller.rb
@@ -21,9 +21,7 @@ module Referrals
             )
           )
         if @contact_details_address_form.save
-          redirect_to referrals_update_contact_details_check_answers_path(
-                        current_referral
-                      )
+          redirect_to next_page
         else
           render :edit
         end
@@ -40,6 +38,10 @@ module Referrals
           :postcode,
           :country
         )
+      end
+
+      def next_path
+        referrals_update_contact_details_check_answers_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/contact_details/email_controller.rb
+++ b/app/controllers/referrals/contact_details/email_controller.rb
@@ -15,7 +15,7 @@ module Referrals
             contact_details_email_form_params.merge(referral: current_referral)
           )
         if @contact_details_email_form.save
-          redirect_to save_redirect_path
+          redirect_to next_page
         else
           render :edit
         end
@@ -30,15 +30,7 @@ module Referrals
         )
       end
 
-      def save_redirect_path
-        if go_to_check_answers?
-          return(
-            referrals_update_contact_details_check_answers_path(
-              current_referral
-            )
-          )
-        end
-
+      def next_path
         referrals_update_contact_details_telephone_path(current_referral)
       end
     end

--- a/app/controllers/referrals/contact_details/telephone_controller.rb
+++ b/app/controllers/referrals/contact_details/telephone_controller.rb
@@ -17,7 +17,7 @@ module Referrals
             )
           )
         if @contact_details_telephone_form.save
-          redirect_to save_redirect_path
+          redirect_to next_page
         else
           render :edit
         end
@@ -32,15 +32,7 @@ module Referrals
         )
       end
 
-      def save_redirect_path
-        if go_to_check_answers?
-          return(
-            referrals_update_contact_details_check_answers_path(
-              current_referral
-            )
-          )
-        end
-
+      def next_path
         referrals_update_contact_details_address_path(current_referral)
       end
     end

--- a/app/controllers/referrals/organisation_address_controller.rb
+++ b/app/controllers/referrals/organisation_address_controller.rb
@@ -11,7 +11,7 @@ module Referrals
           organisation_address_form_params.merge(referral: current_referral)
         )
       if @organisation_address_form.save
-        redirect_to referral_organisation_path(current_referral)
+        redirect_to next_page
       else
         render :edit
       end
@@ -26,6 +26,10 @@ module Referrals
         :city,
         :postcode
       )
+    end
+
+    def next_path
+      referral_organisation_path(current_referral)
     end
   end
 end

--- a/app/controllers/referrals/organisation_name_controller.rb
+++ b/app/controllers/referrals/organisation_name_controller.rb
@@ -11,7 +11,7 @@ module Referrals
           organisation_name_form_params.merge(referral: current_referral)
         )
       if @organisation_name_form.save
-        redirect_to save_redirect_path
+        redirect_to next_page
       else
         render :edit
       end
@@ -19,11 +19,7 @@ module Referrals
 
     private
 
-    def save_redirect_path
-      if go_to_check_answers?
-        return referral_organisation_path(current_referral)
-      end
-
+    def next_path
       edit_referral_organisation_address_path(current_referral)
     end
 

--- a/app/controllers/referrals/personal_details/age_controller.rb
+++ b/app/controllers/referrals/personal_details/age_controller.rb
@@ -19,7 +19,7 @@ module Referrals
           )
 
         if @personal_details_age_form.save
-          redirect_to referrals_edit_personal_details_trn_path(current_referral)
+          redirect_to next_page
         else
           render :edit
         end
@@ -37,6 +37,10 @@ module Referrals
           "date_of_birth(2i)",
           "date_of_birth(3i)"
         )
+      end
+
+      def next_path
+        referrals_edit_personal_details_trn_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/personal_details/name_controller.rb
+++ b/app/controllers/referrals/personal_details/name_controller.rb
@@ -17,7 +17,7 @@ module Referrals
           NameForm.new(name_params.merge(referral: current_referral))
 
         if @personal_details_name_form.save
-          redirect_to referrals_edit_personal_details_age_path(current_referral)
+          redirect_to next_page
         else
           render :edit
         end
@@ -32,6 +32,10 @@ module Referrals
           :name_has_changed,
           :previous_name
         )
+      end
+
+      def next_path
+        referrals_edit_personal_details_age_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/personal_details/qts_controller.rb
+++ b/app/controllers/referrals/personal_details/qts_controller.rb
@@ -14,9 +14,7 @@ module Referrals
           QtsForm.new(qts_params.merge(referral: current_referral))
 
         if @personal_details_qts_form.save
-          redirect_to referrals_edit_personal_details_confirm_path(
-                        current_referral
-                      )
+          redirect_to next_page
         else
           render :edit
         end
@@ -26,6 +24,10 @@ module Referrals
 
       def qts_params
         params.fetch(:referrals_personal_details_qts_form, {}).permit(:has_qts)
+      end
+
+      def next_path
+        referrals_edit_personal_details_confirm_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/personal_details/trn_controller.rb
+++ b/app/controllers/referrals/personal_details/trn_controller.rb
@@ -15,7 +15,7 @@ module Referrals
           TrnForm.new(trn_params.merge(referral: current_referral))
 
         if @personal_details_trn_form.save
-          redirect_to referrals_edit_personal_details_qts_path(current_referral)
+          redirect_to next_page
         else
           render :edit
         end
@@ -28,6 +28,10 @@ module Referrals
           :trn_known,
           :trn
         )
+      end
+
+      def next_path
+        referrals_edit_personal_details_qts_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/previous_misconduct_detailed_account_controller.rb
+++ b/app/controllers/referrals/previous_misconduct_detailed_account_controller.rb
@@ -13,7 +13,7 @@ module Referrals
           )
         )
       if @detailed_account_form.save
-        redirect_to referral_previous_misconduct_path(current_referral)
+        redirect_to next_page
       else
         render :edit
       end
@@ -27,6 +27,10 @@ module Referrals
         :format,
         :upload
       )
+    end
+
+    def next_path
+      referral_previous_misconduct_path(current_referral)
     end
   end
 end

--- a/app/controllers/referrals/previous_misconduct_reported_controller.rb
+++ b/app/controllers/referrals/previous_misconduct_reported_controller.rb
@@ -14,9 +14,7 @@ module Referrals
         )
       if @previous_misconduct_reported_form.save
         if current_referral.previous_misconduct_reported?
-          redirect_to edit_referral_previous_misconduct_detailed_account_path(
-                        current_referral
-                      )
+          redirect_to next_page
         else
           redirect_to referral_previous_misconduct_path(current_referral)
         end
@@ -31,6 +29,18 @@ module Referrals
       params.require(:previous_misconduct_reported_form).permit(
         :previous_misconduct_reported
       )
+    end
+
+    def next_path
+      edit_referral_previous_misconduct_detailed_account_path(current_referral)
+    end
+
+    def next_page
+      if @previous_misconduct_reported_form.referral.saved_changes?
+        return next_path
+      end
+
+      super
     end
   end
 end

--- a/app/controllers/referrals/referrer_job_title_controller.rb
+++ b/app/controllers/referrals/referrer_job_title_controller.rb
@@ -11,7 +11,7 @@ module Referrals
           job_title_params.merge(referral: current_referral)
         )
       if @referrer_job_title_form.save
-        redirect_to edit_referral_referrer_phone_path(current_referral)
+        redirect_to next_page
       else
         render :edit
       end
@@ -21,6 +21,10 @@ module Referrals
 
     def job_title_params
       params.require(:referrer_job_title_form).permit(:job_title)
+    end
+
+    def next_path
+      edit_referral_referrer_phone_path(current_referral)
     end
   end
 end

--- a/app/controllers/referrals/referrer_name_controller.rb
+++ b/app/controllers/referrals/referrer_name_controller.rb
@@ -11,7 +11,7 @@ module Referrals
           name_params.merge(referral: current_referral)
         )
       if @referrer_name_form.save
-        redirect_to edit_referral_referrer_job_title_path(current_referral)
+        redirect_to next_page
       else
         render :edit
       end
@@ -21,6 +21,10 @@ module Referrals
 
     def name_params
       params.require(:referrals_referrer_name_form).permit(:name)
+    end
+
+    def next_path
+      edit_referral_referrer_job_title_path(current_referral)
     end
   end
 end

--- a/app/controllers/referrals/referrer_phone_controller.rb
+++ b/app/controllers/referrals/referrer_phone_controller.rb
@@ -10,7 +10,7 @@ module Referrals
           referrer_phone_form_params.merge(referral: current_referral)
         )
       if @referrer_phone_form.save
-        redirect_to referral_referrer_path(current_referral)
+        redirect_to next_page
       else
         render :edit
       end
@@ -20,6 +20,10 @@ module Referrals
 
     def referrer_phone_form_params
       params.require(:referrer_phone_form).permit(:phone)
+    end
+
+    def next_path
+      referral_referrer_path(current_referral)
     end
   end
 end

--- a/app/controllers/referrals/teacher_role/duties_controller.rb
+++ b/app/controllers/referrals/teacher_role/duties_controller.rb
@@ -16,9 +16,7 @@ module Referrals
           DutiesForm.new(duties_params.merge(referral: current_referral))
 
         if @duties_form.save
-          redirect_to referrals_edit_teacher_role_check_answers_path(
-                        current_referral
-                      )
+          redirect_to next_page
         else
           render :edit
         end
@@ -32,6 +30,10 @@ module Referrals
           :duties_details,
           :duties_upload
         )
+      end
+
+      def next_path
+        referrals_edit_teacher_role_check_answers_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/teacher_role/employment_status_controller.rb
+++ b/app/controllers/referrals/teacher_role/employment_status_controller.rb
@@ -21,7 +21,7 @@ module Referrals
           )
 
         if @employment_status_form.save
-          redirect_to save_redirect_path
+          redirect_to next_page
         else
           render :edit
         end
@@ -44,13 +44,7 @@ module Referrals
         )
       end
 
-      def save_redirect_path
-        if go_to_check_answers?
-          return(
-            referrals_edit_teacher_role_check_answers_path(current_referral)
-          )
-        end
-
+      def next_path
         referrals_edit_teacher_job_title_path(current_referral)
       end
     end

--- a/app/controllers/referrals/teacher_role/job_title_controller.rb
+++ b/app/controllers/referrals/teacher_role/job_title_controller.rb
@@ -14,7 +14,7 @@ module Referrals
           JobTitleForm.new(job_title_params.merge(referral: current_referral))
 
         if @job_title_form.save
-          redirect_to save_redirect_path
+          redirect_to next_page
         else
           render :edit
         end
@@ -28,13 +28,7 @@ module Referrals
         )
       end
 
-      def save_redirect_path
-        if go_to_check_answers?
-          return(
-            referrals_edit_teacher_role_check_answers_path(current_referral)
-          )
-        end
-
+      def next_path
         referrals_edit_teacher_same_organisation_path(current_referral)
       end
     end

--- a/app/controllers/referrals/teacher_role/same_organisation_controller.rb
+++ b/app/controllers/referrals/teacher_role/same_organisation_controller.rb
@@ -16,7 +16,7 @@ module Referrals
           )
 
         if @same_organisation_form.save
-          redirect_to save_redirect_path
+          redirect_to next_page
         else
           render :edit
         end
@@ -30,13 +30,7 @@ module Referrals
         )
       end
 
-      def save_redirect_path
-        if go_to_check_answers?
-          return(
-            referrals_edit_teacher_role_check_answers_path(current_referral)
-          )
-        end
-
+      def next_path
         referrals_edit_teacher_duties_path(current_referral)
       end
     end

--- a/app/controllers/referrals/teacher_role/start_date_controller.rb
+++ b/app/controllers/referrals/teacher_role/start_date_controller.rb
@@ -20,7 +20,7 @@ module Referrals
           )
 
         if @role_start_date_form.save
-          redirect_to save_redirect_path
+          redirect_to next_page
         else
           render :edit
         end
@@ -42,13 +42,7 @@ module Referrals
         )
       end
 
-      def save_redirect_path
-        if go_to_check_answers?
-          return(
-            referrals_edit_teacher_role_check_answers_path(current_referral)
-          )
-        end
-
+      def next_path
         referrals_edit_teacher_employment_status_path(current_referral)
       end
     end

--- a/app/forms/referrals/teacher_role/check_answers_form.rb
+++ b/app/forms/referrals/teacher_role/check_answers_form.rb
@@ -18,16 +18,6 @@ module Referrals
 
         referral.update(teacher_role_complete:)
       end
-
-      def duties_details
-        if referral.duties_upload.attached?
-          "File: #{referral.duties_upload.filename}"
-        elsif referral.duties_details.present?
-          referral.duties_details.truncate(150, " ")
-        else
-          "Incomplete"
-        end
-      end
     end
   end
 end

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -15,4 +15,14 @@ module ReferralHelper
       referrals_edit_evidence_start_path(referral)
     end
   end
+
+  def duties_details(referral)
+    if referral.duties_upload.attached?
+      "File: #{referral.duties_upload.filename}"
+    elsif referral.duties_details.present?
+      referral.duties_details.truncate(150, " ")
+    else
+      "Incomplete"
+    end
+  end
 end

--- a/app/views/referrals/allegation/confirm/edit.html.erb
+++ b/app/views/referrals/allegation/confirm/edit.html.erb
@@ -1,36 +1,13 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_confirm_form.errors.any?}Check and confirm your answers" %>
 <% content_for :back_link_url, url_for(:back) %>
 
-<% rows = [
-  {
-    actions: [
-      { text: "Change", href: referrals_edit_allegation_details_path(current_referral, return_to: request.url), visually_hidden_text: "detailed account" },
-    ],
-    key: { text: "Detailed account" },
-    value: { text: @allegation_confirm_form.allegation_details },
-  },
-  {
-    actions: [
-      { text: "Change", href: referrals_edit_allegation_dbs_path(current_referral, return_to: request.url), visually_hidden_text: "DBS notified" },
-    ],
-    key: { text: "Have you told DBS?" },
-    value: { text: current_referral.dbs_notified ? "Yes" : "No" },
-  },
-] %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">
-          Check and confirm your answers
-        </h1>
-      </div>
-    </div>
+    <h1 class="govuk-heading-xl">
+      Check and confirm your answers
+    </h1>
 
-    <%= render(SummaryCardComponent.new(rows:)) do %>
-      <%= render SummaryCardHeaderComponent.new(title: "What happened") %>
-    <% end %>
+    <%= render WhatHappenedComponent.new(referral: current_referral) %>
 
     <%= form_with model: @allegation_confirm_form, url: referrals_update_allegation_confirm_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/referrals/allegation/confirm/edit.html.erb
+++ b/app/views/referrals/allegation/confirm/edit.html.erb
@@ -4,14 +4,14 @@
 <% rows = [
   {
     actions: [
-      { text: "Change", href: referrals_edit_allegation_details_path(current_referral), visually_hidden_text: "detailed account" },
+      { text: "Change", href: referrals_edit_allegation_details_path(current_referral, return_to: request.url), visually_hidden_text: "detailed account" },
     ],
     key: { text: "Detailed account" },
     value: { text: @allegation_confirm_form.allegation_details },
   },
   {
     actions: [
-      { text: "Change", href: referrals_edit_allegation_dbs_path(current_referral), visually_hidden_text: "DBS notified" },
+      { text: "Change", href: referrals_edit_allegation_dbs_path(current_referral, return_to: request.url), visually_hidden_text: "DBS notified" },
     ],
     key: { text: "Have you told DBS?" },
     value: { text: current_referral.dbs_notified ? "Yes" : "No" },

--- a/app/views/referrals/contact_details/check_answers/edit.html.erb
+++ b/app/views/referrals/contact_details/check_answers/edit.html.erb
@@ -7,35 +7,8 @@
       <span class="govuk-caption-xl">About the person you are referring</span>
       Check and confirm your answers
     </h1>
-    <% rows = [
-      {
-        actions: [
-          { text: "Change", href: referrals_edit_contact_details_email_path(current_referral, return_to: request.url), visually_hidden_text: "email" },
 
-        ],
-        key: { text: "Email address" },
-        value: { text: current_referral.email_known ? current_referral.email_address : "Not known" },
-      },
-      {
-        actions: [
-          { text: "Change", href: referrals_edit_contact_details_telephone_path(current_referral, return_to: request.url), visually_hidden_text: "telephone" },
-
-        ],
-        key: { text: "Phone number" },
-        value: { text: current_referral.phone_known ? current_referral.phone_number : "Not known" },
-      },
-      {
-        actions: [
-          { text: "Change", href: referrals_edit_contact_details_address_path(current_referral, return_to: request.url), visually_hidden_text: "address" },
-
-        ],
-        key: { text: "Address" },
-        value: { text: current_referral.address_known ? address(current_referral) : "Not known" },
-      }
-    ] %>
-    <%= render(SummaryCardComponent.new(rows:)) do %>
-      <%= render SummaryCardHeaderComponent.new(title: 'Contact details') %>
-    <% end %>
+    <%= render ContactDetailsComponent.new(referral: current_referral) %>
 
     <%= form_with model: @contact_details_check_answers_form, url: referrals_update_contact_details_check_answers_url, method: :put do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/referrals/contact_details/check_answers/edit.html.erb
+++ b/app/views/referrals/contact_details/check_answers/edit.html.erb
@@ -10,7 +10,7 @@
     <% rows = [
       {
         actions: [
-          { text: "Change", href: referrals_edit_contact_details_email_path(current_referral), visually_hidden_text: "email" },
+          { text: "Change", href: referrals_edit_contact_details_email_path(current_referral, return_to: request.url), visually_hidden_text: "email" },
 
         ],
         key: { text: "Email address" },
@@ -18,7 +18,7 @@
       },
       {
         actions: [
-          { text: "Change", href: referrals_edit_contact_details_telephone_path(current_referral), visually_hidden_text: "telephone" },
+          { text: "Change", href: referrals_edit_contact_details_telephone_path(current_referral, return_to: request.url), visually_hidden_text: "telephone" },
 
         ],
         key: { text: "Phone number" },
@@ -26,7 +26,7 @@
       },
       {
         actions: [
-          { text: "Change", href: referrals_edit_contact_details_address_path(current_referral), visually_hidden_text: "address" },
+          { text: "Change", href: referrals_edit_contact_details_address_path(current_referral, return_to: request.url), visually_hidden_text: "address" },
 
         ],
         key: { text: "Address" },

--- a/app/views/referrals/contact_details/email/edit.html.erb
+++ b/app/views/referrals/contact_details/email/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @contact_details_email_form, url: referrals_update_contact_details_email_url, method: :put do |f| %>
       <%= f.govuk_error_summary %>
-      <%= hidden_field_tag :go_to_check_answers, request.referrer == referrals_update_contact_details_check_answers_url(current_referral) %>
+
       <%= f.govuk_radio_buttons_fieldset :email_known, legend: { size: "l", text: "Do you know the personal email address of the person you are referring?" }  do %>
         <%= f.hidden_field :email_known %>
         <%= f.govuk_radio_button :email_known, true, label: { text: "Yes" } do %>

--- a/app/views/referrals/contact_details/telephone/edit.html.erb
+++ b/app/views/referrals/contact_details/telephone/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @contact_details_telephone_form, url: referrals_update_contact_details_telephone_url, method: :put do |f| %>
       <%= f.govuk_error_summary %>
-      <%= hidden_field_tag :go_to_check_answers, request.referrer == referrals_update_contact_details_check_answers_url(current_referral) %>
+
       <%= f.govuk_radio_buttons_fieldset :phone_known, legend: { size: "xl", text: "Do you know their main contact number?" }  do %>
         <%= f.hidden_field :phone_known %>
         <%= f.govuk_radio_button :phone_known, true, label: { text: "Yes" } do %>

--- a/app/views/referrals/evidence/confirm/edit.html.erb
+++ b/app/views/referrals/evidence/confirm/edit.html.erb
@@ -1,44 +1,13 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_confirm_form.errors.any?}Check and confirm your answers" %>
 <% content_for :back_link_url, evidence_confirm_back_link(current_referral) %>
 
-<% 
-  if current_referral.evidences.any?
-    rows = current_referral.evidences.map do |evidence|
-      {
-        actions: [
-          { text: "Change", href: referrals_edit_evidence_categories_path(current_referral, evidence), visually_hidden_text: "categories" },
-          { text: "Delete", href: referrals_delete_evidence_path(current_referral, evidence), visually_hidden_text: "evidence upload" },
-        ],
-        key: { text: evidence.filename },
-        value: { text: Referrals::Evidence::CategoriesForm.selected_categories(evidence).join(", ") },
-      }
-    end
-  else
-    rows = [
-      {
-        actions: [
-          { text: "Change", href: referrals_edit_evidence_start_path(current_referral), visually_hidden_text: "evidence" },
-        ],
-        key: { text: "Documents" },
-        value: { text: "No evidence uploaded" },
-      },
-    ]
-  end
-%>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">
-          Check and confirm your answers
-        </h1>
-      </div>
-    </div>
+    <h1 class="govuk-heading-xl">
+      Check and confirm your answers
+    </h1>
 
-    <%= render(SummaryCardComponent.new(rows:)) do %>
-      <%= render SummaryCardHeaderComponent.new(title: "Evidence") %>
-    <% end %>
+    <%= render EvidenceComponent.new(referral: current_referral) %>
 
     <%= form_with model: @evidence_confirm_form, url: referrals_update_evidence_confirm_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/referrals/organisation/show.html.erb
+++ b/app/views/referrals/organisation/show.html.erb
@@ -6,27 +6,8 @@
       <span class="govuk-caption-xl">About you</span>
       Your organisation
     </h1>
-    <% rows = [
-      {
-        actions: [
-          { text: "Change", href: edit_referral_organisation_name_path(current_referral, return_to: request.url), visually_hidden_text: "name" },
 
-        ],
-        key: { text: "Organisation" },
-        value: { text: @organisation.name },
-      },
-      {
-        actions: [
-          { text: "Change", href: edit_referral_organisation_address_path(current_referral, return_to: request.url), visually_hidden_text: "address" },
-
-        ],
-        key: { text: "Address" },
-        value: { text: organisation_address(@organisation) },
-      },
-    ] %>
-    <%= render(SummaryCardComponent.new(rows:)) do %>
-      <%= render SummaryCardHeaderComponent.new(title: 'Your organisation') %>
-    <% end %>
+    <%= render OrganisationComponent.new(referral: current_referral) %>
 
     <%= form_with model: @organisation_form, url: referral_organisation_path(current_referral), method: :patch do |f| %>
       <%= f.govuk_radio_buttons_fieldset :complete, legend: { size: 'm', text: 'Have you completed this section?' } do %>

--- a/app/views/referrals/organisation/show.html.erb
+++ b/app/views/referrals/organisation/show.html.erb
@@ -9,7 +9,7 @@
     <% rows = [
       {
         actions: [
-          { text: "Change", href: edit_referral_organisation_name_path(current_referral), visually_hidden_text: "name" },
+          { text: "Change", href: edit_referral_organisation_name_path(current_referral, return_to: request.url), visually_hidden_text: "name" },
 
         ],
         key: { text: "Organisation" },
@@ -17,7 +17,7 @@
       },
       {
         actions: [
-          { text: "Change", href: edit_referral_organisation_address_path(current_referral), visually_hidden_text: "address" },
+          { text: "Change", href: edit_referral_organisation_address_path(current_referral, return_to: request.url), visually_hidden_text: "address" },
 
         ],
         key: { text: "Address" },

--- a/app/views/referrals/organisation_name/edit.html.erb
+++ b/app/views/referrals/organisation_name/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @organisation_name_form, url: referral_organisation_name_url(current_referral), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
-      <%= hidden_field_tag :go_to_check_answers, request.referrer == referral_organisation_url(current_referral) %>
+
       <%= f.govuk_text_field :name, label: { size: 'xl', text: "What’s the name of your organisation?" } %>
 
       <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>

--- a/app/views/referrals/personal_details/confirm/edit.html.erb
+++ b/app/views/referrals/personal_details/confirm/edit.html.erb
@@ -4,28 +4,28 @@
 <% rows = [
   {
     actions: [
-      { text: "Change", href: referrals_edit_personal_details_name_path(current_referral), visually_hidden_text: "name" },
+      { text: "Change", href: referrals_edit_personal_details_name_path(current_referral, return_to: request.url), visually_hidden_text: "name" },
     ],
     key: { text: "Name" },
     value: { text: "#{current_referral.first_name} #{current_referral.last_name}" },
   },
   {
     actions: [
-      { text: "Change", href: referrals_edit_personal_details_age_path(current_referral), visually_hidden_text: "date of birth" },
+      { text: "Change", href: referrals_edit_personal_details_age_path(current_referral, return_to: request.url), visually_hidden_text: "date of birth" },
     ],
     key: { text: "Date of birth" },
     value: { text: current_referral.date_of_birth&.to_fs(:long_ordinal_uk) },
   },
   {
     actions: [
-      { text: "Change", href: referrals_edit_personal_details_trn_path(current_referral), visually_hidden_text: "teacher reference number (TRN)" },
+      { text: "Change", href: referrals_edit_personal_details_trn_path(current_referral, return_to: request.url), visually_hidden_text: "teacher reference number (TRN)" },
     ],
     key: { text: "Teacher reference number (TRN)" },
     value: { text: current_referral.trn },
   },
   {
     actions: [
-      { text: "Change", href: referrals_edit_personal_details_qts_path(current_referral), visually_hidden_text: "do they have QTS?" },
+      { text: "Change", href: referrals_edit_personal_details_qts_path(current_referral, return_to: request.url), visually_hidden_text: "do they have QTS?" },
     ],
     key: { text: "Do they have QTS?" },
     value: { text: current_referral.has_qts&.humanize },

--- a/app/views/referrals/personal_details/confirm/edit.html.erb
+++ b/app/views/referrals/personal_details/confirm/edit.html.erb
@@ -1,51 +1,14 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_confirm_form.errors.any?}Personal details" %>
 <% content_for :back_link_url, url_for(:back) %>
 
-<% rows = [
-  {
-    actions: [
-      { text: "Change", href: referrals_edit_personal_details_name_path(current_referral, return_to: request.url), visually_hidden_text: "name" },
-    ],
-    key: { text: "Name" },
-    value: { text: "#{current_referral.first_name} #{current_referral.last_name}" },
-  },
-  {
-    actions: [
-      { text: "Change", href: referrals_edit_personal_details_age_path(current_referral, return_to: request.url), visually_hidden_text: "date of birth" },
-    ],
-    key: { text: "Date of birth" },
-    value: { text: current_referral.date_of_birth&.to_fs(:long_ordinal_uk) },
-  },
-  {
-    actions: [
-      { text: "Change", href: referrals_edit_personal_details_trn_path(current_referral, return_to: request.url), visually_hidden_text: "teacher reference number (TRN)" },
-    ],
-    key: { text: "Teacher reference number (TRN)" },
-    value: { text: current_referral.trn },
-  },
-  {
-    actions: [
-      { text: "Change", href: referrals_edit_personal_details_qts_path(current_referral, return_to: request.url), visually_hidden_text: "do they have QTS?" },
-    ],
-    key: { text: "Do they have QTS?" },
-    value: { text: current_referral.has_qts&.humanize },
-  },
-] %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">
-          <span class="govuk-caption-xl">About the person you are referring</span>
-          Personal details
-        </h1>
-      </div>
-    </div>
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">About the person you are referring</span>
+      Personal details
+    </h1>
 
-    <%= render(SummaryCardComponent.new(rows:)) do %>
-      <%= render SummaryCardHeaderComponent.new(title: "Personal details") %>
-    <% end %>
+    <%= render PersonalDetailsComponent.new(referral: current_referral) %>
 
     <%= form_with model: @personal_details_confirm_form, url: referrals_update_personal_details_confirm_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/referrals/previous_misconduct/show.html.erb
+++ b/app/views/referrals/previous_misconduct/show.html.erb
@@ -2,13 +2,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">
-          Check and confirm your answers
-        </h1>
-      </div>
-    </div>
+    <h1 class="govuk-heading-xl">
+      Check and confirm your answers
+    </h1>
 
     <%= render PreviousMisconductComponent.new(referral: current_referral) %>
 

--- a/app/views/referrals/referrers/show.html.erb
+++ b/app/views/referrals/referrers/show.html.erb
@@ -6,33 +6,8 @@
       <span class="govuk-caption-xl">About you</span>
       Your details
     </h1>
-    <% rows = [
-      {
-        actions: [
-          { text: "Change", href: edit_referral_referrer_name_path(current_referral, return_to: request.url), visually_hidden_text: "name" },
 
-        ],
-        key: { text: "Your name" },
-        value: { text: @referrer.name },
-      },
-      {
-        actions: [
-          { text: "Change", href: edit_referral_referrer_job_title_path(current_referral, return_to: request.url), visually_hidden_text: "job title" },
-        ],
-        key: { text: "Your job title" },
-        value: { text: @referrer.job_title },
-      },
-      {
-        actions: [
-          { text: "Change", href: edit_referral_referrer_phone_path(current_referral, return_to: request.url), visually_hidden_text: "phone" },
-        ],
-        key: { text: "Phone number" },
-        value: { text: @referrer.phone },
-      },
-    ] %>
-    <%= render(SummaryCardComponent.new(rows:)) do %>
-      <%= render SummaryCardHeaderComponent.new(title: 'Your details') %>
-    <% end %>
+     <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
 
     <%= form_with model: @referrer_form, url: referral_referrer_path(current_referral), method: :patch do |f| %>
       <%= f.govuk_radio_buttons_fieldset :complete, legend: { size: 'm', text: 'Have you completed this section?' } do %>

--- a/app/views/referrals/referrers/show.html.erb
+++ b/app/views/referrals/referrers/show.html.erb
@@ -9,7 +9,7 @@
     <% rows = [
       {
         actions: [
-          { text: "Change", href: edit_referral_referrer_name_path(current_referral), visually_hidden_text: "name" },
+          { text: "Change", href: edit_referral_referrer_name_path(current_referral, return_to: request.url), visually_hidden_text: "name" },
 
         ],
         key: { text: "Your name" },
@@ -17,14 +17,14 @@
       },
       {
         actions: [
-          { text: "Change", href: edit_referral_referrer_job_title_path(current_referral), visually_hidden_text: "job title" },
+          { text: "Change", href: edit_referral_referrer_job_title_path(current_referral, return_to: request.url), visually_hidden_text: "job title" },
         ],
         key: { text: "Your job title" },
         value: { text: @referrer.job_title },
       },
       {
         actions: [
-          { text: "Change", href: edit_referral_referrer_phone_path(current_referral), visually_hidden_text: "phone" },
+          { text: "Change", href: edit_referral_referrer_phone_path(current_referral, return_to: request.url), visually_hidden_text: "phone" },
         ],
         key: { text: "Phone number" },
         value: { text: @referrer.phone },

--- a/app/views/referrals/teacher_role/check_answers/edit.html.erb
+++ b/app/views/referrals/teacher_role/check_answers/edit.html.erb
@@ -10,7 +10,7 @@
     <% rows = [
       {
         actions: [
-          { text: "Change", href: referrals_edit_teacher_role_start_date_path(current_referral), visually_hidden_text: "start date" },
+          { text: "Change", href: referrals_edit_teacher_role_start_date_path(current_referral, return_to: request.url ), visually_hidden_text: "start date" },
 
         ],
         key: { text: "Job start date" },
@@ -18,7 +18,7 @@
       },
       {
         actions: [
-          { text: "Change", href: referrals_edit_teacher_employment_status_path(current_referral), visually_hidden_text: "employment status" },
+          { text: "Change", href: referrals_edit_teacher_employment_status_path(current_referral, return_to: request.url), visually_hidden_text: "employment status" },
 
         ],
         key: { text: "Are they still employed in that job?" },
@@ -26,7 +26,7 @@
       },
       {
         actions: [
-          { text: "Change", href: referrals_edit_teacher_job_title_path(current_referral), visually_hidden_text: "job title" },
+          { text: "Change", href: referrals_edit_teacher_job_title_path(current_referral, return_to: request.url), visually_hidden_text: "job title" },
 
         ],
         key: { text: "What’s their job title?" },
@@ -34,7 +34,7 @@
       },
       {
         actions: [
-          { text: "Change", href: referrals_edit_teacher_same_organisation_path(current_referral), visually_hidden_text: "working in the same organisation" },
+          { text: "Change", href: referrals_edit_teacher_same_organisation_path(current_referral, return_to: request.url), visually_hidden_text: "working in the same organisation" },
 
         ],
         key: { text: "Do they work in the same organisation as you?" },
@@ -42,7 +42,7 @@
       },
       {
         actions: [
-          { text: "Change", href: referrals_edit_teacher_duties_path(current_referral), visually_hidden_text: "working in the same organisation" },
+          { text: "Change", href: referrals_edit_teacher_duties_path(current_referral, return_to: request.url), visually_hidden_text: "working in the same organisation" },
 
         ],
         key: { text: "About their main duties" },

--- a/app/views/referrals/teacher_role/check_answers/edit.html.erb
+++ b/app/views/referrals/teacher_role/check_answers/edit.html.erb
@@ -7,51 +7,8 @@
       <span class="govuk-caption-xl">About the person you are referring</span>
       Check and confirm your answers
     </h1>
-    <% rows = [
-      {
-        actions: [
-          { text: "Change", href: referrals_edit_teacher_role_start_date_path(current_referral, return_to: request.url ), visually_hidden_text: "start date" },
 
-        ],
-        key: { text: "Job start date" },
-        value: { text: current_referral.role_start_date_known ? current_referral.role_start_date&.to_fs(:long_ordinal_uk) : "Not known" },
-      },
-      {
-        actions: [
-          { text: "Change", href: referrals_edit_teacher_employment_status_path(current_referral, return_to: request.url), visually_hidden_text: "employment status" },
-
-        ],
-        key: { text: "Are they still employed in that job?" },
-        value: { text: current_referral.employment_status ? current_referral.employment_status.humanize : "Not known" },
-      },
-      {
-        actions: [
-          { text: "Change", href: referrals_edit_teacher_job_title_path(current_referral, return_to: request.url), visually_hidden_text: "job title" },
-
-        ],
-        key: { text: "What’s their job title?" },
-        value: { text: current_referral.job_title ? current_referral.job_title : "Not known" },
-      },
-      {
-        actions: [
-          { text: "Change", href: referrals_edit_teacher_same_organisation_path(current_referral, return_to: request.url), visually_hidden_text: "working in the same organisation" },
-
-        ],
-        key: { text: "Do they work in the same organisation as you?" },
-        value: { text: current_referral.same_organisation ? "Yes" : "No" },
-      },
-      {
-        actions: [
-          { text: "Change", href: referrals_edit_teacher_duties_path(current_referral, return_to: request.url), visually_hidden_text: "working in the same organisation" },
-
-        ],
-        key: { text: "About their main duties" },
-        value: { text: @teacher_role_check_answers_form.duties_details },
-      }
-    ] %>
-    <%= render(SummaryCardComponent.new(rows:)) do %>
-      <%= render SummaryCardHeaderComponent.new(title: 'Contact details') %>
-    <% end %>
+    <%= render TheirRoleComponent.new(referral: current_referral) %>
 
     <%= form_with model: @teacher_role_check_answers_form, url: referrals_update_teacher_role_check_answers_url, method: :put do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/referrals/teacher_role/employment_status/edit.html.erb
+++ b/app/views/referrals/teacher_role/employment_status/edit.html.erb
@@ -5,7 +5,6 @@
   <div class="govuk-grid-column-two-thirds-from-desktop ">
     <%= form_with model: @employment_status_form, url: referrals_update_teacher_employment_status_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
-      <%= hidden_field_tag :go_to_check_answers, request.referrer == referrals_update_teacher_role_check_answers_url(current_referral) %>
 
       <%= f.govuk_radio_buttons_fieldset :employment_status, legend: { size: "xl", text: "Are they still employed in that job?" }  do %>
         <%= f.hidden_field :employment_status %>

--- a/app/views/referrals/teacher_role/job_title/edit.html.erb
+++ b/app/views/referrals/teacher_role/job_title/edit.html.erb
@@ -5,7 +5,6 @@
   <div class="govuk-grid-column-two-thirds-from-desktop ">
     <%= form_with model: @job_title_form, url: referrals_update_teacher_job_title_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
-      <%= hidden_field_tag :go_to_check_answers, request.referrer == referrals_update_teacher_role_check_answers_url(current_referral) %>
 
       <%= f.govuk_text_field :job_title,
         label: { text: "What’s their job title?", size: "xl" },

--- a/app/views/referrals/teacher_role/same_organisation/edit.html.erb
+++ b/app/views/referrals/teacher_role/same_organisation/edit.html.erb
@@ -5,7 +5,6 @@
   <div class="govuk-grid-column-two-thirds-from-desktop ">
     <%= form_with model: @same_organisation_form, url: referrals_update_teacher_same_organisation_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
-      <%= hidden_field_tag :go_to_check_answers, request.referrer == referrals_update_teacher_role_check_answers_url(current_referral) %>
 
       <%= f.govuk_radio_buttons_fieldset :same_organisation,
         legend: { size: "l", text: "Do they work in the same organisation as you?" } do %>

--- a/app/views/referrals/teacher_role/start_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/start_date/edit.html.erb
@@ -5,7 +5,6 @@
   <div class="govuk-grid-column-two-thirds-from-desktop ">
     <%= form_with model: @role_start_date_form, url: referrals_update_teacher_role_start_date_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
-      <%= hidden_field_tag :go_to_check_answers, request.referrer == referrals_update_teacher_role_check_answers_url(current_referral) %>
 
       <%= f.govuk_radio_buttons_fieldset :role_start_date_known,
         legend: { size: "l", text: "Do you know when they started their job?" },

--- a/spec/system/referrals/user_adds_an_allegation_spec.rb
+++ b/spec/system/referrals/user_adds_an_allegation_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "Allegation", type: :system do
     summary_rows = all(".govuk-summary-list__row")
 
     within(summary_rows[0]) do
-      expect(find(".govuk-summary-list__key").text).to eq("Detailed account")
+      expect(find(".govuk-summary-list__key").text).to eq("Summary")
       expect(find(".govuk-summary-list__value").text).to eq(
         "Something something something"
       )

--- a/spec/system/referrals/user_adds_an_allegation_spec.rb
+++ b/spec/system/referrals/user_adds_an_allegation_spec.rb
@@ -90,7 +90,11 @@ RSpec.feature "Allegation", type: :system do
       )
       expect(find(".govuk-summary-list__actions")).to have_link(
         "Change",
-        href: referrals_edit_allegation_details_path(@referral)
+        href:
+          referrals_edit_allegation_details_path(
+            @referral,
+            return_to: current_url
+          )
       )
     end
 
@@ -99,7 +103,8 @@ RSpec.feature "Allegation", type: :system do
       expect(find(".govuk-summary-list__value").text).to eq("Yes")
       expect(find(".govuk-summary-list__actions")).to have_link(
         "Change",
-        href: referrals_edit_allegation_dbs_path(@referral)
+        href:
+          referrals_edit_allegation_dbs_path(@referral, return_to: current_url)
       )
     end
   end

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -250,7 +250,11 @@ RSpec.feature "Contact details", type: :system do
       expect(find(".govuk-summary-list__value").text).to eq("name@example.com")
       expect(find(".govuk-summary-list__actions")).to have_link(
         "Change",
-        href: referrals_edit_contact_details_email_path(@referral)
+        href:
+          referrals_edit_contact_details_email_path(
+            @referral,
+            return_to: current_url
+          )
       )
     end
 
@@ -259,7 +263,11 @@ RSpec.feature "Contact details", type: :system do
       expect(find(".govuk-summary-list__value").text).to eq("07700 900 982")
       expect(find(".govuk-summary-list__actions")).to have_link(
         "Change",
-        href: referrals_edit_contact_details_telephone_path(@referral)
+        href:
+          referrals_edit_contact_details_telephone_path(
+            @referral,
+            return_to: current_url
+          )
       )
     end
 
@@ -270,7 +278,11 @@ RSpec.feature "Contact details", type: :system do
       )
       expect(find(".govuk-summary-list__actions")).to have_link(
         "Change",
-        href: referrals_edit_contact_details_address_path(@referral)
+        href:
+          referrals_edit_contact_details_address_path(
+            @referral,
+            return_to: current_url
+          )
       )
     end
   end

--- a/spec/system/referrals/user_adds_organisation_details_spec.rb
+++ b/spec/system/referrals/user_adds_organisation_details_spec.rb
@@ -94,7 +94,8 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
 
   def then_i_am_on_the_organisation_address_page
     expect(page).to have_current_path(
-      "/referrals/#{@referral.id}/organisation_address/edit"
+      "/referrals/#{@referral.id}/organisation_address/edit",
+      ignore_query: true
     )
     expect(page).to have_title(
       "What is your organisation’s address? - Refer serious misconduct by a teacher in England"
@@ -112,7 +113,8 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
 
   def then_i_am_on_the_organisation_name_page
     expect(page).to have_current_path(
-      "/referrals/#{@referral.id}/organisation_name/edit"
+      "/referrals/#{@referral.id}/organisation_name/edit",
+      ignore_query: true
     )
     expect(page).to have_title(
       "What’s the name of your organisation? - Refer serious misconduct by a teacher in England"

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -155,7 +155,11 @@ RSpec.feature "Personal details", type: :system do
       expect(find(".govuk-summary-list__value").text).to eq("Jane Smith")
       expect(find(".govuk-summary-list__actions")).to have_link(
         "Change",
-        href: referrals_edit_personal_details_name_path(@referral)
+        href:
+          referrals_edit_personal_details_name_path(
+            @referral,
+            return_to: current_url
+          )
       )
     end
 
@@ -164,7 +168,11 @@ RSpec.feature "Personal details", type: :system do
       expect(find(".govuk-summary-list__value").text).to eq("17 January 1990")
       expect(find(".govuk-summary-list__actions")).to have_link(
         "Change",
-        href: referrals_edit_personal_details_age_path(@referral)
+        href:
+          referrals_edit_personal_details_age_path(
+            @referral,
+            return_to: current_url
+          )
       )
     end
 
@@ -175,7 +183,11 @@ RSpec.feature "Personal details", type: :system do
       expect(find(".govuk-summary-list__value").text).to eq("9912345")
       expect(find(".govuk-summary-list__actions")).to have_link(
         "Change",
-        href: referrals_edit_personal_details_trn_path(@referral)
+        href:
+          referrals_edit_personal_details_trn_path(
+            @referral,
+            return_to: current_url
+          )
       )
     end
 
@@ -184,7 +196,11 @@ RSpec.feature "Personal details", type: :system do
       expect(find(".govuk-summary-list__value").text).to eq("Yes")
       expect(find(".govuk-summary-list__actions")).to have_link(
         "Change",
-        href: referrals_edit_personal_details_qts_path(@referral)
+        href:
+          referrals_edit_personal_details_qts_path(
+            @referral,
+            return_to: current_url
+          )
       )
     end
 

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -117,7 +117,8 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
 
   def then_i_see_the_previous_misconduct_reported_page
     expect(page).to have_current_path(
-      edit_referral_previous_misconduct_reported_path(@referral)
+      edit_referral_previous_misconduct_reported_path(@referral),
+      ignore_query: true
     )
     expect(page).to have_title(
       "Has there been any previous misconduct, disciplinary action or complaints? - Refer " \

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -88,7 +88,8 @@ RSpec.feature "Employer Referral: About You", type: :system do
 
   def then_i_am_on_the_your_details_page
     expect(page).to have_current_path(
-      "/referrals/#{@referral.id}/referrer-name/edit"
+      "/referrals/#{@referral.id}/referrer-name/edit",
+      ignore_query: true
     )
     expect(page).to have_title(
       "What is your name? - Refer serious misconduct by a teacher in England"

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
 
   def and_i_see_my_answers_on_the_referrer_check_your_answers_page
     expect(page).to have_content("Your name\tTest Name")
-    expect(page).to have_content("Phone number\t01234567890")
+    expect(page).to have_content("Main contact number\t01234567890")
   end
 
   def and_i_see_your_details_flagged_as_incomplete


### PR DESCRIPTION
Instead of sending the redirect argument via a hidden input it saves the redirect URL in the session.
https://trello.com/c/pxwsIyfI/1013-return-back-to-the-confirm-check-answers-page-after-accessing-a-page-from-the-change-link

This PR also makes use of the view components added in #246.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
