### PR TITLE
Add azure-cli to .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
+azure-cli 2.42.0
 nodejs 18.1.0
 postgres 13.5
 redis 6.0.16


### PR DESCRIPTION
Needed when using asdf to manage installations of this tool.
