### PR TITLE
Refactor eligibility / referrals controllers

### DIFF
--- a/app/controllers/concerns/authenticate_user.rb
+++ b/app/controllers/concerns/authenticate_user.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module AuthenticateUser
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_user!,
+                  if: -> { FeatureFlags::FeatureFlag.active?(:user_accounts) }
+  end
+end

--- a/app/controllers/concerns/enforce_question_order.rb
+++ b/app/controllers/concerns/enforce_question_order.rb
@@ -5,7 +5,6 @@ module EnforceQuestionOrder
   included { before_action :redirect_to_next_question }
 
   def redirect_to_next_question
-    return if referrals_request?
     redirect_to(start_url) and return if start_page_is_required?
     return if all_questions_answered?
     return if previous_question_answered?
@@ -102,9 +101,5 @@ module EnforceQuestionOrder
 
   def serious_misconduct_needs_answer?
     eligibility_check.serious_misconduct.nil?
-  end
-
-  def referrals_request?
-    controller_name == "referrals"
   end
 end

--- a/app/controllers/concerns/redirect_if_feature_flag_inactive.rb
+++ b/app/controllers/concerns/redirect_if_feature_flag_inactive.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module RedirectIfFeatureFlagInactive
+  extend ActiveSupport::Concern
+
+  def redirect_if_feature_flag_inactive(feature, path = start_path)
+    return if FeatureFlags::FeatureFlag.active?(feature)
+
+    redirect_to(path) && return
+  end
+end

--- a/app/controllers/concerns/redirect_if_feature_flag_inactive.rb
+++ b/app/controllers/concerns/redirect_if_feature_flag_inactive.rb
@@ -5,6 +5,6 @@ module RedirectIfFeatureFlagInactive
   def redirect_if_feature_flag_inactive(feature, path = start_path)
     return if FeatureFlags::FeatureFlag.active?(feature)
 
-    redirect_to(path) && return
+    redirect_to(path)
   end
 end

--- a/app/controllers/concerns/store_user_location.rb
+++ b/app/controllers/concerns/store_user_location.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module StoreUserLocation
+  extend ActiveSupport::Concern
+
+  included { before_action :store_user_location!, if: :storable_location? }
+
+  def storable_location?
+    request.get? && is_navigational_format? && !devise_controller? &&
+      !request.xhr?
+  end
+
+  def store_user_location!
+    store_location_for(:user, request.fullpath)
+  end
+end

--- a/app/controllers/eligibility_screener_controller.rb
+++ b/app/controllers/eligibility_screener_controller.rb
@@ -1,0 +1,8 @@
+class EligibilityScreenerController < ApplicationController
+  include AuthenticateUser
+  include StoreUserLocation
+  include EnforceQuestionOrder
+  include RedirectIfFeatureFlagInactive
+
+  before_action { redirect_if_feature_flag_inactive(:employer_form) }
+end

--- a/app/controllers/have_complained_controller.rb
+++ b/app/controllers/have_complained_controller.rb
@@ -1,6 +1,4 @@
-class HaveComplainedController < Referrals::BaseController
-  include EnforceQuestionOrder
-
+class HaveComplainedController < EligibilityScreenerController
   def new
     @have_complained_form = HaveComplainedForm.new(eligibility_check:)
   end

--- a/app/controllers/is_teacher_controller.rb
+++ b/app/controllers/is_teacher_controller.rb
@@ -1,6 +1,4 @@
-class IsTeacherController < Referrals::BaseController
-  include EnforceQuestionOrder
-
+class IsTeacherController < EligibilityScreenerController
   def new
     @is_teacher_form = IsTeacherForm.new
   end

--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -1,10 +1,11 @@
 module Referrals
   class BaseController < ApplicationController
-    before_action :store_user_location!, if: :storable_location?
-    before_action :authenticate_user!,
-                  if: -> { FeatureFlags::FeatureFlag.active?(:user_accounts) }
-    before_action :redirect_if_feature_flag_disabled
-    before_action :redirect_referrals_requests_if_user_accounts_disabled
+    include AuthenticateUser
+    include StoreUserLocation
+    include RedirectIfFeatureFlagInactive
+
+    before_action { redirect_if_feature_flag_inactive(:employer_form) }
+    before_action { redirect_if_feature_flag_inactive(:user_accounts) }
     before_action :set_return_to_url, only: :edit
 
     def edit
@@ -16,28 +17,6 @@ module Referrals
       @current_referral ||= current_user.referrals.find(params[:referral_id])
     end
     helper_method :current_referral
-
-    def redirect_if_feature_flag_disabled
-      return if FeatureFlags::FeatureFlag.active?(:employer_form)
-
-      redirect_to start_path && return
-    end
-
-    def storable_location?
-      request.get? && is_navigational_format? && !devise_controller? &&
-        !request.xhr?
-    end
-
-    def store_user_location!
-      store_location_for(:user, request.fullpath)
-    end
-
-    def redirect_referrals_requests_if_user_accounts_disabled
-      return if request.path !~ %r{^/referral}
-      return if FeatureFlags::FeatureFlag.active?(:user_accounts)
-
-      redirect_to root_path
-    end
 
     def set_return_to_url
       session[:return_to] = params["return_to"]

--- a/app/controllers/reporting_as_controller.rb
+++ b/app/controllers/reporting_as_controller.rb
@@ -1,6 +1,4 @@
-class ReportingAsController < Referrals::BaseController
-  include EnforceQuestionOrder
-
+class ReportingAsController < EligibilityScreenerController
   skip_before_action :authenticate_user!
 
   def new

--- a/app/controllers/serious_misconduct_controller.rb
+++ b/app/controllers/serious_misconduct_controller.rb
@@ -1,6 +1,4 @@
-class SeriousMisconductController < Referrals::BaseController
-  include EnforceQuestionOrder
-
+class SeriousMisconductController < EligibilityScreenerController
   def new
     @serious_misconduct_form = SeriousMisconductForm.new(eligibility_check:)
   end

--- a/app/controllers/teaching_in_england_controller.rb
+++ b/app/controllers/teaching_in_england_controller.rb
@@ -1,6 +1,4 @@
-class TeachingInEnglandController < Referrals::BaseController
-  include EnforceQuestionOrder
-
+class TeachingInEnglandController < EligibilityScreenerController
   def new
     @teaching_in_england_form = TeachingInEnglandForm.new(eligibility_check:)
   end

--- a/app/controllers/unsupervised_teaching_controller.rb
+++ b/app/controllers/unsupervised_teaching_controller.rb
@@ -1,6 +1,4 @@
-class UnsupervisedTeachingController < Referrals::BaseController
-  include EnforceQuestionOrder
-
+class UnsupervisedTeachingController < EligibilityScreenerController
   def new
     @unsupervised_teaching_form = UnsupervisedTeachingForm.new
   end

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -16,7 +16,7 @@ module CommonSteps
     FeatureFlags::FeatureFlag.activate(:user_accounts)
   end
 
-  def and_the_eligbility_screener_feature_is_active
+  def and_the_eligibility_screener_feature_is_active
     FeatureFlags::FeatureFlag.activate(:eligibility_screener)
   end
 

--- a/spec/system/eligibility_screener_spec.rb
+++ b/spec/system/eligibility_screener_spec.rb
@@ -2,9 +2,12 @@
 require "rails_helper"
 
 RSpec.feature "Eligibility screener", type: :system do
+  include CommonSteps
+
   scenario "happy path" do
     given_the_service_is_open
-    and_the_eligibility_screener_is_enabled
+    and_the_eligibility_screener_feature_is_active
+    and_the_employer_form_feature_is_active
     and_i_am_signed_in
     when_i_visit_the_service
     then_i_see_the_start_page
@@ -84,19 +87,6 @@ RSpec.feature "Eligibility screener", type: :system do
   end
 
   private
-
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
-  def and_the_eligibility_screener_is_enabled
-    FeatureFlags::FeatureFlag.activate(:eligibility_screener)
-  end
 
   def then_i_see_a_validation_error
     expect(page).to have_content("There is a problem")

--- a/spec/system/question_order_spec.rb
+++ b/spec/system/question_order_spec.rb
@@ -3,9 +3,12 @@ require "rails_helper"
 require_relative "../support/devise"
 
 RSpec.feature "Question order", type: :system do
+  include CommonSteps
+
   scenario "is enforced correctly" do
     given_the_service_is_open
-    and_the_eligibility_screener_is_enabled
+    and_the_eligibility_screener_feature_is_active
+    and_the_employer_form_feature_is_active
     and_i_am_signed_in
     when_i_visit_the_service
     then_i_see_the_start_page
@@ -42,19 +45,6 @@ RSpec.feature "Question order", type: :system do
   end
 
   private
-
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
-  def and_i_am_signed_in
-    @user = create(:user)
-    sign_in(@user)
-  end
-
-  def and_the_eligibility_screener_is_enabled
-    FeatureFlags::FeatureFlag.activate(:eligibility_screener)
-  end
 
   def then_i_see_the_is_a_teacher_page
     expect(page).to have_current_path("/is-a-teacher")

--- a/spec/system/support/staff_user_signs_in_as_user_spec.rb
+++ b/spec/system/support/staff_user_signs_in_as_user_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Test users" do
   scenario "Staff user signs in as user" do
     given_the_service_is_open
     and_the_employer_form_feature_is_active
-    and_the_eligbility_screener_feature_is_active
+    and_the_eligibility_screener_feature_is_active
     and_the_user_accounts_feature_is_active
     and_staff_http_basic_is_active
     when_i_am_authorized_as_a_support_user

--- a/spec/system/user_views_a_referral_when_user_accounts_feature_is_disabled_spec.rb
+++ b/spec/system/user_views_a_referral_when_user_accounts_feature_is_disabled_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "User accounts disabled, user views a referral summary",
   scenario "User views referral summary" do
     given_the_service_is_open
     and_the_employer_form_feature_is_active
-    and_the_eligbility_screener_feature_is_active
+    and_the_eligibility_screener_feature_is_active
     and_the_user_accounts_feature_is_inactive
     and_there_is_an_existing_referral
     when_i_visit_the_referral


### PR DESCRIPTION
### Context

We shared a few controller concerns like redirecting on feature flags and authenticating users between the eligibility screener and the referrals flow by inheriting from `Referrals::BaseController`. This made it difficult to create referrals specific shared controller behaviours as opposed to behaviours particular to the eligibility screener.
<!-- Why are you making this change? -->
https://trello.com/c/P4p7SthX/1015-differentiate-referrals-screener-controllers

### Changes proposed in this pull request

- Moves shared behaviours into concerns.
- Adds `EligibilityScreenerController` as a base controller specific to the screener
- Eligibility screener controllers inherit from `EligibilityScreenerController`
- Includes concerns in the base referrals controller to maintain present behaviours
- Removes path specific conditions which are no longer necessary

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/P4p7SthX/1015-differentiate-referrals-screener-controllers
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
