### PR TITLE
Expand permitted evidence file types

### DIFF
--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -2,11 +2,21 @@ class FileUploadValidator < ActiveModel::EachValidator
   MAX_FILE_SIZE = 25.megabytes
 
   CONTENT_TYPES = {
-    ".pdf" => "application/pdf",
+    ".apng" => "image/apng",
+    ".avif" => "image/avif",
     ".doc" => "application/msword",
     ".docx" =>
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    ".txt" => "text/plain"
+    ".gif" => "image/gif",
+    ".heic" => "image/heic",
+    ".heif" => "image/heif",
+    ".jpg" => "image/jpeg",
+    ".jpeg" => "image/jpeg",
+    ".mp3" => "audio/mpeg",
+    ".pdf" => "application/pdf",
+    ".png" => "image/png",
+    ".txt" => "text/plain",
+    ".webp" => "image/webp"
   }.freeze
 
   def validate_each(record, attribute, uploaded_files)

--- a/spec/forms/referrals/allegation/details_form_spec.rb
+++ b/spec/forms/referrals/allegation/details_form_spec.rb
@@ -75,7 +75,9 @@ RSpec.describe Referrals::Allegation::DetailsForm, type: :model do
       it "adds an error" do
         save
         expect(form.errors[:allegation_upload]).to eq(
-          ["Please upload a valid file type (.doc, .docx, .pdf, .txt)"]
+          [
+            "Please upload a valid file type (#{FileUploadValidator::CONTENT_TYPES.keys.sort.join(", ")})"
+          ]
         )
       end
     end

--- a/spec/forms/referrals/evidence/upload_form_spec.rb
+++ b/spec/forms/referrals/evidence/upload_form_spec.rb
@@ -58,7 +58,9 @@ RSpec.describe Referrals::Evidence::UploadForm, type: :model do
       it "adds an error" do
         save
         expect(upload_form.errors[:evidence_uploads]).to eq(
-          ["Please upload files of valid type (.doc, .docx, .pdf, .txt)"]
+          [
+            "Please upload files of valid type (#{FileUploadValidator::CONTENT_TYPES.keys.sort.join(", ")})"
+          ]
         )
       end
     end

--- a/spec/validators/file_upload_validator_spec.rb
+++ b/spec/validators/file_upload_validator_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe FileUploadValidator do
   subject(:model) { Validatable.new }
 
+  let(:file) { nil }
+
   before do
     stub_const("Validatable", Class.new).class_eval do
       include ActiveModel::Validations
@@ -42,5 +44,26 @@ RSpec.describe FileUploadValidator do
     before { allow(file).to receive(:size).and_return(25 * 1024 * 1024) }
 
     it { is_expected.not_to be_valid }
+  end
+
+  it "supports common media and document file types" do
+    expect(described_class::CONTENT_TYPES.keys).to eq(
+      %w[
+        .apng
+        .avif
+        .doc
+        .docx
+        .gif
+        .heic
+        .heif
+        .jpg
+        .jpeg
+        .mp3
+        .pdf
+        .png
+        .txt
+        .webp
+      ]
+    )
   end
 end


### PR DESCRIPTION
### Context

From design review, we've decided to support more file types (video not supported in MVP).
<!-- Why are you making this change? -->

### Changes proposed in this pull request

- Expands the permitted file type list to include common image file types.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/bOcayQul/995-rsm-employer-form-limit-file-upload-types-and-size
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
