### PR TITLE
Use uuid to identify users during sign in process

### DIFF
--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -6,7 +6,7 @@ class Users::OtpController < DeviseController
   end
 
   def new
-    @otp_form = Users::OtpForm.new(id: params[:id])
+    @otp_form = Users::OtpForm.new(uuid: params[:uuid])
   end
 
   def create
@@ -61,6 +61,6 @@ class Users::OtpController < DeviseController
   end
 
   def user_params
-    params.require(:user).permit(:id, :otp, :email)
+    params.require(:user).permit(:uuid, :otp, :email)
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -7,7 +7,8 @@ class Users::SessionsController < Devise::SessionsController
       if FeatureFlags::FeatureFlag.active?(:otp_emails)
         UserMailer.send_otp(resource).deliver_later
       end
-      redirect_to new_user_otp_path(id: resource.id)
+
+      redirect_to new_user_otp_path(uuid: resource.uuid)
     else
       render :new
     end

--- a/app/forms/users/otp_form.rb
+++ b/app/forms/users/otp_form.rb
@@ -4,7 +4,7 @@ class Users::OtpForm
 
   include ActiveModel::Model
 
-  attr_accessor :otp, :id
+  attr_accessor :otp, :uuid
   attr_writer :email
 
   validates :otp,
@@ -40,7 +40,7 @@ class Users::OtpForm
   end
 
   def user
-    @user ||= User.find(id)
+    @user ||= User.find_by!(uuid:)
   end
 
   def email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,12 @@ class User < ApplicationRecord
 
   scope :newest_first, -> { order(created_at: :desc) }
 
+  after_commit :reload_uuid, on: :create
+
+  def reload_uuid
+    self[:uuid] = self.class.where(id:).pick(:uuid)
+  end
+
   def after_failed_otp_authentication
     clear_otp_state
   end

--- a/app/views/users/otp/new.html.erb
+++ b/app/views/users/otp/new.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: @otp_form, scope: resource_name, url: user_otp_path, method: :post) do |f| %>
-      <%= f.hidden_field :id, value: @otp_form.id %>
+      <%= f.hidden_field :uuid, value: @otp_form.uuid %>
       <%= f.hidden_field :email, value: @otp_form.email %>
       <h2><%= @otp_form.email %></h2>
 

--- a/db/migrate/20221201155324_add_uuid_to_users.rb
+++ b/db/migrate/20221201155324_add_uuid_to_users.rb
@@ -1,0 +1,9 @@
+class AddUuidToUsers < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
+
+    add_column :users, :uuid, :uuid, default: "gen_random_uuid()", null: false
+
+    add_index :users, :uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_29_112522) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_01_155324) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -195,7 +196,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_29_112522) do
     t.string "secret_key"
     t.integer "otp_guesses", default: 0
     t.datetime "otp_created_at", precision: nil
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/forms/users/otp_form_spec.rb
+++ b/spec/forms/users/otp_form_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Users::OtpForm do
-  let(:form) { described_class.new(id: user.id) }
+  let(:form) { described_class.new(uuid: user.uuid) }
 
   describe "#otp_expired?" do
     subject { form.otp_expired? }


### PR DESCRIPTION
### Context

<!-- Why are you making this change? -->

When navigating to the OTP screen, we currently use the database id to identify the user signing in. Rather than expose this, we can switch to a UUID instead.

### Changes proposed in this pull request

Add a uuid column to the users table, with uuid generation as a default value.

Use this identifier instead of the `id`.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/a3lzNJYu
### Checklist

- [x] Attach to Trello card
- [ ] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
