### PR TITLE
Limit log size to 50Mb

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,4 +76,8 @@ Rails.application.configure do
           end
         end
     )
+
+  # Limit logs to 50MB
+  config.logger =
+    ActiveSupport::Logger.new(config.paths["log"].first, 1, 50.megabytes)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,8 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_options = { from: "mail@example.com" }
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+
+  # Limit logs to 50MB
+  config.logger =
+    ActiveSupport::Logger.new(config.paths["log"].first, 1, 50.megabytes)
 end


### PR DESCRIPTION
### Context

There is no reason to keep development and test logs and they end up taking Gbs in size.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
