### PR TITLE
Spike: simplify route declarations for employer form

### DIFF
--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -29,7 +29,7 @@ class PersonalDetailsComponent < ViewComponent::Base
           {
             text: "Change",
             href:
-              referrals_edit_personal_details_age_path(
+              edit_referral_personal_details_age_path(
                 referral,
                 return_to: request.url
               ),

--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -10,7 +10,7 @@ class PersonalDetailsComponent < ViewComponent::Base
           {
             text: "Change",
             href:
-              referrals_edit_personal_details_name_path(
+              edit_referral_personal_details_name_path(
                 referral,
                 return_to: request.url
               ),

--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -48,7 +48,7 @@ class PersonalDetailsComponent < ViewComponent::Base
           {
             text: "Change",
             href:
-              referrals_edit_personal_details_trn_path(
+              edit_referral_personal_details_trn_path(
                 referral,
                 return_to: request.url
               ),

--- a/app/controllers/referrals/personal_details/age_controller.rb
+++ b/app/controllers/referrals/personal_details/age_controller.rb
@@ -40,7 +40,7 @@ module Referrals
       end
 
       def next_path
-        referrals_edit_personal_details_trn_path(current_referral)
+        edit_referral_personal_details_trn_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/personal_details/name_controller.rb
+++ b/app/controllers/referrals/personal_details/name_controller.rb
@@ -34,7 +34,7 @@ module Referrals
       end
 
       def next_path
-        referrals_edit_personal_details_age_path(current_referral)
+        edit_referral_personal_details_age_path(current_referral)
       end
     end
   end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -56,7 +56,7 @@ class ReferralForm
       [
         ReferralSectionItem.new(
           I18n.t("referral_form.personal_details"),
-          referrals_edit_personal_details_name_path(referral),
+          edit_referral_personal_details_name_path(referral),
           section_status(:personal_details_complete)
         ),
         ReferralSectionItem.new(

--- a/app/views/referrals/personal_details/age/edit.html.erb
+++ b/app/views/referrals/personal_details/age/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">
-    <%= form_with model: @personal_details_age_form, url: referrals_update_personal_details_age_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @personal_details_age_form, url: referral_personal_details_age_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset(:age_known, legend: { size: "xl", text: "Do you know their date of birth?" }) do %>

--- a/app/views/referrals/personal_details/age/edit.html.erb
+++ b/app/views/referrals/personal_details/age/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_age_form.errors.any?}Do you know their date of birth?" %>
-<% content_for :back_link_url, return_to_session_or(referrals_edit_personal_details_name_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_personal_details_name_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/personal_details/name/edit.html.erb
+++ b/app/views/referrals/personal_details/name/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">
-    <%= form_with model: @personal_details_name_form, url: referrals_update_personal_details_name_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @personal_details_name_form, url: referral_personal_details_name_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">What is the name of the person you’re referring?</h1>
       <h2 class="govuk-heading-m">Why do we ask for personal information?</h2>

--- a/app/views/referrals/personal_details/qts/edit.html.erb
+++ b/app/views/referrals/personal_details/qts/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_qts_form.errors.any?}Do they have qualified teacher status (QTS)?" %>
-<% content_for :back_link_url, return_to_session_or(referrals_edit_personal_details_trn_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_personal_details_trn_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/personal_details/trn/edit.html.erb
+++ b/app/views/referrals/personal_details/trn/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_trn_form.errors.any?}Do you know their teacher reference number (TRN)?" %>
-<% content_for :back_link_url, return_to_session_or(referrals_edit_personal_details_age_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_personal_details_age_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/referrals/personal_details/trn/edit.html.erb
+++ b/app/views/referrals/personal_details/trn/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">
-    <%= form_with model: @personal_details_trn_form, url: referrals_update_personal_details_trn_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @personal_details_trn_form, url: referral_personal_details_trn_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,15 +125,15 @@ Rails.application.routes.draw do
              controller: "referrals/referrer_name"
 
     resource :review, only: %i[show], controller: "referrals/review"
+
+    scope module: "referrals" do
+      namespace :personal_details, path: "personal-details" do
+        resource :name, only: %i[edit update], controller: :name
+      end
+    end
   end
 
   namespace :referrals do
-    get "/:referral_id/personal-details/name",
-        to: "personal_details/name#edit",
-        as: "edit_personal_details_name"
-    put "/:referral_id/personal-details/name",
-        to: "personal_details/name#update",
-        as: "update_personal_details_name"
     get "/:referral_id/personal-details/age",
         to: "personal_details/age#edit",
         as: "edit_personal_details_age"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,17 +130,12 @@ Rails.application.routes.draw do
       namespace :personal_details, path: "personal-details" do
         resource :name, only: %i[edit update], controller: :name
         resource :age, only: %i[edit update], controller: :age
+        resource :trn, only: %i[edit update], controller: :trn
       end
     end
   end
 
   namespace :referrals do
-    get "/:referral_id/personal-details/trn",
-        to: "personal_details/trn#edit",
-        as: "edit_personal_details_trn"
-    put "/:referral_id/personal-details/trn",
-        to: "personal_details/trn#update",
-        as: "update_personal_details_trn"
     get "/:referral_id/personal-details/qts",
         to: "personal_details/qts#edit",
         as: "edit_personal_details_qts"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,17 +129,12 @@ Rails.application.routes.draw do
     scope module: "referrals" do
       namespace :personal_details, path: "personal-details" do
         resource :name, only: %i[edit update], controller: :name
+        resource :age, only: %i[edit update], controller: :age
       end
     end
   end
 
   namespace :referrals do
-    get "/:referral_id/personal-details/age",
-        to: "personal_details/age#edit",
-        as: "edit_personal_details_age"
-    put "/:referral_id/personal-details/age",
-        to: "personal_details/age#update",
-        as: "update_personal_details_age"
     get "/:referral_id/personal-details/trn",
         to: "personal_details/trn#edit",
         as: "edit_personal_details_trn"

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -153,7 +153,7 @@ RSpec.feature "Personal details", type: :system do
       key: "Name",
       value: "Jane Smith",
       change_link:
-        referrals_edit_personal_details_name_path(
+        edit_referral_personal_details_name_path(
           @referral,
           return_to: current_url
         )

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -173,7 +173,7 @@ RSpec.feature "Personal details", type: :system do
       key: "Teacher reference number (TRN)",
       value: "9912345",
       change_link:
-        referrals_edit_personal_details_trn_path(
+        edit_referral_personal_details_trn_path(
           @referral,
           return_to: current_url
         )

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -163,7 +163,7 @@ RSpec.feature "Personal details", type: :system do
       key: "Date of birth",
       value: "17 January 1990",
       change_link:
-        referrals_edit_personal_details_age_path(
+        edit_referral_personal_details_age_path(
           @referral,
           return_to: current_url
         )


### PR DESCRIPTION
### Context

We have a fairly well established pattern for how our routes/controllers are structured for the employer form. This is probably a good time to refactor the route declarations so they're more condensed and easier to scan. 

This also potentially has implications for how we structure the public form work. If we go down the path of entirely separate routes/controllers for the second form, it'll be important to keep the `routes.rb` manageable.


<!-- Why are you making this change? -->

### Changes proposed in this pull request
Use other routing methods to define nearly the same resources.

For each section:
- Controller names are unchanged
- Path helpers for edit/update change slightly
- The URL for the edit page has `/edit` appended

I've applied this change to a subset of routes to illustrate the idea. If the consensus is 👍🏼 then I'll apply to the remaining ~140 lines worth of referral routes.


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
