### PR TITLE
Move features engine back out of devise scope

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,11 +284,12 @@ Rails.application.routes.draw do
       put "/authenticate", on: :member, to: "test_users#authenticate"
     end
 
+    mount FeatureFlags::Engine => "/features"
+
     devise_scope :staff do
       authenticate :staff do
         # Mount engines that require staff authentication here
         mount Sidekiq::Web, at: "sidekiq"
-        mount FeatureFlags::Engine => "/features"
       end
     end
 


### PR DESCRIPTION
This currently creates a CSRF issue. It isn't necessary to put this engine in the staff scope as its controller is configured to inherit from the SupportInterfaceController, so is correctly authenticated anyway.
