### PR TITLE
Reword maximum file upload error message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -296,7 +296,7 @@ en:
               invalid_content_type: Please upload files of valid type (%{valid_types})
               mismatch_content_type: File type does not match file contents
               file_size_too_big: Maximum file size is %{max_file_size}
-              file_count: No more than %{max_files} files can be uploaded
+              file_count: You can only upload %{max_files} files in total
         "referrals/evidence/categories_form":
           attributes:
             categories:


### PR DESCRIPTION
### Context

This was suggested as part of design review.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Reword max files error message...

![image](https://user-images.githubusercontent.com/93511/207043248-ea66f012-7df5-4fb0-afb6-a3ce8777a4a7.png)

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/UzBWH3Mh/1020-limit-number-of-referral-evidence-files-in-upload
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
