### PR TITLE
Make the back link aware of the return to value

### DIFF
--- a/app/components/evidence_component.rb
+++ b/app/components/evidence_component.rb
@@ -33,12 +33,22 @@ class EvidenceComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href: referrals_edit_evidence_categories_path(referral, evidence),
+            href:
+              referrals_edit_evidence_categories_path(
+                referral,
+                evidence,
+                return_to: request.url
+              ),
             visually_hidden_text: "categories"
           },
           {
             text: "Delete",
-            href: referrals_delete_evidence_path(referral, evidence),
+            href:
+              referrals_delete_evidence_path(
+                referral,
+                evidence,
+                return_to: request.url
+              ),
             visually_hidden_text: "evidence upload"
           }
         ],

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -85,4 +85,8 @@ module ApplicationHelper
       choice
     ]
   end
+
+  def return_to_session_or(url)
+    session[:return_to] || url
+  end
 end

--- a/app/views/referrals/allegation/check_answers/edit.html.erb
+++ b/app/views/referrals/allegation/check_answers/edit.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_check_answers_form.errors.any?}Check and confirm your answers" %>
-<% content_for :back_link_url, url_for(:back) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/referrals/allegation/dbs/edit.html.erb
+++ b/app/views/referrals/allegation/dbs/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_dbs_form.errors.any?}Telling DBS about this case" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_allegation_details_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/allegation/details/edit.html.erb
+++ b/app/views/referrals/allegation/details/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_details_form.errors.any?}How do you want to tell us about your allegation?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/contact_details/address/edit.html.erb
+++ b/app/views/referrals/contact_details/address/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @contact_details_address_form.errors.any?}Do you know their home address?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_contact_details_telephone_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/contact_details/check_answers/edit.html.erb
+++ b/app/views/referrals/contact_details/check_answers/edit.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "#{"Error: " if @contact_details_check_answers_form.errors.any?}Have you completed this section?" %>
-<% content_for :back_link_url, url_for(:back) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/referrals/contact_details/email/edit.html.erb
+++ b/app/views/referrals/contact_details/email/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @contact_details_email_form.errors.any?}Do you know the personal email address of the person you are referring?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/contact_details/telephone/edit.html.erb
+++ b/app/views/referrals/contact_details/telephone/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @contact_details_telephone_form.errors.any?}Do you know their main contact number?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_contact_details_email_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/evidence/categories/edit.html.erb
+++ b/app/views/referrals/evidence/categories/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_categories_form.errors.any?}#{evidence.filename}" %>
-<% content_for :back_link_url, evidence_categories_back_link(@evidence_categories_form) %>
+<% content_for :back_link_url, return_to_session_or(evidence_categories_back_link(@evidence_categories_form)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/evidence/check_answers/delete.html.erb
+++ b/app/views/referrals/evidence/check_answers/delete.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Are you sure you want to delete #{evidence.filename}" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(url_for(:back)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/evidence/check_answers/edit.html.erb
+++ b/app/views/referrals/evidence/check_answers/edit.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_check_answers_form.errors.any?}Check and confirm your answers" %>
-<% content_for :back_link_url, evidence_check_answers_link(current_referral) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/referrals/evidence/start/edit.html.erb
+++ b/app/views/referrals/evidence/start/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_start_form.errors.any?}Evidence and supporting information" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/evidence/upload/edit.html.erb
+++ b/app/views/referrals/evidence/upload/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_upload_form.errors.any?}Upload evidence and supporting information" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_evidence_start_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/organisation_address/edit.html.erb
+++ b/app/views/referrals/organisation_address/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @organisation_address_form.errors.any?}What is your organisation’s address?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_organisation_name_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/organisation_name/edit.html.erb
+++ b/app/views/referrals/organisation_name/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @organisation_name_form.errors.any?}What’s the name of your organisation?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/personal_details/age/edit.html.erb
+++ b/app/views/referrals/personal_details/age/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_age_form.errors.any?}Do you know their date of birth?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_personal_details_name_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/personal_details/check_answers/edit.html.erb
+++ b/app/views/referrals/personal_details/check_answers/edit.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_check_answers_form.errors.any?}Personal details" %>
-<% content_for :back_link_url, url_for(:back) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/referrals/personal_details/name/edit.html.erb
+++ b/app/views/referrals/personal_details/name/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_name_form.errors.any?}What is the name of the person you’re referring?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/personal_details/qts/edit.html.erb
+++ b/app/views/referrals/personal_details/qts/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_qts_form.errors.any?}Do they have qualified teacher status (QTS)?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_personal_details_trn_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/personal_details/trn/edit.html.erb
+++ b/app/views/referrals/personal_details/trn/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_trn_form.errors.any?}Do you know their teacher reference number (TRN)?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_personal_details_age_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/previous_misconduct_detailed_account/edit.html.erb
+++ b/app/views/referrals/previous_misconduct_detailed_account/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @detailed_account_form.errors.any?}Give a detailed account of previous allegations" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_previous_misconduct_reported_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/previous_misconduct_reported/edit.html.erb
+++ b/app/views/referrals/previous_misconduct_reported/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @previous_misconduct_reported_form.errors.any?}Has there been any previous misconduct, disciplinary action or complaints?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/referrer_job_title/edit.html.erb
+++ b/app/views/referrals/referrer_job_title/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @referrer_job_title_form.errors.any?}What is your job title?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_referrer_name_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/referrer_name/edit.html.erb
+++ b/app/views/referrals/referrer_name/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @referrer_name_form.errors.any?}What is your name?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/referrer_phone/edit.html.erb
+++ b/app/views/referrals/referrer_phone/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @referrer_phone_form.errors.any?}What is your phone number?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_referrer_job_title_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/teacher_role/check_answers/edit.html.erb
+++ b/app/views/referrals/teacher_role/check_answers/edit.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "#{"Error: " if @teacher_role_check_answers_form.errors.any?}Check and confirm your answers" %>
-<% content_for :back_link_url, url_for(:back) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/referrals/teacher_role/duties/edit.html.erb
+++ b/app/views/referrals/teacher_role/duties/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @duties_form.errors.any?}How do you want to tell us about their main duties?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_teacher_role_same_organisation_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/teacher_role/employment_status/edit.html.erb
+++ b/app/views/referrals/teacher_role/employment_status/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @employment_status_form.errors.any?}Are they still employed in that job?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_teacher_role_start_date_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/teacher_role/job_title/edit.html.erb
+++ b/app/views/referrals/teacher_role/job_title/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @job_title_form.errors.any?}What’s their job title?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_teacher_role_employment_status_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/teacher_role/same_organisation/edit.html.erb
+++ b/app/views/referrals/teacher_role/same_organisation/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @same_organisation_form.errors.any?}Do they work in the same organisation as you?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_teacher_role_job_title_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/teacher_role/start_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/start_date/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @role_start_date_form.errors.any?}Do you know when they started their job?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/spec/support/helpers/summary_list_helpers.rb
+++ b/spec/support/helpers/summary_list_helpers.rb
@@ -1,11 +1,13 @@
 module SummaryListHelpers
-  def expect_summary_row(key:, value:, change_link:)
+  def expect_summary_row(key:, value:, change_link: nil)
     within(page.find(".govuk-summary-list__row", text: key)) do
       expect(find(".govuk-summary-list__value").text).to match(value)
-      expect(find(".govuk-summary-list__actions")).to have_link(
-        "Change",
-        href: change_link
-      )
+      if change_link
+        expect(find(".govuk-summary-list__actions")).to have_link(
+          "Change",
+          href: change_link
+        )
+      end
     end
   end
 end

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature "Contact details", type: :system do
     then_i_see_the_check_answers_page
 
     # Address known
-    when_i_go_back
+    when_i_click_change_address
     when_i_select_yes
     when_i_fill_in_the_address_details
     and_i_click_save_and_continue
@@ -305,5 +305,9 @@ RSpec.feature "Contact details", type: :system do
     within(page.find(".govuk-summary-list__row", text: "Address")) do
       click_link "Change"
     end
+  end
+
+  def when_i_click_change_address
+    click_link "Change address"
   end
 end

--- a/spec/system/referrals/user_adds_evidence_spec.rb
+++ b/spec/system/referrals/user_adds_evidence_spec.rb
@@ -51,6 +51,11 @@ RSpec.feature "Evidence", type: :system do
     and_i_click_save_and_continue
     then_i_am_asked_to_confirm_the_evidence_details
 
+    when_i_click_change_categories_for_the_first_item
+    then_i_am_asked_to_choose_categories_for_the_first_item
+    when_i_click_back
+    then_i_am_asked_to_confirm_the_evidence_details
+
     when_i_click_save_and_continue
     then_i_see_check_answers_form_validation_errors
 
@@ -160,12 +165,7 @@ RSpec.feature "Evidence", type: :system do
 
     expect_summary_row(
       key: "doc1.pdf",
-      value: "CV, Job offer, Signed witness statements",
-      change_link:
-        referrals_edit_evidence_categories_path(
-          @referral,
-          @referral.evidences.first
-        )
+      value: "CV, Job offer, Signed witness statements"
     )
     expect(page).to have_link(
       "doc1.pdf",
@@ -178,12 +178,7 @@ RSpec.feature "Evidence", type: :system do
 
     expect_summary_row(
       key: "doc2.pdf",
-      value: "Police investigation and reports, Other: Some other details",
-      change_link:
-        referrals_edit_evidence_categories_path(
-          @referral,
-          @referral.evidences.second
-        )
+      value: "Police investigation and reports, Other: Some other details"
     )
     expect(page).to have_link(
       "doc2.pdf",
@@ -226,12 +221,7 @@ RSpec.feature "Evidence", type: :system do
   def then_i_can_no_longer_see_the_upload_in_the_referral_summary
     expect_summary_row(
       key: "doc2.pdf",
-      value: "Police investigation and reports, Other: Some other details",
-      change_link:
-        referrals_edit_evidence_categories_path(
-          @referral,
-          @referral.evidences.first
-        )
+      value: "Police investigation and reports, Other: Some other details"
     )
   end
 
@@ -248,5 +238,9 @@ RSpec.feature "Evidence", type: :system do
         expect(find(".app-task-list__tag").text).to eq("COMPLETED")
       end
     end
+  end
+
+  def when_i_click_change_categories_for_the_first_item
+    click_on "Change categories", match: :first
   end
 end

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature "Personal details", type: :system do
     and_i_click_save_and_continue
     then_i_am_asked_to_confirm_their_personal_details
 
-    when_i_click_back
+    when_i_click_change_qts
     then_i_am_asked_if_i_know_whether_they_have_qts
     and_i_click_save_and_continue
     then_i_am_asked_to_confirm_their_personal_details
@@ -209,5 +209,9 @@ RSpec.feature "Personal details", type: :system do
         expect(find(".app-task-list__tag").text).to eq("COMPLETED")
       end
     end
+  end
+
+  def when_i_click_change_qts
+    click_on "Change do they have QTS"
   end
 end


### PR DESCRIPTION
The back link on each page is a simple `url_for(:back)` but this doesn't
recognise a user visiting from a check answers page.

We already store a return to location in the session to allow redirects
back to a check answers page when appropriate.

The simplest change to allow the back link to behave in a similar
fashion is to use this same session value.

Whenever someone clicks a change link from a check answers page, both
the back link and submitting the form successfully should take the user
back to the check answers page.

I considered taking an approach similar to the one in
[Apply](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/787)
but decided that the complexity and changes required outweigh the
benefits for this project.

Instead, I opted for the simpler (and less feature rich) approach of
using the value in `session[:return_to]` and falling back to a
hard-coded default in the view.

The upside of this is that the URLs are defined explicitly, and at an
individual page level it is easy to understand the navigation.

The downside is that every page needs to define it's referrer.

I think the trade-off is worth it.

https://trello.com/c/t76oJFBj/1024-ensure-back-links-go-to-check-answers-correctly

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
