### PR TITLE
Refactor #save to be consistent with Rails conventions

### DIFF
--- a/app/controllers/referrals/personal_details/age_controller.rb
+++ b/app/controllers/referrals/personal_details/age_controller.rb
@@ -4,16 +4,21 @@ module Referrals
       def edit
         @personal_details_age_form =
           AgeForm.new(
-            referral: current_referral,
-            age_known: current_referral.age_known
+            age_known: current_referral.age_known,
+            referral: current_referral
           )
       end
 
       def update
         @personal_details_age_form =
-          AgeForm.new(age_params.merge(referral: current_referral))
+          AgeForm.new(
+            age_params.merge(
+              date_params: date_of_birth_params,
+              referral: current_referral
+            )
+          )
 
-        if @personal_details_age_form.save(date_of_birth_params)
+        if @personal_details_age_form.save
           redirect_to referrals_edit_personal_details_trn_path(current_referral)
         else
           render :edit

--- a/app/controllers/referrals/teacher_role/employment_status_controller.rb
+++ b/app/controllers/referrals/teacher_role/employment_status_controller.rb
@@ -14,10 +14,13 @@ module Referrals
       def update
         @employment_status_form =
           EmploymentStatusForm.new(
-            employment_status_params.merge(referral: current_referral)
+            employment_status_params.merge(
+              date_params: end_date_params,
+              referral: current_referral
+            )
           )
 
-        if @employment_status_form.save(end_date_params)
+        if @employment_status_form.save
           redirect_to save_redirect_path
         else
           render :edit

--- a/app/controllers/referrals/teacher_role/start_date_controller.rb
+++ b/app/controllers/referrals/teacher_role/start_date_controller.rb
@@ -12,9 +12,14 @@ module Referrals
 
       def update
         @role_start_date_form =
-          StartDateForm.new(role_params.merge(referral: current_referral))
+          StartDateForm.new(
+            role_params.merge(
+              date_params: start_date_params,
+              referral: current_referral
+            )
+          )
 
-        if @role_start_date_form.save(start_date_params)
+        if @role_start_date_form.save
           redirect_to save_redirect_path
         else
           render :edit

--- a/app/forms/referrals/personal_details/age_form.rb
+++ b/app/forms/referrals/personal_details/age_form.rb
@@ -5,7 +5,7 @@ module Referrals
       include ActiveModel::Model
       include ValidatedDate
 
-      attr_accessor :referral
+      attr_accessor :date_params, :referral
       attr_writer :date_of_birth
 
       attr_reader :age_known
@@ -20,7 +20,7 @@ module Referrals
         @date_of_birth ||= referral.date_of_birth
       end
 
-      def save(params = {})
+      def save
         return false if invalid?
 
         referral.update(age_known:)
@@ -28,9 +28,9 @@ module Referrals
         return true unless age_known
 
         unless validated_date(
-                 date_params: params,
                  attribute: :date_of_birth,
-                 date_of_birth: true
+                 date_of_birth: true,
+                 date_params:
                )
           return false
         end

--- a/app/forms/referrals/teacher_role/employment_status_form.rb
+++ b/app/forms/referrals/teacher_role/employment_status_form.rb
@@ -5,7 +5,8 @@ module Referrals
       include ActiveModel::Model
       include ValidatedDate
 
-      attr_accessor :referral,
+      attr_accessor :date_params,
+                    :referral,
                     :role_end_date,
                     :employment_status,
                     :reason_leaving_role
@@ -21,7 +22,7 @@ module Referrals
                 },
                 if: -> { left_role? }
 
-      def save(date_params = {})
+      def save
         return false if invalid?
 
         if date_has_values?(date_params) &&

--- a/app/forms/referrals/teacher_role/start_date_form.rb
+++ b/app/forms/referrals/teacher_role/start_date_form.rb
@@ -5,7 +5,7 @@ module Referrals
       include ActiveModel::Model
       include ValidatedDate
 
-      attr_accessor :referral, :role_start_date
+      attr_accessor :date_params, :referral, :role_start_date
       attr_reader :role_start_date_known
 
       validates :referral, presence: true
@@ -15,11 +15,11 @@ module Referrals
         @role_start_date_known = ActiveModel::Type::Boolean.new.cast(value)
       end
 
-      def save(params = {})
+      def save
         return false if invalid?
 
         if role_start_date_known &&
-             !validated_date(date_params: params, attribute: :role_start_date)
+             !validated_date(date_params:, attribute: :role_start_date)
           return false
         end
 

--- a/spec/forms/referrals/personal_details/age_form_spec.rb
+++ b/spec/forms/referrals/personal_details/age_form_spec.rb
@@ -2,10 +2,9 @@
 require "rails_helper"
 
 RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
+  let(:date_params) { {} }
+  let(:form) { described_class.new(referral:, age_known:, date_params:) }
   let(:referral) { build(:referral) }
-  let(:age_known) { "false" }
-
-  let(:form) { described_class.new(referral:, age_known:) }
 
   context "with invalid age_known" do
     let(:age_known) { "" }
@@ -29,7 +28,6 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
     subject(:save) { form.save }
 
     let(:age_known) { "false" }
-    let(:form) { described_class.new(referral:, age_known:) }
 
     it "saves the age_known value without a date of birth" do
       save

--- a/spec/forms/referrals/teacher_role/employment_status_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/employment_status_form_spec.rb
@@ -2,12 +2,14 @@
 require "rails_helper"
 
 RSpec.describe Referrals::TeacherRole::EmploymentStatusForm, type: :model do
-  let(:referral) { build(:referral) }
+  let(:date_params) { {} }
   let(:employment_status) { "employed" }
   let(:reason_leaving_role) { nil }
+  let(:referral) { build(:referral) }
   let(:role_end_date) { nil }
   let(:form) do
     described_class.new(
+      date_params:,
       referral:,
       employment_status:,
       reason_leaving_role:,

--- a/spec/forms/referrals/teacher_role/start_date_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/start_date_form_spec.rb
@@ -2,9 +2,12 @@
 require "rails_helper"
 
 RSpec.describe Referrals::TeacherRole::StartDateForm, type: :model do
+  let(:date_params) { {} }
   let(:referral) { build(:referral) }
   let(:role_start_date_known) { true }
-  subject(:form) { described_class.new(referral:, role_start_date_known:) }
+  subject(:form) do
+    described_class.new(date_params:, referral:, role_start_date_known:)
+  end
 
   describe "#valid?" do
     subject(:valid) { form.valid? }

--- a/spec/support/shared_examples/validating_date.rb
+++ b/spec/support/shared_examples/validating_date.rb
@@ -5,14 +5,14 @@
 # optional - for date fields that are not required
 
 RSpec.shared_examples "form with a date validator" do |field, optional = true|
-  subject(:save) { form.save(params) }
+  subject(:save) { form.save }
 
   let(:date_field) { referral.send(field) }
 
   before { save }
 
   context "when valid date values" do
-    let(:params) do
+    let(:date_params) do
       {
         "#{field}(1i)" => "2000",
         "#{field}(2i)" => "01",
@@ -26,7 +26,7 @@ RSpec.shared_examples "form with a date validator" do |field, optional = true|
   end
 
   context "with a short month name" do
-    let(:params) do
+    let(:date_params) do
       {
         "#{field}(1i)" => "2000",
         "#{field}(2i)" => "Jan",
@@ -40,7 +40,7 @@ RSpec.shared_examples "form with a date validator" do |field, optional = true|
   end
 
   context "with a word for a number for the day and month" do
-    let(:params) do
+    let(:date_params) do
       {
         "#{field}(1i)" => "2000",
         "#{field}(2i)" => "tWeLvE  ",
@@ -54,7 +54,7 @@ RSpec.shared_examples "form with a date validator" do |field, optional = true|
   end
 
   context "without a valid date" do
-    let(:params) do
+    let(:date_params) do
       {
         "#{field}(1i)" => "2000",
         "#{field}(2i)" => "02",
@@ -75,12 +75,12 @@ RSpec.shared_examples "form with a date validator" do |field, optional = true|
     end
   end
 
-  context "with a blank date" do
-    let(:params) do
+  context "with a blank date", if: !optional do
+    let(:date_params) do
       { "#{field}(1i)" => "", "#{field}(2i)" => "", "#{field}(3i)" => "" }
     end
 
-    it "adds an error", if: !optional do
+    it "adds an error" do
       expect(save).to be_false
       expect(form.errors[field.to_s]).to eq(
         ["Enter their #{field_name(field)}"]
@@ -89,7 +89,7 @@ RSpec.shared_examples "form with a date validator" do |field, optional = true|
   end
 
   context "with a year that is less than 4 digits" do
-    let(:params) do
+    let(:date_params) do
       { "#{field}(1i)" => "99", "#{field}(2i)" => "1", "#{field}(3i)" => "1" }
     end
 
@@ -101,7 +101,7 @@ RSpec.shared_examples "form with a date validator" do |field, optional = true|
   end
 
   context "with a missing day" do
-    let(:params) do
+    let(:date_params) do
       { "#{field}(1i)" => "1990", "#{field}(2i)" => "1", "#{field}(3i)" => "" }
     end
 
@@ -115,7 +115,7 @@ RSpec.shared_examples "form with a date validator" do |field, optional = true|
   end
 
   context "with a missing month" do
-    let(:params) do
+    let(:date_params) do
       { "#{field}(1i)" => "1990", "#{field}(2i)" => "", "#{field}(3i)" => "1" }
     end
 
@@ -129,7 +129,7 @@ RSpec.shared_examples "form with a date validator" do |field, optional = true|
   end
 
   context "with a whitespace month" do
-    let(:params) do
+    let(:date_params) do
       { "#{field}(1i)" => "1990", "#{field}(2i)" => " ", "#{field}(3i)" => "1" }
     end
 
@@ -143,7 +143,7 @@ RSpec.shared_examples "form with a date validator" do |field, optional = true|
   end
 
   context "with a word as a month" do
-    let(:params) do
+    let(:date_params) do
       {
         "#{field}(1i)" => "1990",
         "#{field}(2i)" => "Potatoes",
@@ -162,14 +162,14 @@ RSpec.shared_examples "form with a date validator" do |field, optional = true|
 end
 
 RSpec.shared_examples "form with a date of birth validator" do |field|
-  subject(:save) { form.save(params) }
+  subject(:save) { form.save }
 
   let(:date_field) { referral.send(field) }
 
   before { save }
 
   context "when the date is in the future" do
-    let(:params) do
+    let(:date_params) do
       {
         "#{field}(1i)" => 1.year.from_now.year,
         "#{field}(2i)" => "01",
@@ -187,7 +187,7 @@ RSpec.shared_examples "form with a date of birth validator" do |field|
   end
 
   context "with a date less than 16 years ago" do
-    let(:params) do
+    let(:date_params) do
       {
         "#{field}(1i)" => 15.years.ago.year,
         "#{field}(2i)" => Time.zone.today.month,
@@ -205,7 +205,7 @@ RSpec.shared_examples "form with a date of birth validator" do |field|
   end
 
   context "with a date before 1900" do
-    let(:params) do
+    let(:date_params) do
       { "#{field}(1i)" => "1899", "#{field}(2i)" => "1", "#{field}(3i)" => "1" }
     end
 


### PR DESCRIPTION
Passing params to the save method of a form object is different from the
Rails convention. This unexpected behaviour can make it harder for
someone reading the code in the future to understand quickly.

Moving the date_params to the constructor seemed like the simplest
change to make here. It ensures all params get instantiated in the same
way and lets the `save` method behave the same way as other Rails
models.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
