### PR TITLE
Adjust redirect behaviour after user sign in

### DIFF
--- a/app/controllers/eligibility_screener_controller.rb
+++ b/app/controllers/eligibility_screener_controller.rb
@@ -1,6 +1,6 @@
 class EligibilityScreenerController < ApplicationController
-  include AuthenticateUser
   include StoreUserLocation
+  include AuthenticateUser
   include EnforceQuestionOrder
   include RedirectIfFeatureFlagInactive
 

--- a/app/controllers/support_interface/test_users_controller.rb
+++ b/app/controllers/support_interface/test_users_controller.rb
@@ -31,7 +31,7 @@ module SupportInterface
     def after_sign_in_path
       latest_referral = current_user.latest_referral
 
-      latest_referral ? referral_path(latest_referral) : root_path
+      latest_referral ? referral_path(latest_referral) : who_path
     end
   end
 end

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -57,7 +57,7 @@ class Users::OtpController < DeviseController
   def latest_referral_path(resource)
     latest_referral = resource.latest_referral
 
-    latest_referral ? referral_path(latest_referral) : root_path
+    latest_referral ? referral_path(latest_referral) : who_path
   end
 
   def user_params

--- a/spec/system/user_auth/user_signs_in_spec.rb
+++ b/spec/system/user_auth/user_signs_in_spec.rb
@@ -109,6 +109,8 @@ RSpec.feature "User accounts" do
   end
 
   def and_i_am_not_prompted_to_sign_in_again
+    expect(page).to have_current_path who_path
+    visit root_path
     click_on "Start now"
     expect(page).to have_current_path who_path
   end


### PR DESCRIPTION

### Context
Current redirect behaviour:

- Redirect to stored location if present
- Else redirect to referral if present
- Else redirect to start page

We want to adjust the last scenario to the start of the screener.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
A login by a new user to the service takes them to the start of the screener.

Same for a new test user.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
Can be tested locally by doing a new sign in. Users with a referral should see the referral, new users should see step 1 of the screener.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/XcJGaxPj
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
