### PR TITLE
Export `HOSTING_ENVIRONMENT_NAME` to smoke test env

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -39,6 +39,7 @@ runs:
     - run: bin/smoke
       env:
         HOSTING_DOMAIN: ${{ inputs.url }}
+        HOSTING_ENVIRONMENT_NAME: ${{ inputs.environment }}
         GOVUK_NOTIFY_API_KEY: ${{ steps.keyvault-yaml-secret.outputs.GOVUK_NOTIFY_API_KEY }}
         SUPPORT_USERNAME: ${{ steps.keyvault-yaml-secret.outputs.SUPPORT_USERNAME }}
         SUPPORT_PASSWORD: ${{ steps.keyvault-yaml-secret.outputs.SUPPORT_PASSWORD }}


### PR DESCRIPTION
### Context

Smoke tests rely on the hosting environment name but this is not correctly exported to the smoke test env.
See https://github.com/DFE-Digital/refer-serious-misconduct/actions/runs/3684612060/jobs/6234610945
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Export `HOSTING_ENVIRONMENT_NAME` to smoke test env.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

Is `${{ inputs.environment }}` the correct value? [This](https://github.com/DFE-Digital/refer-serious-misconduct/blob/main/.github/workflows/build-and-deploy.yml#L97) implies it is.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
