### PR TITLE
Add teaching somewhere else page

### DIFF
--- a/app/components/their_role_component.rb
+++ b/app/components/their_role_component.rb
@@ -114,6 +114,25 @@ class TheirRoleComponent < ViewComponent::Base
         value: {
           text: duties_details(referral)
         }
+      },
+      {
+        actions: [
+          {
+            text: "Change",
+            href:
+              referrals_edit_teacher_role_teaching_somewhere_else_path(
+                referral,
+                return_to: request.url
+              ),
+            visually_hidden_text: "teaching somewhere else"
+          }
+        ],
+        key: {
+          text: "Do they teach somewhere else?"
+        },
+        value: {
+          text: referral.teaching_somewhere_else&.humanize
+        }
       }
     ]
   end

--- a/app/controllers/referrals/teacher_role/duties_controller.rb
+++ b/app/controllers/referrals/teacher_role/duties_controller.rb
@@ -33,7 +33,9 @@ module Referrals
       end
 
       def next_path
-        referrals_edit_teacher_role_check_answers_path(current_referral)
+        referrals_edit_teacher_role_teaching_somewhere_else_path(
+          current_referral
+        )
       end
     end
   end

--- a/app/controllers/referrals/teacher_role/teaching_somewhere_else_controller.rb
+++ b/app/controllers/referrals/teacher_role/teaching_somewhere_else_controller.rb
@@ -1,0 +1,37 @@
+module Referrals
+  module TeacherRole
+    class TeachingSomewhereElseController < Referrals::BaseController
+      def edit
+        @teaching_somewhere_else_form =
+          TeachingSomewhereElseForm.new(
+            teaching_somewhere_else: current_referral.teaching_somewhere_else
+          )
+      end
+
+      def update
+        @teaching_somewhere_else_form =
+          TeachingSomewhereElseForm.new(
+            teaching_somewhere_else_params.merge(referral: current_referral)
+          )
+
+        if @teaching_somewhere_else_form.save
+          redirect_to next_page
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def teaching_somewhere_else_params
+        params.require(
+          :referrals_teacher_role_teaching_somewhere_else_form
+        ).permit(:teaching_somewhere_else)
+      end
+
+      def next_path
+        referrals_edit_teacher_role_check_answers_path(current_referral)
+      end
+    end
+  end
+end

--- a/app/forms/referrals/teacher_role/teaching_somewhere_else_form.rb
+++ b/app/forms/referrals/teacher_role/teaching_somewhere_else_form.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Referrals
+  module TeacherRole
+    class TeachingSomewhereElseForm
+      include ActiveModel::Model
+
+      attr_accessor :referral, :teaching_somewhere_else
+
+      validates :referral, presence: true
+      validates :teaching_somewhere_else,
+                inclusion: {
+                  in: %w[yes no dont_know]
+                }
+
+      def save
+        return false if invalid?
+
+        referral.update(teaching_somewhere_else:)
+      end
+    end
+  end
+end

--- a/app/views/referrals/personal_details/qts/edit.html.erb
+++ b/app/views/referrals/personal_details/qts/edit.html.erb
@@ -9,7 +9,7 @@
         <%= f.govuk_radio_buttons_fieldset(:has_qts, legend: { size: "xl", text: "Do they have qualified teacher status (QTS)?" }) do %>
           <%= f.govuk_radio_button :has_qts, "yes", label: { text: "Yes, they have QTS" } %>
           <%= f.govuk_radio_button :has_qts, "no", label: { text: "No, they do not have QTS" } %>
-          <%= f.govuk_radio_button :has_qts, "dont_know", label: { text: " I don’t know" } %>
+          <%= f.govuk_radio_button :has_qts, "dont_know", label: { text: "I don’t know" } %>
         <% end %>
       </div>
       <%= f.govuk_submit "Save and continue" %>

--- a/app/views/referrals/teacher_role/teaching_somewhere_else/edit.html.erb
+++ b/app/views/referrals/teacher_role/teaching_somewhere_else/edit.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, "#{'Error: ' if @teaching_somewhere_else_form.errors.any?}Do you know if they are teaching somewhere else?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <%= form_with model: @teaching_somewhere_else_form, url: referrals_update_teacher_role_teaching_somewhere_else_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :teaching_somewhere_else,
+        legend: { size: "l", text: "Do you know if they are teaching somewhere else?" } do %>
+        <%= f.hidden_field :teaching_somewhere_else %>
+        <%= f.govuk_radio_button :teaching_somewhere_else, "yes", label: { text: "Yes, they are teaching somewhere else" } %>
+        <%= f.govuk_radio_button :teaching_somewhere_else, "no", label: { text: "No, a different organisation" } %>
+        <%= f.govuk_radio_button :teaching_somewhere_else, "dont_know", label: { text: "I don’t know" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,6 +196,10 @@ en:
               invalid_content_type: Please upload files of valid type (%{valid_types})
               mismatch_content_type: File type does not match file contents
               file_size_too_big: Maximum file size is 25MB
+        "referrals/teacher_role/teaching_somewhere_else_form":
+          attributes:
+            teaching_somewhere_else:
+              inclusion: Tell us if you know if they are teaching somewhere else
         "referrals/teacher_role/check_answers_form":
           attributes:
             teacher_role_complete:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,6 +233,12 @@ Rails.application.routes.draw do
     put "/:referral_id/teacher-role/duties",
         to: "teacher_role/duties#update",
         as: "update_teacher_duties"
+    get "/:referral_id/teacher-role/teaching-somewhere-else",
+        to: "teacher_role/teaching_somewhere_else#edit",
+        as: "edit_teacher_role_teaching_somewhere_else"
+    put "/:referral_id/teacher-role/teaching-somewhere-else",
+        to: "teacher_role/teaching_somewhere_else#update",
+        as: "update_teacher_role_teaching_somewhere_else"
     get "/:referral_id/teacher-role/check-answers",
         to: "teacher_role/check_answers#edit",
         as: "edit_teacher_role_check_answers"

--- a/db/migrate/20221205233038_add_teaching_somewhere_elseto_referral.rb
+++ b/db/migrate/20221205233038_add_teaching_somewhere_elseto_referral.rb
@@ -1,0 +1,5 @@
+class AddTeachingSomewhereElsetoReferral < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrals, :teaching_somewhere_else, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_01_155324) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_05_233038) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -132,6 +132,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_01_155324) do
     t.string "duties_details"
     t.boolean "teacher_role_complete"
     t.datetime "submitted_at", precision: nil
+    t.string "teaching_somewhere_else"
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 

--- a/spec/forms/referrals/teacher_role/teaching_somewhere_else_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/teaching_somewhere_else_form_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Referrals::TeacherRole::TeachingSomewhereElseForm,
+               type: :model do
+  subject(:form) { described_class.new(referral:, teaching_somewhere_else:) }
+
+  let(:referral) { build(:referral) }
+  let(:teaching_somewhere_else) { "yes" }
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    before { valid }
+
+    it { is_expected.to be_truthy }
+
+    context "when teaching_somewhere_else is blank" do
+      let(:teaching_somewhere_else) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:teaching_somewhere_else]).to eq(
+          ["Tell us if you know if they are teaching somewhere else"]
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when teaching_somewhere_else is yes" do
+      let(:teaching_somewhere_else) { "yes" }
+
+      it "updates the teaching_somewhere_else to yes" do
+        expect { form.save }.to change(referral, :teaching_somewhere_else).from(
+          nil
+        ).to("yes")
+      end
+    end
+
+    context "when teaching_somewhere_else is no" do
+      let(:teaching_somewhere_else) { "no" }
+
+      it "updates the teaching_somewhere_else to no" do
+        expect { form.save }.to change(referral, :teaching_somewhere_else).from(
+          nil
+        ).to("no")
+      end
+    end
+
+    context "when teaching_somewhere_else is not known" do
+      let(:teaching_somewhere_else) { "dont_know" }
+
+      it "updates the teaching_somewhere_else to dont_know" do
+        expect { form.save }.to change(referral, :teaching_somewhere_else).from(
+          nil
+        ).to("dont_know")
+      end
+    end
+  end
+end

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -119,16 +119,20 @@ RSpec.feature "Teacher role", type: :system do
     and_i_choose_upload
     and_i_attach_a_job_description_file
     and_i_click_save_and_continue
-    then_i_see_the_check_answers_page
-    and_i_see_a_summary_list(duties_description: "File: file.pdf")
+    then_i_see_the_teaching_somewhere_else_page
+
+    when_i_visit_the_check_answers_page
+    then_i_see_a_summary_list(duties_description: "File: file.pdf")
 
     when_i_visit_the_duties_page
     and_i_see_the_uploaded_filename
     and_i_choose_upload
     and_i_attach_a_second_job_description_file
     and_i_click_save_and_continue
-    then_i_see_the_check_answers_page
-    and_i_see_a_summary_list(duties_description: "File: file2.pdf")
+    then_i_see_the_teaching_somewhere_else_page
+
+    when_i_visit_the_check_answers_page
+    then_i_see_a_summary_list(duties_description: "File: file2.pdf")
 
     when_i_visit_the_duties_page
     and_i_see_the_second_uploaded_filename
@@ -136,10 +140,27 @@ RSpec.feature "Teacher role", type: :system do
     when_i_fill_in_the_duties_field
     and_i_click_save_and_continue
 
+    # Do you know if they are teaching somewhere else
+
+    then_i_see_the_teaching_somewhere_else_page
+    when_i_click_save_and_continue
+    then_i_see_teaching_somewhere_else_field_validation_errors
+
+    when_i_choose_no
+    when_i_click_save_and_continue
+    then_i_see_the_check_answers_page
+
+    when_i_visit_the_teaching_somewhere_else_page
+    and_i_choose_yes
+    when_i_click_save_and_continue
+
     # Check and confirm your answers
 
     then_i_see_the_check_answers_page
-    and_i_see_a_summary_list(duties_description: "Main duties")
+    and_i_see_a_summary_list(
+      duties_description: "Main duties",
+      teaching_somewhere_else: "Yes"
+    )
 
     when_i_click_save_and_continue
     then_i_see_a_completed_error
@@ -173,6 +194,10 @@ RSpec.feature "Teacher role", type: :system do
 
   def when_i_visit_the_duties_page
     visit referrals_edit_teacher_duties_path(@referral)
+  end
+
+  def when_i_visit_the_teaching_somewhere_else_page
+    visit referrals_edit_teacher_role_teaching_somewhere_else_path(@referral)
   end
 
   def when_i_visit_the_check_answers_page
@@ -225,6 +250,18 @@ RSpec.feature "Teacher role", type: :system do
     )
     expect(page).to have_title("Do you know when they started their job?")
     expect(page).to have_content("Do you know when they started their job?")
+  end
+
+  def then_i_see_the_teaching_somewhere_else_page
+    expect(page).to have_current_path(
+      "/referrals/#{@referral.id}/teacher-role/teaching-somewhere-else"
+    )
+    expect(page).to have_title(
+      "Do you know if they are teaching somewhere else?"
+    )
+    expect(page).to have_content(
+      "Do you know if they are teaching somewhere else?"
+    )
   end
 
   def then_i_see_the_check_answers_page
@@ -360,6 +397,12 @@ RSpec.feature "Teacher role", type: :system do
     expect(page).to have_content("Enter details of their main duties")
   end
 
+  def then_i_see_teaching_somewhere_else_field_validation_errors
+    expect(page).to have_content(
+      "Tell us if you know if they are teaching somewhere else"
+    )
+  end
+
   def then_i_see_a_completed_error
     expect(page).to have_content("Tell us if you have completed this section")
   end
@@ -374,7 +417,7 @@ RSpec.feature "Teacher role", type: :system do
     expect(page).to have_content("Uploaded file: file2.pdf")
   end
 
-  def and_i_see_a_summary_list(duties_description:)
+  def and_i_see_a_summary_list(duties_description:, teaching_somewhere_else: "")
     expect_summary_row(
       key: "Job start date",
       value: "17 January 1990",
@@ -411,7 +454,18 @@ RSpec.feature "Teacher role", type: :system do
       change_link:
         referrals_edit_teacher_duties_path(@referral, return_to: current_url)
     )
+
+    expect_summary_row(
+      key: "Do they teach somewhere else?",
+      value: teaching_somewhere_else,
+      change_link:
+        referrals_edit_teacher_role_teaching_somewhere_else_path(
+          @referral,
+          return_to: current_url
+        )
+    )
   end
+  alias_method :then_i_see_a_summary_list, :and_i_see_a_summary_list
 
   def then_i_see_the_status_section_in_the_referral_summary(status: "COMPLETED")
     expect_task_row(


### PR DESCRIPTION
### Context

The teaching somewhere else page is part of the teacher role journey. It follows the job duties questions.

<img width="550" alt="Screenshot 2022-12-06 at 10 54 15" src="https://user-images.githubusercontent.com/1636476/205950564-1490e19a-6c9f-4a71-9d8e-2fdd503dfd1a.png">

### Changes proposed in this pull request

- Update the routes
- Generate a migration for adding the `teaching_somewhere_else` field to the referrals table.
- Add the form, including validation
- Link the form to the job duties page

### Link to Trello card

https://trello.com/c/my8kX9Xz/1011-about-their-role-forms-add-teaching-somewhere-else-page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
