### PR TITLE
Speed up deployment

### DIFF
--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -117,10 +117,11 @@ runs:
           make ci ${{ inputs.environment_name }} terraform-apply
         fi
         cd terraform
-        OUTPUTS=($(terraform output --json | jq -r 'keys | @sh' | tr -d \'))
+        TFOUTPUTS=$(terraform output --json)
+        OUTPUTS=($(jq -r <<< "$TFOUTPUTS" | jq -r 'keys | @sh' | tr -d \'))
         for o in "${OUTPUTS[@]}"
         do
-          echo "${o}=$(terraform output -raw ${o})" >> $GITHUB_ENV
+          echo ${o}=$(jq -r .${o}.value <<< "$TFOUTPUTS") >> $GITHUB_ENV
         done
         echo "app_fqdn=$(terraform output -raw app_fqdn)" >>$GITHUB_OUTPUT
       env:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -66,16 +66,17 @@ jobs:
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           url: ${{ steps.deploy.outputs.environment_url }}
 
-  deploy:
+  deploy_non_prod:
     name: Deploy to ${{ matrix.environment }} environment
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     concurrency: deploy_${{ matrix.environment }}
     needs: [build_image]
     strategy:
-      max-parallel: 1
+      fail-fast: false # this is necessary to prevent early terminiation of terraform deployments that will result in tfstate locks
+      max-parallel: 3
       matrix:
-        environment: [dev, test, preprod, production]
+        environment: [dev, test, preprod]
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy.outputs.environment_url }}
@@ -92,9 +93,29 @@ jobs:
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
 
       - uses: ./.github/actions/smoke-test
-        if: ${{ matrix.environment }} != 'production'
         id: smoke-test
         with:
           environment: ${{ matrix.environment }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           url: ${{ steps.deploy.outputs.environment_url }}
+
+  deploy_prod:
+    name: Deploy to production environment
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency: deploy_prod
+    needs: [build_image, deploy_non_prod]
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.environment_url }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/deploy-environment
+        id: deploy
+        with:
+          environment_name: production
+          image_name_tag: ${{ needs.build_image.outputs.image_name_tag }}
+          image_tag: ${{ github.sha }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -3,8 +3,6 @@
   "key_vault_name": "s165d01-rsm-dv-kv",
   "resource_group_name": "s165d01-rsm-dv-rg",
   "storage_account_name": "s165d01rsmtfstatedv",
-  "enable_blue_green": true,
-  "app_service_plan_sku": "S1",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
   "resource_prefix": "s165d01-rsm",

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -3,8 +3,6 @@
   "key_vault_name": "s165t01-rsm-ts-kv",
   "resource_group_name": "s165t01-rsm-ts-rg",
   "storage_account_name": "s165t01rsmtfstatets",
-  "enable_blue_green": true,
-  "app_service_plan_sku": "S1",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
   "resource_prefix": "s165t01-rsm",


### PR DESCRIPTION
### Context

Individual environments take between 7 and 12 minutes to deploy, as they are deployed sequentially this means it can take over 45 minutes to deploy to production.  This makes it difficult to quickly fix production issues.

### Changes proposed in this pull request

- remove blue \ green deployments before preprod
- deploy environments up to preprod in parallel
- refactor terraform output script

### Guidance to review

- Non-review environments are only deployed from master, a test run overrode the conditions to test deployment in parallel.  The logs can be seen [here](https://github.com/DFE-Digital/refer-serious-misconduct/actions/runs/3702644220).

### Link to Trello card

https://trello.com/c/6lvJQmOT

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running manually
