### PR TITLE
Rename employer form feature flag

### DIFF
--- a/app/controllers/concerns/authenticate_user.rb
+++ b/app/controllers/concerns/authenticate_user.rb
@@ -4,6 +4,6 @@ module AuthenticateUser
 
   included do
     before_action :authenticate_user!,
-                  if: -> { FeatureFlags::FeatureFlag.active?(:employer_form) }
+                  if: -> { FeatureFlags::FeatureFlag.active?(:referral_form) }
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,7 @@
 class PagesController < ApplicationController
   def start
     @start_now_path =
-      if FeatureFlags::FeatureFlag.active?(:employer_form)
+      if FeatureFlags::FeatureFlag.active?(:referral_form)
         current_user ? who_path : new_user_session_path
       else
         who_path
@@ -10,7 +10,7 @@ class PagesController < ApplicationController
 
   def you_should_know
     @continue_path =
-      if FeatureFlags::FeatureFlag.active?(:employer_form)
+      if FeatureFlags::FeatureFlag.active?(:referral_form)
         new_referral_path
       else
         complete_path

--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -4,7 +4,7 @@ module Referrals
     include StoreUserLocation
     include RedirectIfFeatureFlagInactive
 
-    before_action { redirect_if_feature_flag_inactive(:employer_form) }
+    before_action { redirect_if_feature_flag_inactive(:referral_form) }
     before_action :set_return_to_url, only: :edit
 
     def edit

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -1,5 +1,5 @@
 class ReferralsController < Referrals::BaseController
-  before_action :check_employer_form_feature_flag_enabled
+  before_action :check_referral_form_feature_flag_enabled
   before_action :redirect_to_referral_if_exists, only: %i[new create]
   before_action :redirect_to_screener_if_no_id_in_session, only: %i[new create]
 
@@ -57,8 +57,8 @@ class ReferralsController < Referrals::BaseController
   end
   helper_method :referral
 
-  def check_employer_form_feature_flag_enabled
-    unless FeatureFlags::FeatureFlag.active?(:employer_form)
+  def check_referral_form_feature_flag_enabled
+    unless FeatureFlags::FeatureFlag.active?(:referral_form)
       redirect_to start_path
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -63,7 +63,7 @@ module ApplicationHelper
           )
         end
       else
-        if FeatureFlags::FeatureFlag.active?(:employer_form)
+        if FeatureFlags::FeatureFlag.active?(:referral_form)
           if current_user
             header.navigation_item(
               href: main_app.users_sign_out_path,

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -13,9 +13,9 @@ feature_flags:
     description: When enabled, the eligibility screener will be shown to
       candidates. When disabled, redirect the visitor to the existing eligibility
       information page on GOV.UK.
-  employer_form:
+  referral_form:
     author: Steve Laing
-    description: Allow users to access the employer-specific form.
+    description: Allow users to access the employer and public facing referral form.
   staff_http_basic_auth:
     author: Malcolm Baig
     description: Allow signing in as a staff user using HTTP Basic

--- a/db/migrate/20221213163958_rename_employer_form_feature_flag.rb
+++ b/db/migrate/20221213163958_rename_employer_form_feature_flag.rb
@@ -1,0 +1,6 @@
+class RenameEmployerFormFeatureFlag < ActiveRecord::Migration[7.0]
+  def change
+    flag = FeatureFlags::Feature.find_by(name: "employer_form")
+    flag.update!(name: "referral_form") if flag
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_09_152155) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_13_163958) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -120,10 +120,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_09_152155) do
     t.date "role_start_date"
     t.datetime "previous_misconduct_completed_at", precision: nil
     t.datetime "previous_misconduct_deferred_at", precision: nil
-    t.string "previous_misconduct_reported"
     t.string "employment_status"
     t.date "role_end_date"
     t.string "reason_leaving_role"
+    t.string "previous_misconduct_reported"
     t.string "job_title"
     t.boolean "same_organisation"
     t.text "previous_misconduct_details"
@@ -133,13 +133,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_09_152155) do
     t.boolean "teacher_role_complete"
     t.datetime "submitted_at", precision: nil
     t.string "teaching_somewhere_else"
+    t.bigint "eligibility_check_id"
     t.boolean "teaching_location_known"
     t.string "teaching_organisation_name"
     t.string "teaching_address_line_1"
     t.string "teaching_address_line_2"
     t.string "teaching_town_or_city"
     t.string "teaching_postcode"
-    t.bigint "eligibility_check_id"
     t.index ["eligibility_check_id"], name: "index_referrals_on_eligibility_check_id"
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -8,8 +8,8 @@ module CommonSteps
     sign_in(@user)
   end
 
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
+  def and_the_referral_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:referral_form)
   end
 
   def and_the_eligibility_screener_feature_is_active

--- a/spec/system/referrals/user_adds_an_allegation_spec.rb
+++ b/spec/system/referrals/user_adds_an_allegation_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Allegation", type: :system do
   scenario "User adds an allegation to a referral" do
     given_the_service_is_open
     and_i_am_signed_in
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_i_have_an_existing_referral
     and_i_visit_the_referral
     then_i_see_the_referral_summary

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Contact details", type: :system do
   scenario "User submits contact details for the referred person" do
     given_the_service_is_open
     and_i_am_signed_in
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_i_have_an_existing_referral
     when_i_visit_the_referral
     then_i_see_the_status_section_in_the_referral_summary(

--- a/spec/system/referrals/user_adds_evidence_spec.rb
+++ b/spec/system/referrals/user_adds_evidence_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Evidence", type: :system do
   scenario "User adds evidence to a referral" do
     given_the_service_is_open
     and_i_am_signed_in
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_i_have_an_existing_referral
     and_i_visit_the_referral
     then_i_see_the_referral_summary

--- a/spec/system/referrals/user_adds_organisation_details_spec.rb
+++ b/spec/system/referrals/user_adds_organisation_details_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
   scenario "User provides the organisation details" do
     given_the_service_is_open
     and_i_am_signed_in
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_i_have_an_existing_referral
     and_i_visit_the_referral
     when_i_click_on_your_organisation

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Personal details", type: :system do
   scenario "User adds personal details to a referral" do
     given_the_service_is_open
     and_i_am_signed_in
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_i_have_an_existing_referral
     and_i_visit_the_referral
     then_i_see_the_referral_summary

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
   scenario "User provides details of previous misconduct" do
     given_the_service_is_open
     and_i_am_signed_in
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_i_have_an_existing_referral
     and_i_visit_the_referral
     when_i_click_on_previous_misconduct

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Teacher role", type: :system do
   scenario "User adds teacher role details to a referral" do
     given_the_service_is_open
     and_i_am_signed_in
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_i_have_an_existing_referral
     and_i_visit_the_referral
     then_i_see_the_referral_summary

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
   scenario "User provides their details" do
     given_the_service_is_open
     and_i_am_signed_in
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_i_have_an_existing_referral
     and_i_visit_the_referral
     when_i_click_on_your_details

--- a/spec/system/referrals/user_deletes_a_draft_referral_spec.rb
+++ b/spec/system/referrals/user_deletes_a_draft_referral_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "User deletes a draft referral", type: :system do
   scenario "User deletes a draft referral" do
     given_the_service_is_open
     and_i_am_signed_in
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
 
     when_i_make_a_new_referral
     and_i_dont_want_to_continue

--- a/spec/system/referrals/user_submits_referral_spec.rb
+++ b/spec/system/referrals/user_submits_referral_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "User submits a referral", type: :system do
   scenario "happy path" do
     given_the_service_is_open
     and_i_am_signed_in
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_i_have_an_incomplete_referral
     when_i_visit_the_referral
     and_i_click_review_and_send

--- a/spec/system/referrals/user_views_a_referral_summary_spec.rb
+++ b/spec/system/referrals/user_views_a_referral_summary_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "User views an existing referral summary", type: :system do
   scenario "Views referral summary sections" do
     given_the_service_is_open
     and_i_am_signed_in
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_i_have_an_existing_referral
     when_i_visit_the_referral
     then_i_see_the_referral_as_sections

--- a/spec/system/referrals/user_views_a_referral_when_employer_form_feature_is_inactive_spec.rb
+++ b/spec/system/referrals/user_views_a_referral_when_employer_form_feature_is_inactive_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Employer form inactive, user views a referral summary",
   scenario "User views referral summary" do
     given_the_service_is_open
     and_the_eligibility_screener_feature_is_active
-    and_the_employer_form_feature_is_inactive
+    and_the_referral_form_feature_is_inactive
     and_there_is_an_existing_referral
     when_i_visit_the_referral
     then_i_am_redirected_to_the_start_page
@@ -20,8 +20,8 @@ RSpec.feature "Employer form inactive, user views a referral summary",
     @referral = create(:referral, user: create(:user))
   end
 
-  def and_the_employer_form_feature_is_inactive
-    FeatureFlags::FeatureFlag.deactivate(:employer_form)
+  def and_the_referral_form_feature_is_inactive
+    FeatureFlags::FeatureFlag.deactivate(:referral_form)
   end
 
   def then_i_am_redirected_to_the_start_page

--- a/spec/system/screener/question_order_spec.rb
+++ b/spec/system/screener/question_order_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Question order", type: :system do
   scenario "is enforced correctly" do
     given_the_service_is_open
     and_the_eligibility_screener_feature_is_active
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_i_am_signed_in
     when_i_visit_the_service
     then_i_see_the_start_page

--- a/spec/system/screener/user_completes_eligibility_screener_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Eligibility screener", type: :system do
   scenario "User completes eligibility screener" do
     given_the_service_is_open
     and_the_eligibility_screener_feature_is_active
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_i_am_signed_in
     when_i_visit_the_service
     then_i_see_the_start_page

--- a/spec/system/screener/user_completes_eligibility_screener_with_inactive_employer_form_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_with_inactive_employer_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Eligibility screener", type: :system do
   scenario "User completes eligibility screener, inactive employer form" do
     given_the_service_is_open
     and_the_eligibility_screener_feature_is_active
-    and_the_employer_form_feature_is_inactive
+    and_the_referral_form_feature_is_inactive
     when_i_visit_the_service
     then_i_see_the_start_page
 
@@ -15,8 +15,8 @@ RSpec.feature "Eligibility screener", type: :system do
     then_i_see_links_to_the_referral_form_documents
   end
 
-  def and_the_employer_form_feature_is_inactive
-    FeatureFlags::FeatureFlag.deactivate(:employer_form)
+  def and_the_referral_form_feature_is_inactive
+    FeatureFlags::FeatureFlag.deactivate(:referral_form)
   end
 
   def when_i_visit_the_service

--- a/spec/system/support/staff_user_signs_in_as_user_spec.rb
+++ b/spec/system/support/staff_user_signs_in_as_user_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Test users" do
 
   scenario "Staff user signs in as user" do
     given_the_service_is_open
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
     and_the_eligibility_screener_feature_is_active
     and_staff_http_basic_is_active
     when_i_am_authorized_as_a_staff_user

--- a/spec/system/user_auth/user_reaches_max_otp_guesses_spec.rb
+++ b/spec/system/user_auth/user_reaches_max_otp_guesses_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "User accounts" do
   scenario "User signs in" do
     given_the_service_is_open
     and_the_eligibility_screener_is_enabled
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
 
     when_i_start_the_signin_flow
     and_max_out_my_otp_guesses
@@ -22,8 +22,8 @@ RSpec.feature "User accounts" do
     FeatureFlags::FeatureFlag.activate(:eligibility_screener)
   end
 
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
+  def and_the_referral_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:referral_form)
   end
 
   def when_i_start_the_signin_flow

--- a/spec/system/user_auth/user_signs_in_spec.rb
+++ b/spec/system/user_auth/user_signs_in_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "User accounts" do
   scenario "User signs in" do
     given_the_service_is_open
     and_the_eligibility_screener_is_enabled
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
 
     when_i_visit_the_root_page
     and_click_start_now
@@ -41,8 +41,8 @@ RSpec.feature "User accounts" do
     FeatureFlags::FeatureFlag.activate(:eligibility_screener)
   end
 
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
+  def and_the_referral_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:referral_form)
   end
 
   def when_i_visit_the_root_page

--- a/spec/system/user_auth/user_tries_signing_in_with_expired_otp_spec.rb
+++ b/spec/system/user_auth/user_tries_signing_in_with_expired_otp_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "User accounts" do
   scenario "User signs in" do
     given_the_service_is_open
     and_the_eligibility_screener_is_enabled
-    and_the_employer_form_feature_is_active
+    and_the_referral_form_feature_is_active
 
     when_i_start_the_signin_flow
     and_my_otp_has_expired
@@ -25,8 +25,8 @@ RSpec.feature "User accounts" do
     FeatureFlags::FeatureFlag.activate(:eligibility_screener)
   end
 
-  def and_the_employer_form_feature_is_active
-    FeatureFlags::FeatureFlag.activate(:employer_form)
+  def and_the_referral_form_feature_is_active
+    FeatureFlags::FeatureFlag.activate(:referral_form)
   end
 
   def when_i_start_the_signin_flow


### PR DESCRIPTION
### Context

We will be using the same feature flag for employer and public facing forms.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Renames `employer_form` feature flag to `referral_form` including any references in codebase.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
