### PR TITLE
Add data migration to remove Referrals without eligibility checks

### DIFF
--- a/db/migrate/20221213105907_remove_referrals_without_eligibility_checks.rb
+++ b/db/migrate/20221213105907_remove_referrals_without_eligibility_checks.rb
@@ -1,0 +1,5 @@
+class RemoveReferralsWithoutEligibilityChecks < ActiveRecord::Migration[7.0]
+  def change
+    Referral.where(eligibility_check_id: nil).destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -120,10 +120,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_13_163958) do
     t.date "role_start_date"
     t.datetime "previous_misconduct_completed_at", precision: nil
     t.datetime "previous_misconduct_deferred_at", precision: nil
+    t.string "previous_misconduct_reported"
     t.string "employment_status"
     t.date "role_end_date"
     t.string "reason_leaving_role"
-    t.string "previous_misconduct_reported"
     t.string "job_title"
     t.boolean "same_organisation"
     t.text "previous_misconduct_details"
@@ -132,8 +132,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_13_163958) do
     t.string "duties_details"
     t.boolean "teacher_role_complete"
     t.datetime "submitted_at", precision: nil
-    t.string "teaching_somewhere_else"
     t.bigint "eligibility_check_id"
+    t.string "teaching_somewhere_else"
     t.boolean "teaching_location_known"
     t.string "teaching_organisation_name"
     t.string "teaching_address_line_1"


### PR DESCRIPTION

### Context
We've recently reworked the flow through the system such that completing the eligibility screener results in the creation of the referral, with an association set up between the two. The association is mandatory by virtue of the belongs_to that sits on the Referral model.

A side effect of this change is that existing referrals in the various environments will trigger a validation error when we attempt any kind of save.

<!-- Why are you making this change? -->

### Changes proposed in this pull request
As we haven't gone live yet, a simple way to fix this is to delete old referrals without associated eligibility check records.


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
It's a bit of a nuclear option, so I'll announce on the team channel before merging.

OK to run this on all environments?
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/Lw592I72
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
