### PR TITLE
Add task and summary spec helpers

### DIFF
--- a/app/components/their_role_component.rb
+++ b/app/components/their_role_component.rb
@@ -10,7 +10,11 @@ class TheirRoleComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_teacher_role_start_date_path(referral),
+            href:
+              referrals_edit_teacher_role_start_date_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "start date"
           }
         ],
@@ -32,7 +36,11 @@ class TheirRoleComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_teacher_employment_status_path(referral),
+            href:
+              referrals_edit_teacher_employment_status_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "employment status"
           }
         ],
@@ -54,7 +62,11 @@ class TheirRoleComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_teacher_job_title_path(referral),
+            href:
+              referrals_edit_teacher_job_title_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "job title"
           }
         ],
@@ -69,12 +81,16 @@ class TheirRoleComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_teacher_same_organisation_path(referral),
+            href:
+              referrals_edit_teacher_same_organisation_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "working in the same organisation"
           }
         ],
         key: {
-          text: "Do they work in the same organisation as you"
+          text: "Do they work in the same organisation as you?"
         },
         value: {
           text: referral.same_organisation ? "Yes" : "No"
@@ -84,7 +100,11 @@ class TheirRoleComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_teacher_duties_path(referral),
+            href:
+              referrals_edit_teacher_duties_path(
+                referral,
+                return_to: request.url
+              ),
             visually_hidden_text: "main duties"
           }
         ],

--- a/spec/support/helpers/summary_list_helpers.rb
+++ b/spec/support/helpers/summary_list_helpers.rb
@@ -1,0 +1,11 @@
+module SummaryListHelpers
+  def expect_summary_row(key:, value:, change_link:)
+    within(page.find(".govuk-summary-list__row", text: key)) do
+      expect(find(".govuk-summary-list__value").text).to match(value)
+      expect(find(".govuk-summary-list__actions")).to have_link(
+        "Change",
+        href: change_link
+      )
+    end
+  end
+end

--- a/spec/support/helpers/task_list_helpers.rb
+++ b/spec/support/helpers/task_list_helpers.rb
@@ -1,0 +1,10 @@
+module TaskListHelpers
+  def expect_task_row(section:, item_position:, name:, tag:)
+    within(page.find(".app-task-list__section", text: section)) do
+      within(all(".app-task-list__item")[item_position - 1]) do
+        expect(find(".app-task-list__task-name a").text).to eq(name)
+        expect(find(".app-task-list__tag").text).to eq(tag)
+      end
+    end
+  end
+end

--- a/spec/system/referrals/user_adds_an_allegation_spec.rb
+++ b/spec/system/referrals/user_adds_an_allegation_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 
 RSpec.feature "Allegation", type: :system do
   include CommonSteps
+  include SummaryListHelpers
 
   scenario "User adds an allegation to a referral" do
     given_the_service_is_open
@@ -81,32 +82,22 @@ RSpec.feature "Allegation", type: :system do
   def then_i_am_asked_to_confirm_the_allegation_details
     expect(page).to have_content("Check and confirm your answers")
 
-    summary_rows = all(".govuk-summary-list__row")
+    expect_summary_row(
+      key: "Summary",
+      value: "Something something something",
+      change_link:
+        referrals_edit_allegation_details_path(
+          @referral,
+          return_to: current_url
+        )
+    )
 
-    within(summary_rows[0]) do
-      expect(find(".govuk-summary-list__key").text).to eq("Summary")
-      expect(find(".govuk-summary-list__value").text).to eq(
-        "Something something something"
-      )
-      expect(find(".govuk-summary-list__actions")).to have_link(
-        "Change",
-        href:
-          referrals_edit_allegation_details_path(
-            @referral,
-            return_to: current_url
-          )
-      )
-    end
-
-    within(summary_rows[1]) do
-      expect(find(".govuk-summary-list__key").text).to eq("Have you told DBS?")
-      expect(find(".govuk-summary-list__value").text).to eq("Yes")
-      expect(find(".govuk-summary-list__actions")).to have_link(
-        "Change",
-        href:
-          referrals_edit_allegation_dbs_path(@referral, return_to: current_url)
-      )
-    end
+    expect_summary_row(
+      key: "Have you told DBS?",
+      value: "Yes",
+      change_link:
+        referrals_edit_allegation_dbs_path(@referral, return_to: current_url)
+    )
   end
 
   def then_i_see_check_answers_form_validation_errors

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 
 RSpec.feature "Contact details", type: :system do
   include CommonSteps
+  include SummaryListHelpers
+  include TaskListHelpers
 
   scenario "User submits contact details for the referred person" do
     given_the_service_is_open
@@ -243,48 +245,35 @@ RSpec.feature "Contact details", type: :system do
   end
 
   def and_i_see_a_summary_list
-    summary_rows = all(".govuk-summary-list__row")
+    expect_summary_row(
+      key: "Email address",
+      value: "name@example.com",
+      change_link:
+        referrals_edit_contact_details_email_path(
+          @referral,
+          return_to: current_url
+        )
+    )
 
-    within(summary_rows[0]) do
-      expect(find(".govuk-summary-list__key").text).to eq("Email address")
-      expect(find(".govuk-summary-list__value").text).to eq("name@example.com")
-      expect(find(".govuk-summary-list__actions")).to have_link(
-        "Change",
-        href:
-          referrals_edit_contact_details_email_path(
-            @referral,
-            return_to: current_url
-          )
-      )
-    end
+    expect_summary_row(
+      key: "Phone number",
+      value: "07700 900 982",
+      change_link:
+        referrals_edit_contact_details_telephone_path(
+          @referral,
+          return_to: current_url
+        )
+    )
 
-    within(summary_rows[1]) do
-      expect(find(".govuk-summary-list__key").text).to eq("Phone number")
-      expect(find(".govuk-summary-list__value").text).to eq("07700 900 982")
-      expect(find(".govuk-summary-list__actions")).to have_link(
-        "Change",
-        href:
-          referrals_edit_contact_details_telephone_path(
-            @referral,
-            return_to: current_url
-          )
-      )
-    end
-
-    within(summary_rows[2]) do
-      expect(find(".govuk-summary-list__key").text).to eq("Address")
-      expect(find(".govuk-summary-list__value").text).to eq(
-        "1428 Elm Street\nLondon\nNW1 4NP"
-      )
-      expect(find(".govuk-summary-list__actions")).to have_link(
-        "Change",
-        href:
-          referrals_edit_contact_details_address_path(
-            @referral,
-            return_to: current_url
-          )
-      )
-    end
+    expect_summary_row(
+      key: "Address",
+      value: "1428 Elm Street\nLondon\nNW1 4NP",
+      change_link:
+        referrals_edit_contact_details_address_path(
+          @referral,
+          return_to: current_url
+        )
+    )
   end
 
   def then_i_see_a_completed_error
@@ -292,25 +281,29 @@ RSpec.feature "Contact details", type: :system do
   end
 
   def then_i_see_the_status_section_in_the_referral_summary(status: "COMPLETED")
-    within(all(".app-task-list__section")[1]) do
-      within(all(".app-task-list__item")[1]) do
-        expect(find(".app-task-list__task-name a").text).to eq(
-          "Contact details"
-        )
-        expect(find(".app-task-list__tag").text).to eq(status)
-      end
-    end
+    expect_task_row(
+      section: "About the person you are referring",
+      item_position: 2,
+      name: "Contact details",
+      tag: status
+    )
   end
 
   def and_i_click_the_change_email_link
-    within(all(".govuk-summary-list__row")[0]) { click_link "Change" }
+    within(page.find(".govuk-summary-list__row", text: "Email address")) do
+      click_link "Change"
+    end
   end
 
   def and_i_click_the_change_phone_link
-    within(all(".govuk-summary-list__row")[1]) { click_link "Change" }
+    within(page.find(".govuk-summary-list__row", text: "Phone number")) do
+      click_link "Change"
+    end
   end
 
   def and_i_click_the_change_address_link
-    within(all(".govuk-summary-list__row")[2]) { click_link "Change" }
+    within(page.find(".govuk-summary-list__row", text: "Address")) do
+      click_link "Change"
+    end
   end
 end

--- a/spec/system/referrals/user_adds_evidence_spec.rb
+++ b/spec/system/referrals/user_adds_evidence_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 
 RSpec.feature "Evidence", type: :system do
   include CommonSteps
+  include SummaryListHelpers
 
   scenario "User adds evidence to a referral" do
     given_the_service_is_open
@@ -157,30 +158,35 @@ RSpec.feature "Evidence", type: :system do
   def then_i_am_asked_to_confirm_the_evidence_details
     expect(page).to have_content("Check and confirm your answers")
 
-    within(all(".govuk-summary-list__row")[0]) do
-      expect(find(".govuk-summary-list__key").text).to eq("doc1.pdf")
-      expect(find(".govuk-summary-list__value").text).to eq(
-        "CV, Job offer, Signed witness statements"
-      )
-    end
+    expect_summary_row(
+      key: "doc1.pdf",
+      value: "CV, Job offer, Signed witness statements",
+      change_link:
+        referrals_edit_evidence_categories_path(
+          @referral,
+          @referral.evidences.first
+        )
+    )
 
-    within(all(".govuk-summary-list__row")[1]) do
-      expect(find(".govuk-summary-list__key").text).to eq("doc2.pdf")
-      expect(find(".govuk-summary-list__value").text).to eq(
-        "Police investigation and reports, Other: Some other details"
-      )
-    end
+    expect_summary_row(
+      key: "doc2.pdf",
+      value: "Police investigation and reports, Other: Some other details",
+      change_link:
+        referrals_edit_evidence_categories_path(
+          @referral,
+          @referral.evidences.second
+        )
+    )
   end
 
   def then_i_am_asked_to_confirm_evidence_details_without_uploads
     expect(page).to have_content("Check and confirm your answers")
 
-    within(all(".govuk-summary-list__row")[0]) do
-      expect(find(".govuk-summary-list__key").text).to eq("Documents")
-      expect(find(".govuk-summary-list__value").text).to eq(
-        "No evidence uploaded"
-      )
-    end
+    expect_summary_row(
+      key: "Documents",
+      value: "No evidence uploaded",
+      change_link: referrals_edit_evidence_start_path(@referral)
+    )
   end
 
   def then_i_see_check_answers_form_validation_errors
@@ -188,7 +194,9 @@ RSpec.feature "Evidence", type: :system do
   end
 
   def when_i_click_delete_on_the_first_evidence_item
-    within(all(".govuk-summary-list__row")[0]) { click_on "Delete" }
+    within(page.find(".govuk-summary-list__row", text: "doc1.pdf")) do
+      click_on "Delete"
+    end
   end
 
   def then_i_am_asked_to_confirm_deletion
@@ -200,13 +208,15 @@ RSpec.feature "Evidence", type: :system do
   end
 
   def then_i_can_no_longer_see_the_upload_in_the_referral_summary
-    within(all(".govuk-summary-list__row")[0]) do
-      expect(find(".govuk-summary-list__key").text).not_to eq("doc1.pdf")
-      expect(find(".govuk-summary-list__key").text).to eq("doc2.pdf")
-      expect(find(".govuk-summary-list__value").text).to eq(
-        "Police investigation and reports, Other: Some other details"
-      )
-    end
+    expect_summary_row(
+      key: "doc2.pdf",
+      value: "Police investigation and reports, Other: Some other details",
+      change_link:
+        referrals_edit_evidence_categories_path(
+          @referral,
+          @referral.evidences.first
+        )
+    )
   end
 
   def when_i_choose_to_confirm

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 
 RSpec.feature "Personal details", type: :system do
   include CommonSteps
+  include SummaryListHelpers
 
   scenario "User adds personal details to a referral" do
     given_the_service_is_open
@@ -148,61 +149,45 @@ RSpec.feature "Personal details", type: :system do
     expect(page).to have_content("About the person you are referring")
     expect(page).to have_content("Personal details")
 
-    summary_rows = all(".govuk-summary-list__row")
+    expect_summary_row(
+      key: "Name",
+      value: "Jane Smith",
+      change_link:
+        referrals_edit_personal_details_name_path(
+          @referral,
+          return_to: current_url
+        )
+    )
 
-    within(summary_rows[0]) do
-      expect(find(".govuk-summary-list__key").text).to eq("Name")
-      expect(find(".govuk-summary-list__value").text).to eq("Jane Smith")
-      expect(find(".govuk-summary-list__actions")).to have_link(
-        "Change",
-        href:
-          referrals_edit_personal_details_name_path(
-            @referral,
-            return_to: current_url
-          )
-      )
-    end
+    expect_summary_row(
+      key: "Date of birth",
+      value: "17 January 1990",
+      change_link:
+        referrals_edit_personal_details_age_path(
+          @referral,
+          return_to: current_url
+        )
+    )
 
-    within(summary_rows[1]) do
-      expect(find(".govuk-summary-list__key").text).to eq("Date of birth")
-      expect(find(".govuk-summary-list__value").text).to eq("17 January 1990")
-      expect(find(".govuk-summary-list__actions")).to have_link(
-        "Change",
-        href:
-          referrals_edit_personal_details_age_path(
-            @referral,
-            return_to: current_url
-          )
-      )
-    end
+    expect_summary_row(
+      key: "Teacher reference number (TRN)",
+      value: "9912345",
+      change_link:
+        referrals_edit_personal_details_trn_path(
+          @referral,
+          return_to: current_url
+        )
+    )
 
-    within(summary_rows[2]) do
-      expect(find(".govuk-summary-list__key").text).to eq(
-        "Teacher reference number (TRN)"
-      )
-      expect(find(".govuk-summary-list__value").text).to eq("9912345")
-      expect(find(".govuk-summary-list__actions")).to have_link(
-        "Change",
-        href:
-          referrals_edit_personal_details_trn_path(
-            @referral,
-            return_to: current_url
-          )
-      )
-    end
-
-    within(summary_rows[3]) do
-      expect(find(".govuk-summary-list__key").text).to eq("Do they have QTS?")
-      expect(find(".govuk-summary-list__value").text).to eq("Yes")
-      expect(find(".govuk-summary-list__actions")).to have_link(
-        "Change",
-        href:
-          referrals_edit_personal_details_qts_path(
-            @referral,
-            return_to: current_url
-          )
-      )
-    end
+    expect_summary_row(
+      key: "Do they have QTS?",
+      value: "Yes",
+      change_link:
+        referrals_edit_personal_details_qts_path(
+          @referral,
+          return_to: current_url
+        )
+    )
 
     expect(page).to have_content("Have you completed this section?")
   end


### PR DESCRIPTION
### Context

These two new helpers are used to avoid the repetition of the summary and task lists selectors.