### PR TITLE
Associate EligibilityCheck records with Referrals

### DIFF
--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -29,6 +29,10 @@ class EligibilityCheck < ApplicationRecord
     reporting_as&.to_sym == :employer
   end
 
+  def reporting_as_member_of_public?
+    reporting_as&.to_sym == :public
+  end
+
   def serious_misconduct?
     %w[yes not_sure].include?(serious_misconduct)
   end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -3,6 +3,12 @@ class EligibilityCheck < ApplicationRecord
 
   validates :reporting_as, presence: true
 
+  enum reporting_as: {
+         employer: "employer",
+         public: "public"
+       },
+       _prefix: "reporting_as"
+
   scope :complete, -> { where(serious_misconduct: "yes") }
   scope :group_by_day, -> { group("date_trunc('day', created_at)") }
   scope :incomplete,
@@ -23,14 +29,6 @@ class EligibilityCheck < ApplicationRecord
 
   def is_teacher?
     %w[yes].include?(is_teacher)
-  end
-
-  def reporting_as_employer?
-    reporting_as&.to_sym == :employer
-  end
-
-  def reporting_as_member_of_public?
-    reporting_as&.to_sym == :public
   end
 
   def serious_misconduct?

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -1,4 +1,6 @@
 class EligibilityCheck < ApplicationRecord
+  has_one :referral
+
   validates :reporting_as, presence: true
 
   scope :complete, -> { where(serious_misconduct: "yes") }

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -17,7 +17,7 @@ class Referral < ApplicationRecord
   end
 
   def from_member_of_public?
-    eligibility_check.reporting_as_member_of_public?
+    eligibility_check.reporting_as_public?
   end
 
   def organisation_status

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -1,4 +1,7 @@
 class Referral < ApplicationRecord
+  belongs_to :eligibility_check, dependent: :destroy
+  belongs_to :user
+
   has_one :organisation, dependent: :destroy
   has_one :referrer, dependent: :destroy
   has_one_attached :allegation_upload, dependent: :destroy
@@ -8,8 +11,6 @@ class Referral < ApplicationRecord
            -> { order(:filename) },
            class_name: "ReferralEvidence",
            dependent: :destroy
-
-  belongs_to :user
 
   def organisation_status
     return :not_started_yet if organisation.blank?

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -12,6 +12,14 @@ class Referral < ApplicationRecord
            class_name: "ReferralEvidence",
            dependent: :destroy
 
+  def from_employer?
+    eligibility_check.reporting_as_employer?
+  end
+
+  def from_member_of_public?
+    eligibility_check.reporting_as_member_of_public?
+  end
+
   def organisation_status
     return :not_started_yet if organisation.blank?
 

--- a/db/migrate/20221207144938_add_eligibility_check_to_referrals.rb
+++ b/db/migrate/20221207144938_add_eligibility_check_to_referrals.rb
@@ -1,0 +1,5 @@
+class AddEligibilityCheckToReferrals < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :referrals, :eligibility_check, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -139,6 +139,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_112937) do
     t.string "teaching_address_line_2"
     t.string "teaching_town_or_city"
     t.string "teaching_postcode"
+    t.bigint "eligibility_check_id"
+    t.index ["eligibility_check_id"], name: "index_referrals_on_eligibility_check_id"
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 
@@ -212,6 +214,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_112937) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "organisations", "referrals"
   add_foreign_key "referral_evidences", "referrals"
+  add_foreign_key "referrals", "eligibility_checks"
   add_foreign_key "referrals", "users"
   add_foreign_key "referrers", "referrals"
 end

--- a/spec/factories/eligibility_checks.rb
+++ b/spec/factories/eligibility_checks.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
       unsupervised_teaching { "no" }
     end
 
-    trait :member_of_public do
+    trait :public do
       reporting_as { "public" }
     end
   end

--- a/spec/factories/eligibility_checks.rb
+++ b/spec/factories/eligibility_checks.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
       is_teacher { "no" }
       unsupervised_teaching { "no" }
     end
+
+    trait :member_of_public do
+      reporting_as { "public" }
+    end
   end
 end

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :referral do
     user
+    eligibility_check
 
     trait :complete do
       allegation_details_complete { true }

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -98,4 +98,50 @@ RSpec.describe Referral, type: :model do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe "#from_employer?" do
+    subject { referral.from_employer? }
+
+    context "when eligibility_check is reporting_as_employer" do
+      let(:referral) do
+        build(:referral, eligibility_check: build(:eligibility_check))
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when eligibility_check is reporting_as_member_of_public" do
+      let(:referral) do
+        build(
+          :referral,
+          eligibility_check: build(:eligibility_check, :member_of_public)
+        )
+      end
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe "#from_member_of_public?" do
+    subject { referral.from_member_of_public? }
+
+    context "when eligibility_check is reporting_as_employer" do
+      let(:referral) do
+        build(:referral, eligibility_check: build(:eligibility_check))
+      end
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when eligibility_check is reporting_as_member_of_public" do
+      let(:referral) do
+        build(
+          :referral,
+          eligibility_check: build(:eligibility_check, :member_of_public)
+        )
+      end
+
+      it { is_expected.to be_truthy }
+    end
+  end
 end

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -110,12 +110,9 @@ RSpec.describe Referral, type: :model do
       it { is_expected.to be_truthy }
     end
 
-    context "when eligibility_check is reporting_as_member_of_public" do
+    context "when eligibility_check is reporting_as_public" do
       let(:referral) do
-        build(
-          :referral,
-          eligibility_check: build(:eligibility_check, :member_of_public)
-        )
+        build(:referral, eligibility_check: build(:eligibility_check, :public))
       end
 
       it { is_expected.to be_falsey }
@@ -133,12 +130,9 @@ RSpec.describe Referral, type: :model do
       it { is_expected.to be_falsey }
     end
 
-    context "when eligibility_check is reporting_as_member_of_public" do
+    context "when eligibility_check is reporting_as_public" do
       let(:referral) do
-        build(
-          :referral,
-          eligibility_check: build(:eligibility_check, :member_of_public)
-        )
+        build(:referral, eligibility_check: build(:eligibility_check, :public))
       end
 
       it { is_expected.to be_truthy }

--- a/spec/system/eligibility_screener_spec.rb
+++ b/spec/system/eligibility_screener_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "Eligibility screener", type: :system do
     given_the_service_is_open
     and_the_eligibility_screener_feature_is_active
     and_the_employer_form_feature_is_active
+    and_the_user_accounts_feature_is_active
     and_i_am_signed_in
     when_i_visit_the_service
     then_i_see_the_start_page
@@ -83,7 +84,9 @@ RSpec.feature "Eligibility screener", type: :system do
     then_i_see_the_you_should_know_page
 
     when_i_press_continue
-    then_i_see_the_completion_page
+    then_i_see_the_progress_is_saved_page
+    when_i_press_continue
+    then_i_have_started_a_member_of_public_referral
   end
 
   private
@@ -92,14 +95,8 @@ RSpec.feature "Eligibility screener", type: :system do
     expect(page).to have_content("There is a problem")
   end
 
-  def then_i_see_the_completion_page
-    expect(page).to have_current_path("/complete")
-    expect(page).to have_title(
-      "You need to complete a teacher misconduct form - Refer serious misconduct by a teacher in England"
-    )
-    expect(page).to have_content(
-      "You need to complete a teacher misconduct form"
-    )
+  def then_i_see_the_progress_is_saved_page
+    expect(page).to have_content "Your progress is saved as you go"
   end
 
   def then_i_see_the_employer_or_public_question
@@ -275,5 +272,12 @@ RSpec.feature "Eligibility screener", type: :system do
 
   def when_i_visit_the_service
     visit root_path
+  end
+
+  def then_i_have_started_a_member_of_public_referral
+    referral = User.last.latest_referral
+
+    expect(page).to have_current_path edit_referral_path(referral)
+    expect(referral).to be_from_member_of_public
   end
 end

--- a/spec/system/referrals/user_deletes_a_draft_referral_spec.rb
+++ b/spec/system/referrals/user_deletes_a_draft_referral_spec.rb
@@ -25,8 +25,8 @@ RSpec.feature "User deletes a draft referral", type: :system do
   private
 
   def when_i_make_a_new_referral
-    visit new_referral_path
-    click_on "Continue"
+    and_i_have_an_existing_referral
+    and_i_visit_the_referral
   end
 
   def and_i_dont_want_to_continue


### PR DESCRIPTION
### Context

<!-- Why are you making this change? -->
There's currently no way of identifying whether a referral is from an employer or a member of the public. We need to distinguish between the two to provide different journeys.

### Changes proposed in this pull request
- Add a 1-1 association between an EligibilityCheck record and the Referral that gets created once the check is complete.
- Add convenience methods on Referral to query the type


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

~Raised as draft initially to discuss approach, specs to follow.~
~Is this approach sound?~

Aside from code review, a manual test could consist of going through the screener and observing the type of referral created in the console.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/GgpmUmCx
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
