### PR TITLE
Update the previous misconduct summary

### DIFF
--- a/app/components/previous_misconduct_component.rb
+++ b/app/components/previous_misconduct_component.rb
@@ -33,7 +33,7 @@ class PreviousMisconductComponent < ViewComponent::Base
           }
         ],
         key: {
-          text: "Detailed report"
+          text: "Detailed account"
         },
         value: {
           text: report
@@ -49,6 +49,10 @@ class PreviousMisconductComponent < ViewComponent::Base
       return referral.previous_misconduct_upload.filename
     end
 
-    simple_format(referral.previous_misconduct_details)
+    if referral.previous_misconduct_details.present?
+      return simple_format(referral.previous_misconduct_details)
+    end
+
+    "Not answered yet"
   end
 end

--- a/app/views/referrals/previous_misconduct/show.html.erb
+++ b/app/views/referrals/previous_misconduct/show.html.erb
@@ -10,28 +10,7 @@
       </div>
     </div>
 
-    <% rows = [
-      {
-        actions: [
-          { text: "Change", href: edit_referral_previous_misconduct_reported_path(current_referral), visually_hidden_text: "reported" },
-
-        ],
-        key: { text: "Has there been any previous misconduct?" },
-        value: { text: humanize_three_way_choice(current_referral.previous_misconduct_reported) },
-      }
-    ] %>
-
-    <% rows << {
-      actions: [
-        { text: "Change", href: edit_referral_previous_misconduct_detailed_account_path(current_referral), visually_hidden_text: "details" },
-      ],
-      key: { text: "Detailed report" },
-      value: { text: current_referral.previous_misconduct_upload.attached? ? current_referral.previous_misconduct_upload.filename : simple_format(current_referral.previous_misconduct_details) },
-    } if current_referral.previous_misconduct_reported? %>
-
-    <%= render(SummaryCardComponent.new(rows:)) do %>
-      <%= render SummaryCardHeaderComponent.new(title: 'Previous allegations') %>
-    <% end %>
+    <%= render PreviousMisconductComponent.new(referral: current_referral) %>
 
     <%= form_with model: @previous_misconduct_form, url: referral_previous_misconduct_path(current_referral), method: :patch do |f| %>
       <%= f.govuk_radio_buttons_fieldset :complete, legend: { size: 'm', text: 'Have you completed this section?' } do %>

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -89,12 +89,12 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
   end
 
   def and_i_see_the_details_are_displayed
-    expect(page).to have_content("Detailed report")
+    expect(page).to have_content("Detailed account")
     expect(page).to have_content("Some details")
   end
 
   def and_i_see_the_uploaded_file_name
-    expect(page).to have_content("Detailed report")
+    expect(page).to have_content("Detailed account")
     expect(page).to have_content("upload.txt")
   end
 


### PR DESCRIPTION
The feedback from the design review asked for a change to the title of
one of the summary fields. Also, we want to use a default value for the
detailed account field to display when there has been no input from the
user.

<img width="1019" alt="Screenshot 2022-12-02 at 9 31 48 am" src="https://user-images.githubusercontent.com/3126/205263233-a48441f0-b74e-4675-8531-b9c22dbf3932.png">


### Link to Trello card

https://trello.com/c/vr74MIXL/972-previous-allegation-page-requires-file-upload

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
