### PR TITLE
Reduced resource requirements for ACI worker app

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -196,8 +196,8 @@ resource "azurerm_container_group" "rsm-worker" {
     name  = local.rsm_worker_app_name
     image = var.rsm_docker_image
 
-    cpu    = "1"
-    memory = "1.5"
+    cpu    = "0.5"
+    memory = "0.5"
 
     environment_variables = local.rsm_env_vars
 


### PR DESCRIPTION
### Context

The Azure Container Instance that runs the sidekiq worker app typically uses 200MB RAM and 2% CPU (bursting to 200% ~1 p/day).  The higher the resource demands the more likely that the Azure region we are deploying into won't be able to satisfy that requirement.  As we need to recreate the Container Instance resource with each deployment that will block deployments even when there are no code changes associated with sidekiq.

#### Production Container Instance metrics from last 7 days

![image](https://user-images.githubusercontent.com/34914709/207639611-cba0e0ff-81cc-4103-b4c0-132af4564aae.png)

### Changes proposed in this pull request

Reducing resource demand increases reliability of deployment but may cause sidekiq jobs to run slower.  The infrequency of high resource demands should mean this has limited to no impact on users.

### Guidance to review

- Simulate a job in the review app, the job that creates high CPU demand would be most useful
- Based on your understanding of the app is resource demand likely to increase, ie will sidekiq do more CPU or memory intensive jobs in the future?

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
