### PR TITLE
Limit number of referral evidence files in upload

### DIFF
--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -1,5 +1,6 @@
 class FileUploadValidator < ActiveModel::EachValidator
   MAX_FILE_SIZE = 25.megabytes
+  MAX_FILES = 10
 
   CONTENT_TYPES = {
     ".apng" => "image/apng",
@@ -21,12 +22,20 @@ class FileUploadValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, uploaded_files)
     uploaded_files = [uploaded_files] unless uploaded_files.is_a?(Array)
+    uploaded_files.compact_blank!
 
-    uploaded_files.compact_blank.each do |uploaded_file|
+    if uploaded_files.size > MAX_FILES
+      record.errors.add(attribute, :file_count, max_files: MAX_FILES)
+    end
+
+    uploaded_files.each do |uploaded_file|
       next if uploaded_file.nil?
 
       if uploaded_file.size >= MAX_FILE_SIZE
-        record.errors.add attribute, :file_size_too_big
+        record.errors.add(
+          attribute,
+          :file_size_too_big,
+        )
         break
       end
 

--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -1,4 +1,6 @@
 class FileUploadValidator < ActiveModel::EachValidator
+  include ActionView::Helpers::NumberHelper
+
   MAX_FILE_SIZE = 25.megabytes
   MAX_FILES = 10
 
@@ -35,6 +37,7 @@ class FileUploadValidator < ActiveModel::EachValidator
         record.errors.add(
           attribute,
           :file_size_too_big,
+          max_file_size: number_to_human_size(MAX_FILE_SIZE)
         )
         break
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,6 +279,7 @@ en:
               invalid_content_type: Please upload files of valid type (%{valid_types})
               mismatch_content_type: File type does not match file contents
               file_size_too_big: Maximum file size is 25MB
+              file_count: No more than %{max_files} files can be uploaded
         "referrals/evidence/categories_form":
           attributes:
             categories:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,7 +258,7 @@ en:
               blank: Select a file containing details of your allegation
               invalid_content_type: Please upload a valid file type (%{valid_types})
               mismatch_content_type: File type does not match file contents
-              file_size_too_big: Maximum file size is 25MB
+              file_size_too_big: Maximum file size is %{max_file_size}
         "referrals/allegation/dbs_form":
           attributes:
             dbs_notified:
@@ -278,7 +278,7 @@ en:
               blank: Select evidence to upload
               invalid_content_type: Please upload files of valid type (%{valid_types})
               mismatch_content_type: File type does not match file contents
-              file_size_too_big: Maximum file size is 25MB
+              file_size_too_big: Maximum file size is %{max_file_size}
               file_count: No more than %{max_files} files can be uploaded
         "referrals/evidence/categories_form":
           attributes:

--- a/spec/validators/file_upload_validator_spec.rb
+++ b/spec/validators/file_upload_validator_spec.rb
@@ -3,47 +3,67 @@ require "rails_helper"
 RSpec.describe FileUploadValidator do
   subject(:model) { Validatable.new }
 
-  let(:file) { nil }
+  let(:files) { nil }
 
   before do
     stub_const("Validatable", Class.new).class_eval do
       include ActiveModel::Validations
-      attr_accessor :file
-      validates :file, file_upload: true
+      attr_accessor :files
+      validates :files, file_upload: true
     end
-    model.file = file
+    model.files = files
   end
 
   context "with a valid file" do
-    let(:file) { fixture_file_upload("upload.pdf", "application/pdf") }
+    let(:files) { fixture_file_upload("upload.pdf", "application/pdf") }
 
     it { is_expected.to be_valid }
   end
 
   context "with a valid file with an uppercase extension" do
-    let(:file) { fixture_file_upload("upload.PDF", "application/pdf") }
+    let(:files) { fixture_file_upload("upload.PDF", "application/pdf") }
 
     it { is_expected.to be_valid }
   end
 
   context "with an invalid content type" do
-    let(:file) { fixture_file_upload("upload.pl", "application/x-perl") }
+    let(:files) { fixture_file_upload("upload.pl", "application/x-perl") }
 
     it { is_expected.not_to be_valid }
   end
 
   context "with an invalid extension" do
-    let(:file) { fixture_file_upload("upload.txt", "application/pdf") }
+    let(:files) { fixture_file_upload("upload.txt", "application/pdf") }
 
     it { is_expected.not_to be_valid }
   end
 
   context "with a large file" do
-    let(:file) { fixture_file_upload("upload.pdf", "application/pdf") }
+    let(:files) { fixture_file_upload("upload.pdf", "application/pdf") }
 
-    before { allow(file).to receive(:size).and_return(25 * 1024 * 1024) }
+    before { allow(files).to receive(:size).and_return(25 * 1024 * 1024) }
 
-    it { is_expected.not_to be_valid }
+    it { is_expected.to be_invalid }
+  end
+
+  context "with too many files" do
+    let(:files) do
+      [
+        fixture_file_upload("upload.pdf", "application/pdf"),
+        fixture_file_upload("upload.pdf", "application/pdf"),
+        fixture_file_upload("upload.pdf", "application/pdf"),
+        fixture_file_upload("upload.pdf", "application/pdf"),
+        fixture_file_upload("upload.pdf", "application/pdf"),
+        fixture_file_upload("upload.pdf", "application/pdf"),
+        fixture_file_upload("upload.pdf", "application/pdf"),
+        fixture_file_upload("upload.pdf", "application/pdf"),
+        fixture_file_upload("upload.pdf", "application/pdf"),
+        fixture_file_upload("upload.pdf", "application/pdf"),
+        fixture_file_upload("upload.pdf", "application/pdf")
+      ]
+    end
+
+    it { is_expected.to be_invalid }
   end
 
   it "supports common media and document file types" do


### PR DESCRIPTION
### Context

When submitting evidence multiple files can be uploaded, a maximum file size is imposed but the number of files is not restricted.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

- Limit the number of upload files to 10
- Make max file size error consistent with validator constant

![image](https://user-images.githubusercontent.com/93511/205890223-4d6a9f6d-5856-47a7-af85-6d0aabf4cbc7.png)



<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/UzBWH3Mh/1020-limit-number-of-referral-evidence-files-in-upload
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
