### PR TITLE
Handle stale otp form submissions

### DIFF
--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -19,7 +19,7 @@ class Users::OtpController < DeviseController
   def create
     @otp_form = Users::OtpForm.new(user_params)
 
-    if @otp_form.otp_expired?
+    if @otp_form.otp_expired? || !@otp_form.secret_key?
       fail_and_retry(reason: :expired)
     elsif @otp_form.valid?
       self.resource = warden.authenticate!(auth_options)

--- a/app/forms/users/otp_form.rb
+++ b/app/forms/users/otp_form.rb
@@ -28,9 +28,7 @@ class Users::OtpForm
   end
 
   def otp_expired?
-    return false unless user.otp_created_at
-
-    (EXPIRY_IN_MINUTES.ago >= user.otp_created_at)
+    user.otp_created_at.blank? || (EXPIRY_IN_MINUTES.ago >= user.otp_created_at)
   end
 
   def maximum_guesses?

--- a/app/forms/users/otp_form.rb
+++ b/app/forms/users/otp_form.rb
@@ -17,7 +17,7 @@ class Users::OtpForm
   validate :must_be_expected_otp
 
   def must_be_expected_otp
-    return unless user.secret_key
+    return unless secret_key?
 
     expected_otp = Devise::Otp.derive_otp(user.secret_key)
 
@@ -29,6 +29,10 @@ class Users::OtpForm
 
   def otp_expired?
     user.otp_created_at.blank? || (EXPIRY_IN_MINUTES.ago >= user.otp_created_at)
+  end
+
+  def secret_key?
+    user.secret_key.present?
   end
 
   def maximum_guesses?

--- a/spec/forms/users/otp_form_spec.rb
+++ b/spec/forms/users/otp_form_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe Users::OtpForm do
       it { is_expected.to be_falsey }
     end
 
-    context "when the OTP has not been created" do
+    context "when there is no OTP timestamp" do
       let(:otp_created_at) { nil }
 
-      it { is_expected.to be_falsey }
+      it { is_expected.to be_truthy }
     end
   end
 end

--- a/spec/forms/users/otp_form_spec.rb
+++ b/spec/forms/users/otp_form_spec.rb
@@ -3,10 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Users::OtpForm do
+  let(:form) { described_class.new(id: user.id) }
+
   describe "#otp_expired?" do
     subject { form.otp_expired? }
 
-    let(:form) { described_class.new(id: user.id) }
     let(:user) { create(:user, otp_created_at:) }
 
     before { freeze_time }
@@ -28,6 +29,22 @@ RSpec.describe Users::OtpForm do
       let(:otp_created_at) { nil }
 
       it { is_expected.to be_truthy }
+    end
+  end
+
+  describe "#secret_key?" do
+    subject { form.secret_key? }
+
+    context "when user secret_key is present" do
+      let(:user) { create(:user, secret_key: "test_key") }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when user secret_key is blank" do
+      let(:user) { create(:user, secret_key: nil) }
+
+      it { is_expected.to be_falsey }
     end
   end
 end


### PR DESCRIPTION
### Context

<!-- Why are you making this change? -->
If a user manually navigates back to the OTP screen after failed
authentication (eg - they've exhausted their OTP guesses), a stale form
submission gives them an error but doesn't redirect them anywhere
regardless of how many times they submit the form. This is because the
secret key has been wiped on their account, but there isn't any special
handling for that case.
### Changes proposed in this pull request
Deal with this by sending the user down the expired OTP journey.

Also introduce a small semantic change to how OtpForm#otp_expired? works (see commits).
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

Steps to test:
- Be signed out
- Sign in
- Submit email
- Exhaust otp guesses (submit empty values)
- When redirected to the retry screen, hit back
- Submit the form
- Corrected behaviour should display the expired retry screen rather than allow infinite form submissions

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/pnaS8YMg
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
