### PR TITLE
Direct user to start of the evidence flow if not started yet

### DIFF
--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -90,7 +90,11 @@ class ReferralForm
         ),
         ReferralSectionItem.new(
           I18n.t("referral_form.evidence_and_supporting_information"),
-          referrals_edit_evidence_start_path(referral),
+          section_path(
+            section_status(:evidence_details_complete),
+            referrals_edit_evidence_start_path(referral),
+            referrals_edit_evidence_check_answers_path(referral)
+          ),
           section_status(:evidence_details_complete)
         )
       ]
@@ -102,5 +106,11 @@ class ReferralForm
     return :not_started_yet if status.nil?
 
     status ? :completed : :incomplete
+  end
+
+  def section_path(status, start_path, check_answers_path)
+    return start_path if status == :not_started_yet
+
+    check_answers_path
   end
 end

--- a/spec/system/referrals/user_adds_evidence_spec.rb
+++ b/spec/system/referrals/user_adds_evidence_spec.rb
@@ -65,17 +65,15 @@ RSpec.feature "Evidence", type: :system do
     when_i_confirm_i_want_to_delete
     then_i_can_no_longer_see_the_upload_in_the_referral_summary
 
-    when_i_choose_to_confirm
+    when_i_choose_not_to_confirm
     and_i_click_save_and_continue
     then_i_see_the_referral_summary
-    and_the_evidence_section_is_complete
+    and_the_evidence_section_state_is(:incomplete)
 
-    # Additional scenario of changing to 'No evidence' state
     when_i_edit_the_evidence
-    then_i_am_asked_if_i_have_evidence_to_upload
-    when_i_choose_no_to_uploading_evidence
+    and_i_choose_to_confirm
     and_i_click_save_and_continue
-    then_i_am_asked_to_confirm_evidence_details_without_uploads
+    then_the_evidence_section_state_is(:completed)
   end
 
   private
@@ -190,16 +188,6 @@ RSpec.feature "Evidence", type: :system do
     )
   end
 
-  def then_i_am_asked_to_confirm_evidence_details_without_uploads
-    expect(page).to have_content("Check and confirm your answers")
-
-    expect_summary_row(
-      key: "Documents",
-      value: "No evidence uploaded",
-      change_link: referrals_edit_evidence_start_path(@referral)
-    )
-  end
-
   def then_i_see_check_answers_form_validation_errors
     expect(page).to have_content("Tell us if you have completed this section")
   end
@@ -225,20 +213,26 @@ RSpec.feature "Evidence", type: :system do
     )
   end
 
-  def when_i_choose_to_confirm
+  def and_i_choose_to_confirm
     choose "Yes, I’ve completed this section", visible: false
   end
 
-  def and_the_evidence_section_is_complete
+  def when_i_choose_not_to_confirm
+    choose "No, I’ll come back to it later", visible: false
+  end
+
+  def and_the_evidence_section_state_is(state)
     within(all(".app-task-list__section")[2]) do
       within(all(".app-task-list__item")[2]) do
         expect(find(".app-task-list__task-name a").text).to eq(
           "Evidence and supporting information"
         )
-        expect(find(".app-task-list__tag").text).to eq("COMPLETED")
+        expect(find(".app-task-list__tag").text).to eq(state.to_s.upcase)
       end
     end
   end
+  alias_method :then_the_evidence_section_state_is,
+               :and_the_evidence_section_state_is
 
   def when_i_click_change_categories_for_the_first_item
     click_on "Change categories", match: :first


### PR DESCRIPTION
### Context

The user should only be taken through the evidence flow if they've not started it before.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

If the user has previously been through the evidence flow take them to the check-answers step.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
