### PR TITLE
Swap factorybot usage for User model when creating test users

### DIFF
--- a/app/controllers/support_interface/test_users_controller.rb
+++ b/app/controllers/support_interface/test_users_controller.rb
@@ -8,7 +8,7 @@ module SupportInterface
     end
 
     def create
-      user = FactoryBot.create(:user)
+      user = User.create!(email: "#{SecureRandom.hex(5)}@example.com")
       flash[:success] = "User #{user.email} created"
       redirect_to support_interface_test_users_path
     end


### PR DESCRIPTION
We currently use factorybot when creating a new test user. We don't have the factorybot gem available outside of dev or test groups so this fails on deployed environments. Rather than move it into the ungrouped set of gems for this one use case, this change swaps FactoryBot for direct interaction with the User model.
