### PR TITLE
Add teaching location page

### DIFF
--- a/app/components/contact_details_component.rb
+++ b/app/components/contact_details_component.rb
@@ -1,6 +1,6 @@
 class ContactDetailsComponent < ViewComponent::Base
   include ActiveModel::Model
-  include ReferrerHelper
+  include AddressHelper
 
   attr_accessor :referral
 

--- a/app/components/organisation_component.rb
+++ b/app/components/organisation_component.rb
@@ -1,6 +1,6 @@
 class OrganisationComponent < ViewComponent::Base
   include ActiveModel::Model
-  include ReferrerHelper
+  include AddressHelper
 
   attr_accessor :referral
 

--- a/app/components/their_role_component.rb
+++ b/app/components/their_role_component.rb
@@ -1,11 +1,12 @@
 class TheirRoleComponent < ViewComponent::Base
   include ActiveModel::Model
   include ReferralHelper
+  include AddressHelper
 
   attr_accessor :referral
 
   def rows
-    [
+    @rows = [
       {
         actions: [
           {
@@ -135,5 +136,30 @@ class TheirRoleComponent < ViewComponent::Base
         }
       }
     ]
+
+    if referral.teaching_somewhere_else?
+      @rows << {
+        actions: [
+          {
+            text: "Change",
+            href:
+              referrals_edit_teacher_role_teaching_location_path(
+                referral,
+                return_to: request.url
+              ),
+            visually_hidden_text: "teaching location"
+          }
+        ],
+        key: {
+          text: "Do you know where they are teaching?"
+        },
+        value: {
+          text:
+            referral.teaching_location_known ? teaching_address(referral) : "No"
+        }
+      }
+    end
+
+    @rows
   end
 end

--- a/app/controllers/referrals/teacher_role/teaching_location_controller.rb
+++ b/app/controllers/referrals/teacher_role/teaching_location_controller.rb
@@ -1,0 +1,48 @@
+module Referrals
+  module TeacherRole
+    class TeachingLocationController < Referrals::BaseController
+      def edit
+        @teaching_location_form =
+          TeachingLocationForm.new(
+            teaching_location_known: current_referral.teaching_location_known,
+            teaching_organisation_name:
+              current_referral.teaching_organisation_name,
+            teaching_address_line_1: current_referral.teaching_address_line_1,
+            teaching_address_line_2: current_referral.teaching_address_line_2,
+            teaching_town_or_city: current_referral.teaching_town_or_city,
+            teaching_postcode: current_referral.teaching_postcode
+          )
+      end
+
+      def update
+        @teaching_location_form =
+          TeachingLocationForm.new(
+            teaching_location_params.merge(referral: current_referral)
+          )
+
+        if @teaching_location_form.save
+          redirect_to next_page
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def teaching_location_params
+        params.require(:referrals_teacher_role_teaching_location_form).permit(
+          :teaching_location_known,
+          :teaching_organisation_name,
+          :teaching_address_line_1,
+          :teaching_address_line_2,
+          :teaching_town_or_city,
+          :teaching_postcode
+        )
+      end
+
+      def next_path
+        referrals_edit_teacher_role_check_answers_path(current_referral)
+      end
+    end
+  end
+end

--- a/app/controllers/referrals/teacher_role/teaching_somewhere_else_controller.rb
+++ b/app/controllers/referrals/teacher_role/teaching_somewhere_else_controller.rb
@@ -30,7 +30,19 @@ module Referrals
       end
 
       def next_path
-        referrals_edit_teacher_role_check_answers_path(current_referral)
+        if current_referral.teaching_somewhere_else?
+          referrals_edit_teacher_role_teaching_location_path(current_referral)
+        else
+          referrals_edit_teacher_role_check_answers_path(current_referral)
+        end
+      end
+
+      def next_page
+        if @teaching_somewhere_else_form.referral.saved_changes?
+          return next_path
+        end
+
+        super
       end
     end
   end

--- a/app/forms/referrals/teacher_role/teaching_location_form.rb
+++ b/app/forms/referrals/teacher_role/teaching_location_form.rb
@@ -1,0 +1,62 @@
+module Referrals
+  module TeacherRole
+    class TeachingLocationForm
+      include ActiveModel::Model
+
+      attr_accessor :referral,
+                    :teaching_organisation_name,
+                    :teaching_address_line_1,
+                    :teaching_address_line_2,
+                    :teaching_town_or_city,
+                    :teaching_postcode
+      attr_reader :teaching_location_known
+
+      validates :referral, presence: true
+      validates :teaching_location_known, inclusion: { in: [true, false] }
+      validates :teaching_organisation_name,
+                :teaching_address_line_1,
+                :teaching_town_or_city,
+                :teaching_postcode,
+                presence: true,
+                if: -> { teaching_location_known }
+      validate :postcode_is_valid,
+               if: -> { teaching_postcode.present? && teaching_location_known }
+
+      def teaching_location_known=(value)
+        @teaching_location_known = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save
+        return false unless valid?
+
+        address_attrs = {
+          teaching_location_known:,
+          teaching_organisation_name: nil,
+          teaching_address_line_1: nil,
+          teaching_address_line_2: nil,
+          teaching_town_or_city: nil,
+          teaching_postcode: nil
+        }
+
+        if teaching_location_known
+          address_attrs.merge!(
+            teaching_organisation_name:,
+            teaching_address_line_1:,
+            teaching_address_line_2:,
+            teaching_town_or_city:,
+            teaching_postcode:
+          )
+        end
+        referral.update(address_attrs)
+      end
+
+      private
+
+      def postcode_is_valid
+        unless UKPostcode.parse(teaching_postcode).full_valid?
+          errors.add(:teaching_postcode, :invalid)
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -1,4 +1,4 @@
-module ReferrerHelper
+module AddressHelper
   def address(referral)
     address_fields_to_html(
       [
@@ -18,6 +18,18 @@ module ReferrerHelper
         organisation.street_2,
         organisation.city,
         organisation.postcode
+      ]
+    )
+  end
+
+  def teaching_address(referral)
+    address_fields_to_html(
+      [
+        referral.teaching_organisation_name,
+        referral.teaching_address_line_1,
+        referral.teaching_address_line_2,
+        referral.teaching_town_or_city,
+        referral.teaching_postcode
       ]
     )
   end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -35,4 +35,8 @@ class Referral < ApplicationRecord
 
     referrer.status
   end
+
+  def teaching_somewhere_else?
+    teaching_somewhere_else == "yes"
+  end
 end

--- a/app/views/referrals/teacher_role/teaching_location/edit.html.erb
+++ b/app/views/referrals/teacher_role/teaching_location/edit.html.erb
@@ -1,0 +1,30 @@
+<% content_for :page_title, "#{"Error: " if @teaching_location_form.errors.any?}Do you know where they are teaching?" %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_teacher_role_teaching_somewhere_else_path(current_referral)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @teaching_location_form, url: referrals_update_teacher_role_teaching_location_url, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :teaching_location_known, legend: { size: "xl", text: "Do you know where they are teaching?" }  do %>
+        <%= f.hidden_field :teaching_location_known %>
+        <%= f.govuk_radio_button :teaching_location_known, true, label: { text: "Yes" } do %>
+          <div class="govuk-form-group">
+            <%= f.govuk_text_field :teaching_organisation_name, label: { text: "Organisation name", size: "s" } %>
+          </div>
+           <div class="govuk-form-group">
+            <%= f.govuk_fieldset legend: { text: "Organisation address", size: "s" } do %>
+              <%= f.govuk_text_field :teaching_address_line_1, label: { text: "Address line 1" } %>
+              <%= f.govuk_text_field :teaching_address_line_2, label: { text: "Address line 2 (optional)" } %>
+              <%= f.govuk_text_field :teaching_town_or_city, label: { text: "Town or city" } %>
+              <%= f.govuk_text_field :teaching_postcode, label: { text: "Postcode" } %>
+            <% end %>
+          </div>
+        <% end %>
+
+        <%= f.govuk_radio_button :teaching_location_known, false, label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue", prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/teacher_role/teaching_somewhere_else/edit.html.erb
+++ b/app/views/referrals/teacher_role/teaching_somewhere_else/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @teaching_somewhere_else_form.errors.any?}Do you know if they are teaching somewhere else?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(referrals_edit_teacher_role_duties_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">
@@ -10,7 +10,7 @@
         legend: { size: "l", text: "Do you know if they are teaching somewhere else?" } do %>
         <%= f.hidden_field :teaching_somewhere_else %>
         <%= f.govuk_radio_button :teaching_somewhere_else, "yes", label: { text: "Yes, they are teaching somewhere else" } %>
-        <%= f.govuk_radio_button :teaching_somewhere_else, "no", label: { text: "No, a different organisation" } %>
+        <%= f.govuk_radio_button :teaching_somewhere_else, "no", label: { text: "No, they are not teaching somewhere else" } %>
         <%= f.govuk_radio_button :teaching_somewhere_else, "dont_know", label: { text: "I don’t know" } %>
       <% end %>
       <%= f.govuk_submit "Save and continue" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,6 +200,19 @@ en:
           attributes:
             teaching_somewhere_else:
               inclusion: Tell us if you know if they are teaching somewhere else
+        "referrals/teacher_role/teaching_location_form":
+          attributes:
+            teaching_location_known:
+              inclusion: Tell us if you know where they are teaching
+            teaching_organisation_name:
+              blank: Tell us the name of their organisation
+            teaching_address_line_1:
+              blank: Enter the first line of their organisation's address
+            teaching_town_or_city:
+              blank: Enter a town or city for their organisation
+            teaching_postcode:
+              blank: Enter a postcode for their organisation
+              invalid: Enter a real postcode
         "referrals/teacher_role/check_answers_form":
           attributes:
             teacher_role_complete:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -239,6 +239,12 @@ Rails.application.routes.draw do
     put "/:referral_id/teacher-role/teaching-somewhere-else",
         to: "teacher_role/teaching_somewhere_else#update",
         as: "update_teacher_role_teaching_somewhere_else"
+    get "/:referral_id/teacher-role/teaching-location",
+        to: "teacher_role/teaching_location#edit",
+        as: "edit_teacher_role_teaching_location"
+    put "/:referral_id/teacher-role/teaching-location",
+        to: "teacher_role/teaching_location#update",
+        as: "update_teacher_role_teaching_location"
     get "/:referral_id/teacher-role/check-answers",
         to: "teacher_role/check_answers#edit",
         as: "edit_teacher_role_check_answers"

--- a/db/migrate/20221208112937_add_teaching_location_to_referrals.rb
+++ b/db/migrate/20221208112937_add_teaching_location_to_referrals.rb
@@ -1,0 +1,10 @@
+class AddTeachingLocationToReferrals < ActiveRecord::Migration[7.0]
+  change_table :referrals, bulk: true do |t|
+    t.boolean :teaching_location_known
+    t.string :teaching_organisation_name
+    t.string :teaching_address_line_1
+    t.string :teaching_address_line_2
+    t.string :teaching_town_or_city
+    t.string :teaching_postcode
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_05_233038) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_08_112937) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -133,6 +133,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_05_233038) do
     t.boolean "teacher_role_complete"
     t.datetime "submitted_at", precision: nil
     t.string "teaching_somewhere_else"
+    t.boolean "teaching_location_known"
+    t.string "teaching_organisation_name"
+    t.string "teaching_address_line_1"
+    t.string "teaching_address_line_2"
+    t.string "teaching_town_or_city"
+    t.string "teaching_postcode"
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 

--- a/spec/forms/referrals/teacher_role/teaching_location_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/teaching_location_form_spec.rb
@@ -1,0 +1,167 @@
+require "rails_helper"
+
+RSpec.describe Referrals::TeacherRole::TeachingLocationForm, type: :model do
+  let(:referral) { create(:referral) }
+  let(:form) { described_class.new(params) }
+
+  let(:params) do
+    {
+      teaching_location_known: true,
+      teaching_organisation_name: "High School",
+      teaching_address_line_1: "1428 Elm Street",
+      teaching_address_line_2: "Sunset Boulevard",
+      teaching_postcode: "NW1 4NP",
+      referral:,
+      teaching_town_or_city: "London"
+    }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:referral) }
+
+    context "when address is known" do
+      subject { form }
+
+      let(:params) { { teaching_location_known: true } }
+
+      it { is_expected.to validate_presence_of(:teaching_organisation_name) }
+      it { is_expected.to validate_presence_of(:teaching_address_line_1) }
+      it { is_expected.to validate_presence_of(:teaching_town_or_city) }
+      it { is_expected.to validate_presence_of(:teaching_postcode) }
+    end
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    before { valid }
+
+    it { is_expected.to be_truthy }
+
+    context "when teaching_location_known is blank" do
+      let(:params) { super().merge(teaching_location_known: "") }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:teaching_location_known]).to eq(
+          ["Tell us if you know where they are teaching"]
+        )
+      end
+    end
+
+    context "when teaching_organisation_name is blank" do
+      let(:params) { super().merge(teaching_organisation_name: "") }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:teaching_organisation_name]).to eq(
+          ["Tell us the name of their organisation"]
+        )
+      end
+    end
+
+    context "when teaching_address_line_1 is blank" do
+      let(:params) { super().merge(teaching_address_line_1: "") }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:teaching_address_line_1]).to eq(
+          ["Enter the first line of their organisation's address"]
+        )
+      end
+    end
+
+    context "when teaching_town_or_city is blank" do
+      let(:params) { super().merge(teaching_town_or_city: "") }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:teaching_town_or_city]).to eq(
+          ["Enter a town or city for their organisation"]
+        )
+      end
+    end
+
+    context "when teaching_postcode is blank" do
+      let(:params) { super().merge(teaching_postcode: "") }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:teaching_postcode]).to eq(
+          ["Enter a postcode for their organisation"]
+        )
+      end
+    end
+
+    context "when teaching_postcode is invalid" do
+      let(:params) { super().merge(teaching_postcode: "Invalid") }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:teaching_postcode]).to eq(["Enter a real postcode"])
+      end
+    end
+  end
+
+  describe "#save" do
+    before { form.save }
+
+    it "saves teaching_location_known" do
+      expect(referral.teaching_location_known).to be_truthy
+    end
+
+    it "saves teaching_organisation_name" do
+      expect(referral.teaching_organisation_name).to eq("High School")
+    end
+
+    it "saves teaching_address_line_1" do
+      expect(referral.teaching_address_line_1).to eq("1428 Elm Street")
+    end
+
+    it "saves teaching_address_line_2" do
+      expect(referral.teaching_address_line_2).to eq("Sunset Boulevard")
+    end
+
+    it "saves teaching_town_or_city" do
+      expect(referral.teaching_town_or_city).to eq("London")
+    end
+
+    it "saves teaching_postcode" do
+      expect(referral.teaching_postcode).to eq("NW1 4NP")
+    end
+
+    context "when the address is not known" do
+      let(:params) { super().merge(teaching_location_known: false) }
+
+      it "sets the teaching_location_known to false" do
+        expect(referral.teaching_location_known).to be_falsy
+      end
+
+      it "sets the teaching_organisation_name to nil" do
+        expect(referral.teaching_organisation_name).to be_nil
+      end
+
+      it "sets the teaching_address_line_1 to nil" do
+        expect(referral.teaching_address_line_1).to be_nil
+      end
+
+      it "sets the teaching_address_line_2 to nil" do
+        expect(referral.teaching_address_line_2).to be_nil
+      end
+
+      it "sets the teaching_town_or_city to nil" do
+        expect(referral.teaching_town_or_city).to be_nil
+      end
+
+      it "sets the teaching_postcode to nil" do
+        expect(referral.teaching_postcode).to be_nil
+      end
+    end
+  end
+end

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -149,8 +149,31 @@ RSpec.feature "Teacher role", type: :system do
     when_i_choose_no
     when_i_click_save_and_continue
     then_i_see_the_check_answers_page
+    and_i_see_a_summary_list(
+      duties_description: "Main duties",
+      teaching_somewhere_else: "No"
+    )
 
     when_i_visit_the_teaching_somewhere_else_page
+    and_i_choose_yes
+    when_i_click_save_and_continue
+
+    # Do you know where they are teaching?
+
+    then_i_see_the_teaching_location_page
+
+    when_i_click_save_and_continue
+    then_i_see_teaching_location_field_validation_errors
+
+    when_i_choose_no
+    and_i_click_save_and_continue
+
+    when_i_visit_the_teaching_location_page
+    and_i_choose_yes
+    when_i_click_save_and_continue
+    then_i_see_teaching_location_address_field_validation_errors
+
+    when_i_fill_in_the_teaching_address_details
     and_i_choose_yes
     when_i_click_save_and_continue
 
@@ -161,6 +184,7 @@ RSpec.feature "Teacher role", type: :system do
       duties_description: "Main duties",
       teaching_somewhere_else: "Yes"
     )
+    and_i_see_a_summary_row_for_teaching_address
 
     when_i_click_save_and_continue
     then_i_see_a_completed_error
@@ -198,6 +222,10 @@ RSpec.feature "Teacher role", type: :system do
 
   def when_i_visit_the_teaching_somewhere_else_page
     visit referrals_edit_teacher_role_teaching_somewhere_else_path(@referral)
+  end
+
+  def when_i_visit_the_teaching_location_page
+    visit referrals_edit_teacher_role_teaching_location_path(@referral)
   end
 
   def when_i_visit_the_check_answers_page
@@ -264,6 +292,14 @@ RSpec.feature "Teacher role", type: :system do
     )
   end
 
+  def then_i_see_the_teaching_location_page
+    expect(page).to have_current_path(
+      "/referrals/#{@referral.id}/teacher-role/teaching-location"
+    )
+    expect(page).to have_title("Do you know where they are teaching?")
+    expect(page).to have_content("Do you know where they are teaching?")
+  end
+
   def then_i_see_the_check_answers_page
     expect(page).to have_current_path(
       "/referrals/#{@referral.id}/teacher-role/check-answers"
@@ -327,6 +363,13 @@ RSpec.feature "Teacher role", type: :system do
 
   def when_i_fill_in_the_duties_field
     fill_in "Describe their main duties", with: "Main duties"
+  end
+
+  def when_i_fill_in_the_teaching_address_details
+    fill_in "Organisation name", with: "High School"
+    fill_in "Address line 1", with: "1428 Elm Street"
+    fill_in "Town or city", with: "London"
+    fill_in "Postcode", with: "NW1 4NP"
   end
 
   # File uploads
@@ -403,6 +446,19 @@ RSpec.feature "Teacher role", type: :system do
     )
   end
 
+  def then_i_see_teaching_location_field_validation_errors
+    expect(page).to have_content("Tell us if you know where they are teaching")
+  end
+
+  def then_i_see_teaching_location_address_field_validation_errors
+    expect(page).to have_content("Tell us the name of their organisation")
+    expect(page).to have_content(
+      "Enter the first line of their organisation's address"
+    )
+    expect(page).to have_content("Enter a town or city for their organisation")
+    expect(page).to have_content("Enter a postcode for their organisation")
+  end
+
   def then_i_see_a_completed_error
     expect(page).to have_content("Tell us if you have completed this section")
   end
@@ -469,6 +525,18 @@ RSpec.feature "Teacher role", type: :system do
     )
   end
   alias_method :then_i_see_a_summary_list, :and_i_see_a_summary_list
+
+  def and_i_see_a_summary_row_for_teaching_address
+    expect_summary_row(
+      key: "Do you know where they are teaching?",
+      value: "High School\n1428 Elm Street\nLondon\nNW1 4NP",
+      change_link:
+        referrals_edit_teacher_role_teaching_location_path(
+          @referral,
+          return_to: current_url
+        )
+    )
+  end
 
   def then_i_see_the_status_section_in_the_referral_summary(status: "COMPLETED")
     expect_task_row(


### PR DESCRIPTION
### Context

The page gets displayed if the user selects yes to the previous question regarding teaching somewhere else.

<img width="692" alt="Screenshot 2022-12-09 at 09 21 57" src="https://user-images.githubusercontent.com/1636476/206668695-130891d6-3cd2-4de8-b364-ae675ac460fd.png">

### Changes proposed in this pull request

- Update the routes
- Generate a migration for adding the teaching location fields to the referrals table.
- Add the form, including validation
- Link the form to the teaching somewhere else question

### Link to Trello card

https://trello.com/c/Kd8VGpRT/1012-about-their-role-forms-teaching-location-page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
