### PR TITLE
Remove temporary OTP display on sign in screen

### DIFF
--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -7,13 +7,6 @@ class Users::OtpController < DeviseController
 
   def new
     @otp_form = Users::OtpForm.new(id: params[:id])
-
-    # TODO: Remove this block once emailed OTPs are implemented
-    # For now this makes manual testing in test environments simpler
-    if HostingEnvironment.test_environment? && @otp_form.user.secret_key
-      otp_generator = ROTP::HOTP.new(@otp_form.user.secret_key)
-      @derived_otp = otp_generator.at(0)
-    end
   end
 
   def create

--- a/app/views/users/otp/new.html.erb
+++ b/app/views/users/otp/new.html.erb
@@ -2,14 +2,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if HostingEnvironment.test_environment? %>
-      <%= "Expected OTP: #{@derived_otp}" %>
-    <% end %>
-
     <%= form_with(model: @otp_form, scope: resource_name, url: user_otp_path, method: :post) do |f| %>
       <%= f.hidden_field :id, value: @otp_form.id %>
       <%= f.hidden_field :email, value: @otp_form.email %>
-      <h3><%= @otp_form.email %></h3>
+      <h2><%= @otp_form.email %></h2>
 
       <%= f.govuk_text_field :otp, size: 'm', label: { text: "Enter your code" }, class: 'govuk-!-width-one-quarter' %>
 


### PR DESCRIPTION

### Context

<!-- Why are you making this change? -->
On test environments we've been displaying the expected OTP just above the OTP form to ease manual testing.

We now have two routes for signing in on dev/test/preprod:

- Create a test user via the support interface
- Go through the user sign in process and fetch the OTP from the email body in the Notify service

With these additions, the temporary OTP display can be removed.

### Changes proposed in this pull request
Remove controller and view code that was allowing this to be rendered.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Try signing in — OTP should no longer appear on OTP screen
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->
na
### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
