### PR TITLE
Update "About their role" section

### DIFF
--- a/app/components/their_role_component.rb
+++ b/app/components/their_role_component.rb
@@ -7,159 +7,375 @@ class TheirRoleComponent < ViewComponent::Base
 
   def rows
     @rows = [
-      {
-        actions: [
-          {
-            text: "Change",
-            href:
-              edit_referral_teacher_role_start_date_path(
-                referral,
-                return_to: request.url
-              ),
-            visually_hidden_text: "start date"
-          }
-        ],
-        key: {
-          text: "Job start date"
-        },
-        value: {
-          text:
-            (
-              if referral.role_start_date_known
-                referral.role_start_date&.to_fs(:long_ordinal_uk)
-              else
-                "Not known"
-              end
-            )
-        }
-      },
-      {
-        actions: [
-          {
-            text: "Change",
-            href:
-              edit_referral_teacher_role_employment_status_path(
-                referral,
-                return_to: request.url
-              ),
-            visually_hidden_text: "employment status"
-          }
-        ],
-        key: {
-          text: "Are they still employed in that job?"
-        },
-        value: {
-          text:
-            (
-              if referral.employment_status
-                referral.employment_status.humanize
-              else
-                "Not known"
-              end
-            )
-        }
-      },
-      {
-        actions: [
-          {
-            text: "Change",
-            href:
-              edit_referral_teacher_role_job_title_path(
-                referral,
-                return_to: request.url
-              ),
-            visually_hidden_text: "job title"
-          }
-        ],
-        key: {
-          text: "Job title"
-        },
-        value: {
-          text: referral.job_title || "Not known"
-        }
-      },
-      {
-        actions: [
-          {
-            text: "Change",
-            href:
-              edit_referral_teacher_role_same_organisation_path(
-                referral,
-                return_to: request.url
-              ),
-            visually_hidden_text: "working in the same organisation"
-          }
-        ],
-        key: {
-          text: "Do they work in the same organisation as you?"
-        },
-        value: {
-          text: referral.same_organisation ? "Yes" : "No"
-        }
-      },
-      {
-        actions: [
-          {
-            text: "Change",
-            href:
-              edit_referral_teacher_role_duties_path(
-                referral,
-                return_to: request.url
-              ),
-            visually_hidden_text: "main duties"
-          }
-        ],
-        key: {
-          text: "About their main duties"
-        },
-        value: {
-          text: duties_details(referral)
-        }
-      },
-      {
-        actions: [
-          {
-            text: "Change",
-            href:
-              edit_referral_teacher_role_teaching_somewhere_else_path(
-                referral,
-                return_to: request.url
-              ),
-            visually_hidden_text: "teaching somewhere else"
-          }
-        ],
-        key: {
-          text: "Do they teach somewhere else?"
-        },
-        value: {
-          text: referral.teaching_somewhere_else&.humanize
-        }
-      }
+      job_title_row,
+      role_duties_row,
+      role_duties_description_row,
+      same_organisation_row
     ]
 
-    if referral.teaching_somewhere_else?
-      @rows << {
-        actions: [
-          {
-            text: "Change",
-            href:
-              edit_referral_teacher_role_teaching_location_path(
-                referral,
-                return_to: request.url
-              ),
-            visually_hidden_text: "teaching location"
-          }
-        ],
-        key: {
-          text: "Do you know where they are teaching?"
-        },
-        value: {
-          text:
-            referral.teaching_location_known ? teaching_address(referral) : "No"
-        }
-      }
+    unless referral.same_organisation?
+      @rows << organisation_address_known_row
+      @rows << organisation_address_row
     end
 
-    @rows
+    @rows << start_date_known_row
+    @rows << start_date_row if referral.role_start_date_known
+    @rows << employment_status_row
+
+    return @rows unless referral.left_role?
+
+    @rows << end_date_known_row
+    @rows << end_date_row if referral.role_end_date_known
+    @rows << reason_leaving_role_row
+    @rows << teaching_somewhere_else_row
+
+    return @rows unless referral.teaching_somewhere_else?
+
+    @rows << teaching_location_known_row
+
+    return @rows unless referral.teaching_location_known
+
+    @rows << teaching_location_row
+  end
+
+  private
+
+  def job_title_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_job_title_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text: "their job title"
+        }
+      ],
+      key: {
+        text: "Their job title"
+      },
+      value: {
+        text: referral.job_title || "Not known"
+      }
+    }
+  end
+
+  def role_duties_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_duties_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text:
+            "how do you want to give details about their main duties"
+        }
+      ],
+      key: {
+        text: "How do you want to give details about their main duties?"
+      },
+      value: {
+        text: duties_format(referral)
+      }
+    }
+  end
+
+  def role_duties_description_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_duties_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text: "the description of their role"
+        }
+      ],
+      key: {
+        text: "Description of their role"
+      },
+      value: {
+        text: duties_details(referral)
+      }
+    }
+  end
+
+  def same_organisation_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_same_organisation_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text: "working in the same organisation"
+        }
+      ],
+      key: {
+        text:
+          "Did they work at the same organisation as you at the time of the alleged misconduct?"
+      },
+      value: {
+        text: referral.same_organisation ? "Yes" : "No"
+      }
+    }
+  end
+
+  def organisation_address_known_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_organisation_address_known_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text:
+            "if you know the name and address of the organisation where the alleged misconduct took place"
+        }
+      ],
+      key: {
+        text:
+          "Do you know the name and address of the organisation where the alleged misconduct took place?"
+      },
+      value: {
+        text: referral.organisation_address_known ? "Yes" : "No"
+      }
+    }
+  end
+
+  def organisation_address_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_organisation_address_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text:
+            "where they were employed at the time of the alleged misconduct"
+        }
+      ],
+      key: {
+        text: "Where they were employed at the time of the alleged misconduct"
+      },
+      value: {
+        text: referral_organisation_address(referral)
+      }
+    }
+  end
+
+  def start_date_known_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_start_date_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text: "if you know when they started their job"
+        }
+      ],
+      key: {
+        text: "Do you know when they started their job?"
+      },
+      value: {
+        text: referral.role_start_date_known ? "Yes" : "No"
+      }
+    }
+  end
+
+  def start_date_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_start_date_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text: "their job start date"
+        }
+      ],
+      key: {
+        text: "Job start date"
+      },
+      value: {
+        text: referral.role_start_date&.to_fs(:long_ordinal_uk)
+      }
+    }
+  end
+
+  def employment_status_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_employment_status_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text:
+            "if they are still employed in the job where the alleged misconduct took place"
+        }
+      ],
+      key: {
+        text:
+          "Are they still employed in the job where the alleged misconduct took place?"
+      },
+      value: {
+        text: employment_status(referral)
+      }
+    }
+  end
+
+  def end_date_known_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_end_date_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text: "if you know when they left the job"
+        }
+      ],
+      key: {
+        text: "Do you know when they left the job?"
+      },
+      value: {
+        text: referral.role_end_date_known ? "Yes" : "No"
+      }
+    }
+  end
+
+  def end_date_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_end_date_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text: "their job end date"
+        }
+      ],
+      key: {
+        text: "Job end date"
+      },
+      value: {
+        text: referral.role_end_date&.to_fs(:long_ordinal_uk)
+      }
+    }
+  end
+
+  def reason_leaving_role_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_reason_leaving_role_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text: "the reason they left the job"
+        }
+      ],
+      key: {
+        text: "Reason they left the job"
+      },
+      value: {
+        text: referral.reason_leaving_role&.humanize
+      }
+    }
+  end
+
+  def teaching_somewhere_else_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_teaching_somewhere_else_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text: "if they are they employed somewhere else"
+        }
+      ],
+      key: {
+        text: "Are they employed somewhere else?"
+      },
+      value: {
+        text: referral.teaching_somewhere_else&.humanize
+      }
+    }
+  end
+
+  def teaching_location_known_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_teaching_location_known_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text:
+            "if you know the name and address of the organisation where they’re currently working"
+        }
+      ],
+      key: {
+        text:
+          "Do you know the name and address of the organisation where they’re currently working?"
+      },
+      value: {
+        text: referral.teaching_location_known ? "Yes" : "No"
+      }
+    }
+  end
+
+  def teaching_location_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            edit_referral_teacher_role_teaching_location_path(
+              referral,
+              return_to: request.url
+            ),
+          visually_hidden_text: "where they currently work"
+        }
+      ],
+      key: {
+        text: "Where they currently work"
+      },
+      value: {
+        text: teaching_address(referral)
+      }
+    }
   end
 end

--- a/app/controllers/referrals/teacher_role/duties_controller.rb
+++ b/app/controllers/referrals/teacher_role/duties_controller.rb
@@ -32,9 +32,7 @@ module Referrals
       end
 
       def next_path
-        edit_referral_teacher_role_teaching_somewhere_else_path(
-          current_referral
-        )
+        edit_referral_teacher_role_same_organisation_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/teacher_role/employment_status_controller.rb
+++ b/app/controllers/referrals/teacher_role/employment_status_controller.rb
@@ -4,19 +4,14 @@ module Referrals
       def edit
         @employment_status_form =
           EmploymentStatusForm.new(
-            employment_status: current_referral.employment_status,
-            role_end_date: current_referral.role_end_date,
-            reason_leaving_role: current_referral.reason_leaving_role
+            employment_status: current_referral.employment_status
           )
       end
 
       def update
         @employment_status_form =
           EmploymentStatusForm.new(
-            employment_status_params.merge(
-              date_params: end_date_params,
-              referral: current_referral
-            )
+            employment_status_params.merge(referral: current_referral)
           )
 
         if @employment_status_form.save
@@ -30,21 +25,25 @@ module Referrals
 
       def employment_status_params
         params.require(:referrals_teacher_role_employment_status_form).permit(
-          :employment_status,
-          :reason_leaving_role
-        )
-      end
-
-      def end_date_params
-        params.require(:referrals_teacher_role_employment_status_form).permit(
-          "role_end_date(3i)",
-          "role_end_date(2i)",
-          "role_end_date(1i)"
+          :employment_status
         )
       end
 
       def next_path
-        edit_referral_teacher_role_job_title_path(current_referral)
+        if current_referral.left_role?
+          edit_referral_teacher_role_end_date_path(current_referral)
+        else
+          edit_referral_teacher_role_check_answers_path(current_referral)
+        end
+      end
+
+      def next_page
+        if @employment_status_form.referral.saved_changes? &&
+             current_referral.left_role?
+          return next_path
+        end
+
+        super
       end
     end
   end

--- a/app/controllers/referrals/teacher_role/end_date_controller.rb
+++ b/app/controllers/referrals/teacher_role/end_date_controller.rb
@@ -1,0 +1,53 @@
+module Referrals
+  module TeacherRole
+    class EndDateController < Referrals::BaseController
+      def edit
+        @role_end_date_form =
+          EndDateForm.new(
+            role_end_date_known: current_referral.role_end_date_known,
+            role_end_date: current_referral.role_end_date
+          )
+      end
+
+      def update
+        @role_end_date_form =
+          EndDateForm.new(
+            role_params.merge(
+              date_params: end_date_params,
+              referral: current_referral
+            )
+          )
+
+        if @role_end_date_form.save
+          redirect_to next_page
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def role_params
+        params.require(:referrals_teacher_role_end_date_form).permit(
+          :role_end_date_known
+        )
+      end
+
+      def end_date_params
+        params.require(:referrals_teacher_role_end_date_form).permit(
+          "role_end_date(3i)",
+          "role_end_date(2i)",
+          "role_end_date(1i)"
+        )
+      end
+
+      def next_path
+        if current_referral.left_role?
+          edit_referral_teacher_role_reason_leaving_role_path(current_referral)
+        else
+          edit_referral_teacher_role_check_answers_path(current_referral)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/referrals/teacher_role/job_title_controller.rb
+++ b/app/controllers/referrals/teacher_role/job_title_controller.rb
@@ -26,7 +26,7 @@ module Referrals
       end
 
       def next_path
-        edit_referral_teacher_role_same_organisation_path(current_referral)
+        edit_referral_teacher_role_duties_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/teacher_role/organisation_address_controller.rb
+++ b/app/controllers/referrals/teacher_role/organisation_address_controller.rb
@@ -1,0 +1,50 @@
+module Referrals
+  module TeacherRole
+    class OrganisationAddressController < Referrals::BaseController
+      def edit
+        @organisation_address_form =
+          OrganisationAddressForm.new(
+            organisation_name: current_referral.organisation_name,
+            organisation_address_line_1:
+              current_referral.organisation_address_line_1,
+            organisation_address_line_2:
+              current_referral.organisation_address_line_2,
+            organisation_town_or_city:
+              current_referral.organisation_town_or_city,
+            organisation_postcode: current_referral.organisation_postcode
+          )
+      end
+
+      def update
+        @organisation_address_form =
+          OrganisationAddressForm.new(
+            organisation_address_params.merge(referral: current_referral)
+          )
+
+        if @organisation_address_form.save
+          redirect_to next_page
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def organisation_address_params
+        params.require(
+          :referrals_teacher_role_organisation_address_form
+        ).permit(
+          :organisation_name,
+          :organisation_address_line_1,
+          :organisation_address_line_2,
+          :organisation_town_or_city,
+          :organisation_postcode
+        )
+      end
+
+      def next_path
+        edit_referral_teacher_role_start_date_path(current_referral)
+      end
+    end
+  end
+end

--- a/app/controllers/referrals/teacher_role/organisation_address_known_controller.rb
+++ b/app/controllers/referrals/teacher_role/organisation_address_known_controller.rb
@@ -1,0 +1,51 @@
+module Referrals
+  module TeacherRole
+    class OrganisationAddressKnownController < Referrals::BaseController
+      def edit
+        @organisation_address_known_form =
+          OrganisationAddressKnownForm.new(
+            organisation_address_known:
+              current_referral.organisation_address_known
+          )
+      end
+
+      def update
+        @organisation_address_known_form =
+          OrganisationAddressKnownForm.new(
+            organisation_address_known_params.merge(referral: current_referral)
+          )
+
+        if @organisation_address_known_form.save
+          redirect_to next_page
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def organisation_address_known_params
+        params.require(
+          :referrals_teacher_role_organisation_address_known_form
+        ).permit(:organisation_address_known)
+      end
+
+      def next_path
+        if current_referral.organisation_address_known?
+          edit_referral_teacher_role_organisation_address_path(current_referral)
+        else
+          edit_referral_teacher_role_start_date_path(current_referral)
+        end
+      end
+
+      def next_page
+        if @organisation_address_known_form.referral.saved_changes? &&
+             current_referral.organisation_address_known
+          return next_path
+        end
+
+        super
+      end
+    end
+  end
+end

--- a/app/controllers/referrals/teacher_role/reason_leaving_role_controller.rb
+++ b/app/controllers/referrals/teacher_role/reason_leaving_role_controller.rb
@@ -1,0 +1,39 @@
+module Referrals
+  module TeacherRole
+    class ReasonLeavingRoleController < Referrals::BaseController
+      def edit
+        @reason_leaving_role_form =
+          ReasonLeavingRoleForm.new(
+            reason_leaving_role: current_referral.reason_leaving_role
+          )
+      end
+
+      def update
+        @reason_leaving_role_form =
+          ReasonLeavingRoleForm.new(
+            reason_leaving_role_params.merge(referral: current_referral)
+          )
+
+        if @reason_leaving_role_form.save
+          redirect_to next_page
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def reason_leaving_role_params
+        params.require(:referrals_teacher_role_reason_leaving_role_form).permit(
+          :reason_leaving_role
+        )
+      end
+
+      def next_path
+        edit_referral_teacher_role_teaching_somewhere_else_path(
+          current_referral
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/referrals/teacher_role/same_organisation_controller.rb
+++ b/app/controllers/referrals/teacher_role/same_organisation_controller.rb
@@ -30,7 +30,22 @@ module Referrals
       end
 
       def next_path
-        edit_referral_teacher_role_duties_path(current_referral)
+        if current_referral.same_organisation?
+          edit_referral_teacher_role_start_date_path(current_referral)
+        else
+          edit_referral_teacher_role_organisation_address_known_path(
+            current_referral
+          )
+        end
+      end
+
+      def next_page
+        if @same_organisation_form.referral.saved_changes? &&
+             !current_referral.same_organisation
+          return next_path
+        end
+
+        super
       end
     end
   end

--- a/app/controllers/referrals/teacher_role/teaching_location_controller.rb
+++ b/app/controllers/referrals/teacher_role/teaching_location_controller.rb
@@ -4,7 +4,6 @@ module Referrals
       def edit
         @teaching_location_form =
           TeachingLocationForm.new(
-            teaching_location_known: current_referral.teaching_location_known,
             teaching_organisation_name:
               current_referral.teaching_organisation_name,
             teaching_address_line_1: current_referral.teaching_address_line_1,
@@ -31,7 +30,6 @@ module Referrals
 
       def teaching_location_params
         params.require(:referrals_teacher_role_teaching_location_form).permit(
-          :teaching_location_known,
           :teaching_organisation_name,
           :teaching_address_line_1,
           :teaching_address_line_2,

--- a/app/controllers/referrals/teacher_role/teaching_location_known_controller.rb
+++ b/app/controllers/referrals/teacher_role/teaching_location_known_controller.rb
@@ -1,0 +1,50 @@
+module Referrals
+  module TeacherRole
+    class TeachingLocationKnownController < Referrals::BaseController
+      def edit
+        @teaching_location_known_form =
+          TeachingLocationKnownForm.new(
+            teaching_location_known: current_referral.teaching_location_known
+          )
+      end
+
+      def update
+        @teaching_location_known_form =
+          TeachingLocationKnownForm.new(
+            teaching_location_known_params.merge(referral: current_referral)
+          )
+
+        if @teaching_location_known_form.save
+          redirect_to next_page
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def teaching_location_known_params
+        params.require(
+          :referrals_teacher_role_teaching_location_known_form
+        ).permit(:teaching_location_known)
+      end
+
+      def next_path
+        if current_referral.teaching_location_known?
+          edit_referral_teacher_role_teaching_location_path(current_referral)
+        else
+          edit_referral_teacher_role_check_answers_path(current_referral)
+        end
+      end
+
+      def next_page
+        if @teaching_location_known_form.referral.saved_changes? &&
+             current_referral.teaching_location_known
+          return next_path
+        end
+
+        super
+      end
+    end
+  end
+end

--- a/app/controllers/referrals/teacher_role/teaching_somewhere_else_controller.rb
+++ b/app/controllers/referrals/teacher_role/teaching_somewhere_else_controller.rb
@@ -31,14 +31,17 @@ module Referrals
 
       def next_path
         if current_referral.teaching_somewhere_else?
-          edit_referral_teacher_role_teaching_location_path(current_referral)
+          edit_referral_teacher_role_teaching_location_known_path(
+            current_referral
+          )
         else
           edit_referral_teacher_role_check_answers_path(current_referral)
         end
       end
 
       def next_page
-        if @teaching_somewhere_else_form.referral.saved_changes?
+        if @teaching_somewhere_else_form.referral.saved_changes? &&
+             current_referral.teaching_somewhere_else
           return next_path
         end
 

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -84,7 +84,7 @@ class ReferralForm
         section.items.append(
           ReferralSectionItem.new(
             I18n.t("referral_form.about_their_role"),
-            edit_referral_teacher_role_start_date_path(referral),
+            edit_referral_teacher_role_job_title_path(referral),
             section_status(:teacher_role_complete)
           )
         )

--- a/app/forms/referrals/teacher_role/duties_form.rb
+++ b/app/forms/referrals/teacher_role/duties_form.rb
@@ -6,7 +6,7 @@ module Referrals
 
       attr_accessor :referral, :duties_details, :duties_format, :duties_upload
 
-      validates :duties_format, inclusion: { in: %w[details incomplete upload] }
+      validates :duties_format, inclusion: { in: %w[details upload] }
       validates :duties_details,
                 presence: true,
                 if: -> { duties_format == "details" }

--- a/app/forms/referrals/teacher_role/end_date_form.rb
+++ b/app/forms/referrals/teacher_role/end_date_form.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Referrals
+  module TeacherRole
+    class EndDateForm
+      include ActiveModel::Model
+
+      attr_accessor :date_params, :referral, :role_end_date
+      attr_reader :role_end_date_known
+
+      validates :referral, presence: true
+      validates :role_end_date_known, inclusion: { in: [true, false] }
+      validates :role_end_date,
+                date: {
+                  in_the_future: false
+                },
+                if: -> { role_end_date_known }
+
+      def role_end_date_known=(value)
+        @role_end_date_known = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save
+        return false if invalid?
+
+        referral.update(role_end_date:, role_end_date_known:)
+      end
+    end
+  end
+end

--- a/app/forms/referrals/teacher_role/organisation_address_form.rb
+++ b/app/forms/referrals/teacher_role/organisation_address_form.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+module Referrals
+  module TeacherRole
+    class OrganisationAddressForm
+      include ActiveModel::Model
+
+      attr_accessor :referral,
+                    :organisation_name,
+                    :organisation_address_line_1,
+                    :organisation_address_line_2,
+                    :organisation_town_or_city,
+                    :organisation_postcode
+
+      validates :referral,
+                :organisation_name,
+                :organisation_address_line_1,
+                :organisation_town_or_city,
+                :organisation_postcode,
+                presence: true
+      validate :postcode_is_valid, if: -> { organisation_postcode.present? }
+
+      def save
+        return false if invalid?
+
+        referral.update(
+          organisation_name:,
+          organisation_address_line_1:,
+          organisation_address_line_2:,
+          organisation_town_or_city:,
+          organisation_postcode:
+        )
+      end
+
+      private
+
+      def postcode_is_valid
+        unless UKPostcode.parse(organisation_postcode).full_valid?
+          errors.add(:organisation_postcode, :invalid)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/referrals/teacher_role/organisation_address_known_form.rb
+++ b/app/forms/referrals/teacher_role/organisation_address_known_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module Referrals
+  module TeacherRole
+    class OrganisationAddressKnownForm
+      include ActiveModel::Model
+
+      attr_accessor :referral
+      attr_reader :organisation_address_known
+
+      validates :referral, presence: true
+      validates :organisation_address_known, inclusion: { in: [true, false] }
+
+      def organisation_address_known=(value)
+        @organisation_address_known = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save
+        return false if invalid?
+
+        referral.update(organisation_address_known:)
+      end
+    end
+  end
+end

--- a/app/forms/referrals/teacher_role/reason_leaving_role_form.rb
+++ b/app/forms/referrals/teacher_role/reason_leaving_role_form.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 module Referrals
   module TeacherRole
-    class EmploymentStatusForm
+    class ReasonLeavingRoleForm
       include ActiveModel::Model
 
-      attr_accessor :referral, :employment_status
+      attr_accessor :referral, :reason_leaving_role
 
       validates :referral, presence: true
-      validates :employment_status,
+      validates :reason_leaving_role,
                 inclusion: {
-                  in: %w[employed suspended left_role]
+                  in: %w[resigned dismissed retired unknown]
                 }
 
       def save
         return false if invalid?
 
-        referral.update(employment_status:)
+        referral.update(reason_leaving_role:)
       end
     end
   end

--- a/app/forms/referrals/teacher_role/start_date_form.rb
+++ b/app/forms/referrals/teacher_role/start_date_form.rb
@@ -9,7 +9,11 @@ module Referrals
 
       validates :referral, presence: true
       validates :role_start_date_known, inclusion: { in: [true, false] }
-      validates :role_start_date, date: true, if: -> { role_start_date_known }
+      validates :role_start_date,
+                date: {
+                  in_the_future: false
+                },
+                if: -> { role_start_date_known }
 
       def role_start_date_known=(value)
         @role_start_date_known = ActiveModel::Type::Boolean.new.cast(value)

--- a/app/forms/referrals/teacher_role/teaching_location_form.rb
+++ b/app/forms/referrals/teacher_role/teaching_location_form.rb
@@ -9,45 +9,25 @@ module Referrals
                     :teaching_address_line_2,
                     :teaching_town_or_city,
                     :teaching_postcode
-      attr_reader :teaching_location_known
 
       validates :referral, presence: true
-      validates :teaching_location_known, inclusion: { in: [true, false] }
       validates :teaching_organisation_name,
                 :teaching_address_line_1,
                 :teaching_town_or_city,
                 :teaching_postcode,
-                presence: true,
-                if: -> { teaching_location_known }
-      validate :postcode_is_valid,
-               if: -> { teaching_postcode.present? && teaching_location_known }
-
-      def teaching_location_known=(value)
-        @teaching_location_known = ActiveModel::Type::Boolean.new.cast(value)
-      end
+                presence: true
+      validate :postcode_is_valid, if: -> { teaching_postcode.present? }
 
       def save
         return false unless valid?
 
-        address_attrs = {
-          teaching_location_known:,
-          teaching_organisation_name: nil,
-          teaching_address_line_1: nil,
-          teaching_address_line_2: nil,
-          teaching_town_or_city: nil,
-          teaching_postcode: nil
-        }
-
-        if teaching_location_known
-          address_attrs.merge!(
-            teaching_organisation_name:,
-            teaching_address_line_1:,
-            teaching_address_line_2:,
-            teaching_town_or_city:,
-            teaching_postcode:
-          )
-        end
-        referral.update(address_attrs)
+        referral.update(
+          teaching_organisation_name:,
+          teaching_address_line_1:,
+          teaching_address_line_2:,
+          teaching_town_or_city:,
+          teaching_postcode:
+        )
       end
 
       private

--- a/app/forms/referrals/teacher_role/teaching_location_known_form.rb
+++ b/app/forms/referrals/teacher_role/teaching_location_known_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module Referrals
+  module TeacherRole
+    class TeachingLocationKnownForm
+      include ActiveModel::Model
+
+      attr_accessor :referral
+      attr_reader :teaching_location_known
+
+      validates :referral, presence: true
+      validates :teaching_location_known, inclusion: { in: [true, false] }
+
+      def teaching_location_known=(value)
+        @teaching_location_known = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save
+        return false if invalid?
+
+        referral.update(teaching_location_known:)
+      end
+    end
+  end
+end

--- a/app/forms/referrals/teacher_role/teaching_somewhere_else_form.rb
+++ b/app/forms/referrals/teacher_role/teaching_somewhere_else_form.rb
@@ -7,10 +7,7 @@ module Referrals
       attr_accessor :referral, :teaching_somewhere_else
 
       validates :referral, presence: true
-      validates :teaching_somewhere_else,
-                inclusion: {
-                  in: %w[yes no dont_know]
-                }
+      validates :teaching_somewhere_else, inclusion: { in: %w[yes no not_sure] }
 
       def save
         return false if invalid?

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -22,6 +22,18 @@ module AddressHelper
     )
   end
 
+  def referral_organisation_address(referral)
+    address_fields_to_html(
+      [
+        referral.organisation_name,
+        referral.organisation_address_line_1,
+        referral.organisation_address_line_2,
+        referral.organisation_town_or_city,
+        referral.organisation_postcode
+      ]
+    )
+  end
+
   def teaching_address(referral)
     address_fields_to_html(
       [

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -14,6 +14,12 @@ module ReferralHelper
     end
   end
 
+  def duties_format(referral)
+    return "Describe their main duties" if referral.duties_format == "details"
+
+    "Upload file"
+  end
+
   def duties_details(referral)
     if referral.duties_upload.attached?
       "File: #{referral.duties_upload.filename}"
@@ -34,5 +40,18 @@ module ReferralHelper
     args << { return_to: } if return_to
 
     send(path_name, *args)
+  end
+
+  def employment_status(referral)
+    case referral.employment_status
+    when "employed"
+      "Yes"
+    when "suspended"
+      "They’re still employed but they’ve been suspended"
+    when "left_role"
+      "No, they have left the organisation"
+    else
+      "Incomplete"
+    end
   end
 end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -48,4 +48,8 @@ class Referral < ApplicationRecord
   def teaching_somewhere_else?
     teaching_somewhere_else == "yes"
   end
+
+  def left_role?
+    employment_status == "left_role"
+  end
 end

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -73,7 +73,7 @@ class DateValidator < ActiveModel::EachValidator
       return false
     end
 
-    return true unless options[:date_of_birth]
+    return true unless options[:date_of_birth] || !options[:in_the_future]
 
     if year > Time.zone.today.year
       record.errors.add(attribute, :in_the_future)

--- a/app/views/referrals/teacher_role/duties/edit.html.erb
+++ b/app/views/referrals/teacher_role/duties/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @duties_form.errors.any?}How do you want to tell us about their main duties?" %>
+<% content_for :page_title, "#{'Error: ' if @duties_form.errors.any?}How do you want to give details about their main duties?" %>
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_same_organisation_path(current_referral)) %>
 
 <div class="govuk-grid-row">
@@ -6,20 +6,20 @@
     <%= form_with model: @duties_form, url: referral_teacher_role_duties_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
+      <span class="govuk-caption-l">About their role</span>
       <div class="govuk-form-group">
-        <%= f.govuk_radio_buttons_fieldset(:duties_format, legend: { size: "xl", text: "How do you want to tell us about their main duties?" }) do %>
-          <%= f.govuk_radio_button :duties_format, "upload", label: { text: "I’ll upload a job description" } do %>
+        <%= f.govuk_radio_buttons_fieldset(:duties_format, legend: { text: "How do you want to give details about their main duties?", tag: 'h1', size: "l" }) do %>
+          <%= f.govuk_radio_button :duties_format, "upload", label: { text: "Upload file" } do %>
             <%= f.govuk_file_field :duties_upload,
-              label: { text: "Upload job description", size: "s" },
-              hint: { text: current_referral.duties_upload.attached? ? "Uploaded file: #{current_referral.duties_upload.filename}" : ""  }
+              label: { text: "Upload file", size: "s" },
+              hint: { text: current_referral.duties_upload.attached? ? "Uploaded file: #{current_referral.duties_upload.filename}" : "For example, a job description"  }
               %>
           <% end %>
-          <%= f.govuk_radio_button :duties_format, "details", label: { text: "I’ll describe their main duties" } do %>
+          <%= f.govuk_radio_button :duties_format, "details", label: { text: "Describe their main duties" } do %>
             <%= f.govuk_text_area :duties_details,
-                                  label: { text: "Describe their main duties", size: "m" },
-                                  rows: 20 %>
+                                  label: { text: "Description of their main duties", size: "s" },
+                                  rows: 15 %>
           <% end %>
-          <%= f.govuk_radio_button :duties_format, "incomplete", label: { text: "I’ll do this later" } %>
         <% end %>
       </div>
 

--- a/app/views/referrals/teacher_role/employment_status/edit.html.erb
+++ b/app/views/referrals/teacher_role/employment_status/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @employment_status_form.errors.any?}Are they still employed in that job?" %>
+<% content_for :page_title, "#{'Error: ' if @employment_status_form.errors.any?}Are they still employed in the job where the alleged misconduct took place?" %>
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_start_date_path(current_referral)) %>
 
 <div class="govuk-grid-row">
@@ -6,21 +6,13 @@
     <%= form_with model: @employment_status_form, url: referral_teacher_role_employment_status_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :employment_status, legend: { size: "xl", text: "Are they still employed in that job?" }  do %>
+      <span class="govuk-caption-l">About their role</span>
+      <%= f.govuk_radio_buttons_fieldset :employment_status,
+        legend: { text: "Are they still employed in the job where the alleged misconduct took place?", tag: 'h1', size: "l" }  do %>
         <%= f.hidden_field :employment_status %>
         <%= f.govuk_radio_button :employment_status, "employed", label: { text: "Yes" } %>
-        <%= f.govuk_radio_button :employment_status, "suspended", label: { text: "They are still employed but they’ve been suspended" } %>
-        <%= f.govuk_radio_button :employment_status, "left_role", label: { text: "No, they have left the organisation" } do %>
-          <%= f.govuk_date_field :role_end_date,
-            legend: { text: "When did they leave the organisation? (optional)", size: "m" },
-            hint: { text: "For example, 27 3 2021" } %>
-          <%= f.govuk_radio_buttons_fieldset :reason_leaving_role, legend: { size: "m", text: "How did they leave the organisation?" }  do %>
-             <%= f.govuk_radio_button :reason_leaving_role, "resigned", label: { text: "Resigned" } %>
-             <%= f.govuk_radio_button :reason_leaving_role, "dismissed", label: { text: "Dismissed" } %>
-             <%= f.govuk_radio_button :reason_leaving_role, "retired", label: { text: "Retired" } %>
-             <%= f.govuk_radio_button :reason_leaving_role, "unknown", label: { text: "I don't know" } %>
-          <% end %>
-        <% end %>
+        <%= f.govuk_radio_button :employment_status, "suspended", label: { text: "They’re still employed but they’ve been suspended" } %>
+        <%= f.govuk_radio_button :employment_status, "left_role", label: { text: "No, they have left the organisation" } %>
       <% end %>
       <%= f.govuk_submit "Save and continue" %>
     <% end %>

--- a/app/views/referrals/teacher_role/end_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/end_date/edit.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title, "#{'Error: ' if @role_end_date_form.errors.any?}Do you know when they left the job?" %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <%= form_with model: @role_end_date_form, url: referral_teacher_role_end_date_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l">About their role</span>
+      <%= f.govuk_radio_buttons_fieldset :role_end_date_known,
+        legend: { text: "Do you know when they left the job?", tag: 'h1', size: "l" } do %>
+        <%= f.hidden_field :role_end_date_known %>
+        <%= f.govuk_radio_button :role_end_date_known, true, label: { text: "Yes" } do %>
+          <%= f.govuk_date_field :role_end_date,
+            legend: { text: "Job end date", size: "s" },
+            hint: { text: "For example, 27 3 2022" } %>
+        <% end %>
+        <%= f.govuk_radio_button :role_end_date_known, false, label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/teacher_role/job_title/edit.html.erb
+++ b/app/views/referrals/teacher_role/job_title/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @job_title_form.errors.any?}What’s their job title?" %>
+<% content_for :page_title, "#{'Error: ' if @job_title_form.errors.any?}Their job title" %>
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_employment_status_path(current_referral)) %>
 
 <div class="govuk-grid-row">
@@ -6,8 +6,9 @@
     <%= form_with model: @job_title_form, url: referral_teacher_role_job_title_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
+      <span class="govuk-caption-l">About their role</span>
       <%= f.govuk_text_field :job_title,
-        label: { text: "What’s their job title?", size: "xl" },
+        label: { text: "Their job title", tag: 'h1', size: "l" },
         hint: { text: "For example, ‘Teacher’" }
       %>
       <%= f.govuk_submit "Save and continue" %>

--- a/app/views/referrals/teacher_role/organisation_address/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address/edit.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, "#{'Error: ' if @organisation_address_form.errors.any?}Where they were employed at the time of the alleged misconduct" %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_job_title_path(current_referral)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <%= form_with model: @organisation_address_form, url: referral_teacher_role_organisation_address_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l">About their role</span>
+      <h1 class="govuk-heading-l">
+        Where they were employed at the time of the alleged misconduct
+      </h1>
+
+      <%= f.govuk_text_field :organisation_name, label: { text: "Organisation name", size: "m" } %>
+      <%= f.govuk_text_field :organisation_address_line_1, label: { text: "Address line 1", size: "m" } %>
+      <%= f.govuk_text_field :organisation_address_line_2, label: { text: "Address line 2 (optional)", size: "m" } %>
+      <%= f.govuk_text_field :organisation_town_or_city, label: { text: "Town or city", size: "m" } %>
+      <%= f.govuk_text_field :organisation_postcode, label: { text: "Postcode", size: "m" } %>
+      <%= f.govuk_submit 'Save and continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, "#{'Error: ' if @organisation_address_known_form.errors.any?}Do you know the name and address of the organisation?" %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_job_title_path(current_referral)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <%= form_with model: @organisation_address_known_form, url: referral_teacher_role_organisation_address_known_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l">About their role</span>
+      <%= f.govuk_radio_buttons_fieldset :organisation_address_known,
+        legend: { text: "Do you know the name and address of the organisation where the alleged misconduct took place?", tag: 'h1', size: "l" } do %>
+        <%= f.hidden_field :organisation_address_known %>
+        <%= f.govuk_radio_button :organisation_address_known, true, label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :organisation_address_known, false, label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/teacher_role/reason_leaving_role/edit.html.erb
+++ b/app/views/referrals/teacher_role/reason_leaving_role/edit.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, "#{'Error: ' if @reason_leaving_role_form.errors.any?}Reason they left the job" %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_start_date_path(current_referral)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <%= form_with model: @reason_leaving_role_form, url: referral_teacher_role_reason_leaving_role_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l">About their role</span>
+      <%= f.govuk_radio_buttons_fieldset :reason_leaving_role,
+        legend: { text: "Reason they left the job", tag: 'h1', size: "l" }  do %>
+        <%= f.hidden_field :reason_leaving_role %>
+
+        <%= f.govuk_radio_button :reason_leaving_role, "resigned", label: { text: "Resigned" } %>
+        <%= f.govuk_radio_button :reason_leaving_role, "dismissed", label: { text: "Dismissed" } %>
+        <%= f.govuk_radio_button :reason_leaving_role, "retired", label: { text: "Retired" } %>
+        <%= f.govuk_radio_button :reason_leaving_role, "unknown", label: { text: "I’m not sure" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/teacher_role/same_organisation/edit.html.erb
+++ b/app/views/referrals/teacher_role/same_organisation/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @same_organisation_form.errors.any?}Do they work in the same organisation as you?" %>
+<% content_for :page_title, "#{'Error: ' if @same_organisation_form.errors.any?}Did they work at the same organisation as you at the time of the alleged misconduct?" %>
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_job_title_path(current_referral)) %>
 
 <div class="govuk-grid-row">
@@ -6,11 +6,12 @@
     <%= form_with model: @same_organisation_form, url: referral_teacher_role_same_organisation_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
+      <span class="govuk-caption-l">About their role</span>
       <%= f.govuk_radio_buttons_fieldset :same_organisation,
-        legend: { size: "l", text: "Do they work in the same organisation as you?" } do %>
+        legend: { text: "Did they work at the same organisation as you at the time of the alleged misconduct?", tag: 'h1', size: "l" } do %>
         <%= f.hidden_field :same_organisation %>
-        <%= f.govuk_radio_button :same_organisation, true, label: { text: "Yes, the same organisation" } %>
-        <%= f.govuk_radio_button :same_organisation, false, label: { text: "No, a different organisation" } %>
+        <%= f.govuk_radio_button :same_organisation, true, label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :same_organisation, false, label: { text: "No" } %>
       <% end %>
       <%= f.govuk_submit "Save and continue" %>
     <% end %>

--- a/app/views/referrals/teacher_role/start_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/start_date/edit.html.erb
@@ -5,14 +5,13 @@
   <div class="govuk-grid-column-two-thirds-from-desktop ">
     <%= form_with model: @role_start_date_form, url: referral_teacher_role_start_date_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
-
+      <span class="govuk-caption-l">About their role</span>
       <%= f.govuk_radio_buttons_fieldset :role_start_date_known,
-        legend: { size: "l", text: "Do you know when they started their job?" },
-        hint: { size: "m", text: "This is the job the person had when the allegation of serious misconduct was made against them." } do %>
+        legend: { text: "Do you know when they started their job?", tag: 'h1', size: "l" } do %>
         <%= f.hidden_field :role_start_date_known %>
         <%= f.govuk_radio_button :role_start_date_known, true, label: { text: "Yes" } do %>
           <%= f.govuk_date_field :role_start_date,
-            legend: { text: "Start date", size: "m" },
+            legend: { text: "Job start date", size: "s" },
             hint: { text: "For example, 27 3 2021" } %>
         <% end %>
         <%= f.govuk_radio_button :role_start_date_known, false, label: { text: "No" } %>

--- a/app/views/referrals/teacher_role/teaching_location/edit.html.erb
+++ b/app/views/referrals/teacher_role/teaching_location/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{"Error: " if @teaching_location_form.errors.any?}Do you know where they are teaching?" %>
+<% content_for :page_title, "#{"Error: " if @teaching_location_form.errors.any?}Where they currently work" %>
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_teaching_somewhere_else_path(current_referral)) %>
 
 <div class="govuk-grid-row">
@@ -6,24 +6,16 @@
     <%= form_with model: @teaching_location_form, url: referral_teacher_role_teaching_location_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :teaching_location_known, legend: { size: "xl", text: "Do you know where they are teaching?" }  do %>
-        <%= f.hidden_field :teaching_location_known %>
-        <%= f.govuk_radio_button :teaching_location_known, true, label: { text: "Yes" } do %>
-          <div class="govuk-form-group">
-            <%= f.govuk_text_field :teaching_organisation_name, label: { text: "Organisation name", size: "s" } %>
-          </div>
-           <div class="govuk-form-group">
-            <%= f.govuk_fieldset legend: { text: "Organisation address", size: "s" } do %>
-              <%= f.govuk_text_field :teaching_address_line_1, label: { text: "Address line 1" } %>
-              <%= f.govuk_text_field :teaching_address_line_2, label: { text: "Address line 2 (optional)" } %>
-              <%= f.govuk_text_field :teaching_town_or_city, label: { text: "Town or city" } %>
-              <%= f.govuk_text_field :teaching_postcode, label: { text: "Postcode" } %>
-            <% end %>
-          </div>
-        <% end %>
+      <span class="govuk-caption-l">About their role</span>
+      <h1 class="govuk-heading-l">
+        Where they currently work
+      </h1>
 
-        <%= f.govuk_radio_button :teaching_location_known, false, label: { text: "No" } %>
-      <% end %>
+      <%= f.govuk_text_field :teaching_organisation_name, label: { text: "Organisation name", size: "m" } %>
+      <%= f.govuk_text_field :teaching_address_line_1, label: { text: "Address line 1", size: "m" } %>
+      <%= f.govuk_text_field :teaching_address_line_2, label: { text: "Address line 2 (optional)", size: "m" } %>
+      <%= f.govuk_text_field :teaching_town_or_city, label: { text: "Town or city", size: "m" } %>
+      <%= f.govuk_text_field :teaching_postcode, label: { text: "Postcode", size: "m" } %>
       <%= f.govuk_submit "Save and continue", prevent_double_click: false %>
     <% end %>
   </div>

--- a/app/views/referrals/teacher_role/teaching_location_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/teaching_location_known/edit.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, "#{'Error: ' if @teaching_location_known_form.errors.any?}Do you know the name and address of the organisation where they’re currently working?" %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_job_title_path(current_referral)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <%= form_with model: @teaching_location_known_form, url: referral_teacher_role_teaching_location_known_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l">About their role</span>
+      <%= f.govuk_radio_buttons_fieldset :teaching_location_known,
+        legend: { text: "Do you know the name and address of the organisation where they’re currently working?", tag: 'h1', size: "l" } do %>
+        <%= f.hidden_field :teaching_location_known %>
+        <%= f.govuk_radio_button :teaching_location_known, true, label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :teaching_location_known, false, label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/teacher_role/teaching_somewhere_else/edit.html.erb
+++ b/app/views/referrals/teacher_role/teaching_somewhere_else/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @teaching_somewhere_else_form.errors.any?}Do you know if they are teaching somewhere else?" %>
+<% content_for :page_title, "#{'Error: ' if @teaching_somewhere_else_form.errors.any?}Are they employed somewhere else?" %>
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_duties_path(current_referral)) %>
 
 <div class="govuk-grid-row">
@@ -6,12 +6,13 @@
     <%= form_with model: @teaching_somewhere_else_form, url: referral_teacher_role_teaching_somewhere_else_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
+      <span class="govuk-caption-l">About their role</span>
       <%= f.govuk_radio_buttons_fieldset :teaching_somewhere_else,
-        legend: { size: "l", text: "Do you know if they are teaching somewhere else?" } do %>
+        legend: { size: "l", text: "Are they employed somewhere else?" } do %>
         <%= f.hidden_field :teaching_somewhere_else %>
-        <%= f.govuk_radio_button :teaching_somewhere_else, "yes", label: { text: "Yes, they are teaching somewhere else" } %>
-        <%= f.govuk_radio_button :teaching_somewhere_else, "no", label: { text: "No, they are not teaching somewhere else" } %>
-        <%= f.govuk_radio_button :teaching_somewhere_else, "dont_know", label: { text: "I don’t know" } %>
+        <%= f.govuk_radio_button :teaching_somewhere_else, "yes", label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :teaching_somewhere_else, "no", label: { text: "No" } %>
+        <%= f.govuk_radio_button :teaching_somewhere_else, "not_sure", label: { text: "I’m not sure" } %>
       <% end %>
       <%= f.govuk_submit "Save and continue" %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,7 +98,7 @@ en:
               missing_month: Enter a month for their date of birth, formatted as a number
               missing_year: Enter a year with 4 digits
             age_known:
-              inclusion: Tell us if you know their date of birth
+              inclusion: Select yes if you know their date of birth
         "referrals/personal_details/name_form":
           attributes:
             first_name:
@@ -168,15 +168,6 @@ en:
           attributes:
             employment_status:
               inclusion: Select whether they’re still employed where the alleged misconduct took place
-            reason_leaving_role:
-              inclusion: Select the reason they left the job
-            role_end_date:
-              blank: Enter the job end date
-              in_the_future: Job end date must be in the past
-              invalid: Job end date must be a real date
-              missing_day: Job end date must include a day
-              missing_month: Job end date must include a month
-              missing_year: Job end date must include a year
         "referrals/teacher_role/job_title_form":
           attributes:
             job_title:
@@ -202,8 +193,6 @@ en:
               inclusion: Select yes if they’re employed somewhere else
         "referrals/teacher_role/teaching_location_form":
           attributes:
-            teaching_location_known:
-              inclusion: Select yes if you know the name and address of the organisation where they’re currently working
             teaching_organisation_name:
               blank: Enter the organisation name
             teaching_address_line_1:
@@ -213,6 +202,40 @@ en:
             teaching_postcode:
               blank: Enter the postcode
               invalid: Enter a real postcode
+        "referrals/teacher_role/teaching_location_known_form":
+          attributes:
+            teaching_location_known:
+              inclusion: Select yes if you know the name and address of the organisation where they’re currently working
+        "referrals/teacher_role/organisation_address_known_form":
+          attributes:
+            organisation_address_known:
+              inclusion: Select yes if you know the name and address of the organisation
+        "referrals/teacher_role/organisation_address_form":
+          attributes:
+            organisation_name:
+              blank: Enter organisation name
+            organisation_address_line_1:
+              blank: Enter the first line of their organisation's address
+            organisation_town_or_city:
+              blank: Enter a town or city for their organisation
+            organisation_postcode:
+              blank: Enter a postcode for their organisation
+              invalid: Enter a real postcode
+        "referrals/teacher_role/end_date_form":
+          attributes:
+            role_end_date_known:
+              inclusion: Select yes if you know when they left the job
+            role_end_date:
+              blank: Enter the job end date
+              in_the_future: Job end date must be in the past
+              invalid: Job end date must be a real date
+              missing_day: Job end date must include a day
+              missing_month: Job end date must include a month
+              missing_year: Job end date must include a year
+        "referrals/teacher_role/reason_leaving_role_form":
+          attributes:
+            reason_leaving_role:
+              inclusion: Select the reason they left the job
         "referrals/teacher_role/check_answers_form":
           attributes:
             teacher_role_complete:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,10 +161,30 @@ Rails.application.routes.draw do
                  path: "teaching-somewhere-else",
                  only: %i[edit update],
                  controller: :teaching_somewhere_else
+        resource :teaching_location_known,
+                 path: "teaching-location-known",
+                 only: %i[edit update],
+                 controller: :teaching_location_known
         resource :teaching_location,
                  path: "teaching-location",
                  only: %i[edit update],
                  controller: :teaching_location
+        resource :organisation_address_known,
+                 path: "organisation-address-known",
+                 only: %i[edit update],
+                 controller: :organisation_address_known
+        resource :organisation_address,
+                 path: "organisation-address",
+                 only: %i[edit update],
+                 controller: :organisation_address
+        resource :end_date,
+                 path: "end-date",
+                 only: %i[edit update],
+                 controller: :end_date
+        resource :reason_leaving_role,
+                 path: "reason-leaving-role",
+                 only: %i[edit update],
+                 controller: :reason_leaving_role
         resource :check_answers, path: "check-answers", only: %i[edit update]
       end
 

--- a/db/migrate/20221215183310_add_teacher_organisation_address_to_referrals.rb
+++ b/db/migrate/20221215183310_add_teacher_organisation_address_to_referrals.rb
@@ -1,0 +1,10 @@
+class AddTeacherOrganisationAddressToReferrals < ActiveRecord::Migration[7.0]
+  change_table :referrals, bulk: true do |t|
+    t.boolean :organisation_address_known
+    t.string :organisation_name
+    t.string :organisation_address_line_1
+    t.string :organisation_address_line_2
+    t.string :organisation_town_or_city
+    t.string :organisation_postcode, limit: 11
+  end
+end

--- a/db/migrate/20221216172718_add_role_end_date_known_to_referral.rb
+++ b/db/migrate/20221216172718_add_role_end_date_known_to_referral.rb
@@ -1,0 +1,5 @@
+class AddRoleEndDateKnownToReferral < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrals, :role_end_date_known, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_13_163958) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_16_172718) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -126,20 +126,28 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_13_163958) do
     t.string "reason_leaving_role"
     t.string "job_title"
     t.boolean "same_organisation"
-    t.text "previous_misconduct_details"
-    t.datetime "previous_misconduct_details_incomplete_at", precision: nil
     t.string "duties_format"
     t.string "duties_details"
     t.boolean "teacher_role_complete"
+    t.text "previous_misconduct_details"
+    t.datetime "previous_misconduct_details_incomplete_at", precision: nil
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.datetime "submitted_at", precision: nil
-    t.bigint "eligibility_check_id"
     t.string "teaching_somewhere_else"
+    t.bigint "eligibility_check_id"
     t.boolean "teaching_location_known"
     t.string "teaching_organisation_name"
     t.string "teaching_address_line_1"
     t.string "teaching_address_line_2"
     t.string "teaching_town_or_city"
     t.string "teaching_postcode"
+    t.boolean "organisation_address_known"
+    t.string "organisation_name"
+    t.string "organisation_address_line_1"
+    t.string "organisation_address_line_2"
+    t.string "organisation_town_or_city"
+    t.string "organisation_postcode", limit: 11
+    t.boolean "role_end_date_known"
     t.index ["eligibility_check_id"], name: "index_referrals_on_eligibility_check_id"
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end

--- a/spec/forms/referrals/personal_details/age_form_spec.rb
+++ b/spec/forms/referrals/personal_details/age_form_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Referrals::PersonalDetails::AgeForm, type: :model do
     it "adds an error message" do
       form.valid?
       expect(form.errors[:age_known]).to eq(
-        ["Tell us if you know their date of birth"]
+        ["Select yes if you know their date of birth"]
       )
     end
   end

--- a/spec/forms/referrals/teacher_role/duties_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/duties_form_spec.rb
@@ -104,21 +104,5 @@ RSpec.describe Referrals::TeacherRole::DutiesForm, type: :model do
         end
       end
     end
-
-    context "when format is incomplete" do
-      let(:duties_details) { "Something something" }
-      let(:duties_upload) { fixture_file_upload("upload1.pdf") }
-      let(:duties_format) { "incomplete" }
-
-      it { is_expected.to be_truthy }
-
-      it "clears out the description" do
-        expect(referral.duties_details).to be_nil
-      end
-
-      it "purges the attached file" do
-        expect(referral.duties_upload).not_to be_attached
-      end
-    end
   end
 end

--- a/spec/forms/referrals/teacher_role/employment_status_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/employment_status_form_spec.rb
@@ -2,9 +2,9 @@
 require "rails_helper"
 
 RSpec.describe Referrals::TeacherRole::EmploymentStatusForm, type: :model do
-  let(:form) { described_class.new(params) }
+  let(:form) { described_class.new(referral:, employment_status:) }
+  let(:employment_status) { "" }
   let(:referral) { build(:referral) }
-  let(:params) { {} }
   let(:date_params) { nil }
 
   describe "validations" do
@@ -21,7 +21,7 @@ RSpec.describe Referrals::TeacherRole::EmploymentStatusForm, type: :model do
     subject(:valid) { form.valid? }
 
     context "when employment_status is blank" do
-      let(:params) { { employment_status: "" } }
+      let(:employment_status) { "" }
 
       it "adds an error" do
         valid
@@ -37,40 +37,33 @@ RSpec.describe Referrals::TeacherRole::EmploymentStatusForm, type: :model do
   describe "#save" do
     subject(:save) { form.save }
 
-    context "when employment_status is left_role" do
-      let(:params) do
-        {
-          date_params:,
-          employment_status: "left_role",
-          reason_leaving_role: "resigned",
-          referral:
-        }
-      end
-      let(:optional) { true }
+    context "when employment_status is employed" do
+      let(:employment_status) { "employed" }
 
-      it_behaves_like "form with a date validator", "role_end_date"
-    end
-
-    context "without a reason_leaving_role" do
-      let(:params) { { employment_status: "left_role", referral: } }
-
-      it { is_expected.to be_falsy }
-
-      it "adds an error" do
-        save
-        expect(form.errors[:reason_leaving_role]).to eq(
-          ["Select the reason they left the job"]
-        )
+      it "updates the employment_status to employed" do
+        expect { form.save }.to change(referral, :employment_status).from(
+          nil
+        ).to("employed")
       end
     end
 
     context "when employment_status is suspended" do
-      let(:params) { { employment_status: "suspended", referral: } }
+      let(:employment_status) { "suspended" }
 
       it "updates the employment_status to suspended" do
         expect { form.save }.to change(referral, :employment_status).from(
           nil
         ).to("suspended")
+      end
+    end
+
+    context "when employment_status is left_role" do
+      let(:employment_status) { "left_role" }
+
+      it "updates the employment_status to left_role" do
+        expect { form.save }.to change(referral, :employment_status).from(
+          nil
+        ).to("left_role")
       end
     end
   end

--- a/spec/forms/referrals/teacher_role/end_date_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/end_date_form_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Referrals::TeacherRole::EndDateForm, type: :model do
+  let(:form) { described_class.new(params) }
+  let(:referral) { build(:referral) }
+  let(:params) { {} }
+  let(:date_params) { nil }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:referral) }
+
+    specify do
+      expect(form).to validate_inclusion_of(:role_end_date_known).in_array(
+        [true, false]
+      )
+    end
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    context "when role_end_date_known is blank" do
+      let(:params) { { role_end_date_known: "" } }
+
+      it "adds an error" do
+        valid
+        expect(form.errors[:role_end_date_known]).to eq(
+          ["Select yes if you know when they left the job"]
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    context "when role_end_date_known is true" do
+      let(:params) { { date_params:, role_end_date_known: true, referral: } }
+      let(:optional) { true }
+
+      it_behaves_like "form with a date validator", "role_end_date"
+    end
+  end
+end

--- a/spec/forms/referrals/teacher_role/organisation_address_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/organisation_address_form_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe Referrals::TeacherRole::OrganisationAddressForm, type: :model do
+  let(:referral) { create(:referral) }
+  let(:form) { described_class.new(params) }
+
+  let(:params) do
+    {
+      organisation_name: "DfE",
+      organisation_address_line_1: "1428 Elm Street",
+      organisation_address_line_2: "Sunset Boulevard",
+      organisation_postcode: "NW1 4NP",
+      referral:,
+      organisation_town_or_city: "London"
+    }
+  end
+
+  describe "validations" do
+    subject { form }
+
+    it { is_expected.to validate_presence_of(:referral) }
+    it { is_expected.to validate_presence_of(:organisation_name) }
+    it { is_expected.to validate_presence_of(:organisation_address_line_1) }
+    it { is_expected.to validate_presence_of(:organisation_town_or_city) }
+    it { is_expected.to validate_presence_of(:organisation_postcode) }
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    before { valid }
+
+    it { is_expected.to be_truthy }
+
+    context "when organisation_name is blank" do
+      let(:params) { super().merge(organisation_name: "") }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:organisation_name]).to eq(
+          ["Enter organisation name"]
+        )
+      end
+    end
+
+    context "when organisation_address_line_1 is blank" do
+      let(:params) { super().merge(organisation_address_line_1: "") }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:organisation_address_line_1]).to eq(
+          ["Enter the first line of their organisation's address"]
+        )
+      end
+    end
+
+    context "when organisation_town_or_city is blank" do
+      let(:params) { super().merge(organisation_town_or_city: "") }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:organisation_town_or_city]).to eq(
+          ["Enter a town or city for their organisation"]
+        )
+      end
+    end
+
+    context "when organisation_postcode is blank" do
+      let(:params) { super().merge(organisation_postcode: "") }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:organisation_postcode]).to eq(
+          ["Enter a postcode for their organisation"]
+        )
+      end
+    end
+
+    context "when organisation_postcode is invalid" do
+      let(:params) { super().merge(organisation_postcode: "Invalid") }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:organisation_postcode]).to eq(
+          ["Enter a real postcode"]
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    before { form.save }
+
+    it "saves organisation_name" do
+      expect(referral.organisation_name).to eq("DfE")
+    end
+
+    it "saves organisation_address_line_1" do
+      expect(referral.organisation_address_line_1).to eq("1428 Elm Street")
+    end
+
+    it "saves organisation_address_line_2" do
+      expect(referral.organisation_address_line_2).to eq("Sunset Boulevard")
+    end
+
+    it "saves organisation_town_or_city" do
+      expect(referral.organisation_town_or_city).to eq("London")
+    end
+
+    it "saves organisation_postcode" do
+      expect(referral.organisation_postcode).to eq("NW1 4NP")
+    end
+  end
+end

--- a/spec/forms/referrals/teacher_role/organisation_address_known_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/organisation_address_known_form_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Referrals::TeacherRole::OrganisationAddressKnownForm,
+               type: :model do
+  subject(:form) { described_class.new(referral:, organisation_address_known:) }
+
+  let(:referral) { build(:referral) }
+  let(:organisation_address_known) { true }
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    before { valid }
+
+    it { is_expected.to be_truthy }
+
+    context "when organisation_address_known is blank" do
+      let(:organisation_address_known) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:organisation_address_known]).to eq(
+          ["Select yes if you know the name and address of the organisation"]
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when organisation_address_known is true" do
+      let(:organisation_address_known) { "true" }
+
+      it "updates the organisation_address_known to true" do
+        expect { form.save }.to change(
+          referral,
+          :organisation_address_known
+        ).from(nil).to(true)
+      end
+    end
+
+    context "when organisation_address_known is false" do
+      let(:organisation_address_known) { false }
+
+      it "updates the organisation_address_known to false" do
+        expect { form.save }.to change(
+          referral,
+          :organisation_address_known
+        ).from(nil).to(false)
+      end
+    end
+  end
+end

--- a/spec/forms/referrals/teacher_role/reason_leaving_role_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/reason_leaving_role_form_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Referrals::TeacherRole::ReasonLeavingRoleForm, type: :model do
+  let(:form) { described_class.new(referral:, reason_leaving_role:) }
+  let(:referral) { build(:referral) }
+  let(:reason_leaving_role) { "" }
+  let(:params) { {} }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:referral) }
+
+    specify do
+      expect(form).to validate_inclusion_of(:reason_leaving_role).in_array(
+        %w[resigned dismissed retired unknown]
+      )
+    end
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    context "when reason_leaving_role is blank" do
+      it "adds an error" do
+        valid
+        expect(form.errors[:reason_leaving_role]).to eq(
+          ["Select the reason they left the job"]
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    context "without a reason_leaving_role" do
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        save
+        expect(form.errors[:reason_leaving_role]).to eq(
+          ["Select the reason they left the job"]
+        )
+      end
+    end
+
+    context "when reason_leaving_role is resigned" do
+      let(:reason_leaving_role) { "resigned" }
+
+      it "updates the employment_status to employed" do
+        expect { form.save }.to change(referral, :reason_leaving_role).from(
+          nil
+        ).to("resigned")
+      end
+    end
+  end
+end

--- a/spec/forms/referrals/teacher_role/teaching_location_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/teaching_location_form_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Referrals::TeacherRole::TeachingLocationForm, type: :model do
 
   let(:params) do
     {
-      teaching_location_known: true,
       teaching_organisation_name: "High School",
       teaching_address_line_1: "1428 Elm Street",
       teaching_address_line_2: "Sunset Boulevard",
@@ -18,17 +17,10 @@ RSpec.describe Referrals::TeacherRole::TeachingLocationForm, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:referral) }
-
-    context "when address is known" do
-      subject { form }
-
-      let(:params) { { teaching_location_known: true } }
-
-      it { is_expected.to validate_presence_of(:teaching_organisation_name) }
-      it { is_expected.to validate_presence_of(:teaching_address_line_1) }
-      it { is_expected.to validate_presence_of(:teaching_town_or_city) }
-      it { is_expected.to validate_presence_of(:teaching_postcode) }
-    end
+    it { is_expected.to validate_presence_of(:teaching_organisation_name) }
+    it { is_expected.to validate_presence_of(:teaching_address_line_1) }
+    it { is_expected.to validate_presence_of(:teaching_town_or_city) }
+    it { is_expected.to validate_presence_of(:teaching_postcode) }
   end
 
   describe "#valid?" do
@@ -37,20 +29,6 @@ RSpec.describe Referrals::TeacherRole::TeachingLocationForm, type: :model do
     before { valid }
 
     it { is_expected.to be_truthy }
-
-    context "when teaching_location_known is blank" do
-      let(:params) { super().merge(teaching_location_known: "") }
-
-      it { is_expected.to be_falsy }
-
-      it "adds an error" do
-        expect(form.errors[:teaching_location_known]).to eq(
-          [
-            "Select yes if you know the name and address of the organisation where they’re currently working"
-          ]
-        )
-      end
-    end
 
     context "when teaching_organisation_name is blank" do
       let(:params) { super().merge(teaching_organisation_name: "") }
@@ -112,10 +90,6 @@ RSpec.describe Referrals::TeacherRole::TeachingLocationForm, type: :model do
   describe "#save" do
     before { form.save }
 
-    it "saves teaching_location_known" do
-      expect(referral.teaching_location_known).to be_truthy
-    end
-
     it "saves teaching_organisation_name" do
       expect(referral.teaching_organisation_name).to eq("High School")
     end
@@ -134,34 +108,6 @@ RSpec.describe Referrals::TeacherRole::TeachingLocationForm, type: :model do
 
     it "saves teaching_postcode" do
       expect(referral.teaching_postcode).to eq("NW1 4NP")
-    end
-
-    context "when the address is not known" do
-      let(:params) { super().merge(teaching_location_known: false) }
-
-      it "sets the teaching_location_known to false" do
-        expect(referral.teaching_location_known).to be_falsy
-      end
-
-      it "sets the teaching_organisation_name to nil" do
-        expect(referral.teaching_organisation_name).to be_nil
-      end
-
-      it "sets the teaching_address_line_1 to nil" do
-        expect(referral.teaching_address_line_1).to be_nil
-      end
-
-      it "sets the teaching_address_line_2 to nil" do
-        expect(referral.teaching_address_line_2).to be_nil
-      end
-
-      it "sets the teaching_town_or_city to nil" do
-        expect(referral.teaching_town_or_city).to be_nil
-      end
-
-      it "sets the teaching_postcode to nil" do
-        expect(referral.teaching_postcode).to be_nil
-      end
     end
   end
 end

--- a/spec/forms/referrals/teacher_role/teaching_location_known_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/teaching_location_known_form_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe Referrals::TeacherRole::TeachingLocationKnownForm,
+               type: :model do
+  let(:referral) { create(:referral) }
+  let(:teaching_location_known) { true }
+  let(:form) { described_class.new(referral:, teaching_location_known:) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:referral) }
+
+    it do
+      expect(form).to validate_presence_of(
+        :teaching_location_known
+      ).with_message(
+        "Select yes if you know the name and address of the organisation where they’re currently working"
+      )
+    end
+  end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    before { valid }
+
+    it { is_expected.to be_truthy }
+
+    context "when teaching_location_known is blank" do
+      let(:teaching_location_known) { "" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:teaching_location_known]).to eq(
+          [
+            "Select yes if you know the name and address of the organisation where they’re currently working"
+          ]
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    before { form.save }
+
+    it "saves teaching_location_known" do
+      expect(referral.teaching_location_known).to be_truthy
+    end
+
+    context "when the address is not known" do
+      let(:teaching_location_known) { false }
+
+      it "sets the teaching_location_known to false" do
+        expect(referral.teaching_location_known).to be_falsy
+      end
+    end
+  end
+end

--- a/spec/forms/referrals/teacher_role/teaching_somewhere_else_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/teaching_somewhere_else_form_spec.rb
@@ -50,12 +50,12 @@ RSpec.describe Referrals::TeacherRole::TeachingSomewhereElseForm,
     end
 
     context "when teaching_somewhere_else is not known" do
-      let(:teaching_somewhere_else) { "dont_know" }
+      let(:teaching_somewhere_else) { "not_sure" }
 
-      it "updates the teaching_somewhere_else to dont_know" do
+      it "updates the teaching_somewhere_else to not_sure" do
         expect { form.save }.to change(referral, :teaching_somewhere_else).from(
           nil
-        ).to("dont_know")
+        ).to("not_sure")
       end
     end
   end

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature "Personal details", type: :system do
   end
 
   def then_i_see_age_field_validation_errors
-    expect(page).to have_content("Tell us if you know their date of birth")
+    expect(page).to have_content("Select yes if you know their date of birth")
   end
 
   def when_i_fill_out_their_date_of_birth

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -19,63 +19,7 @@ RSpec.feature "Teacher role", type: :system do
 
     when_i_edit_teacher_role_details
 
-    # Do you know when they started their job?
-
-    then_i_see_the_job_start_date_page
-    and_i_click_back
-    then_i_see_the_referral_summary
-
-    when_i_edit_teacher_role_details
-    then_i_see_the_job_start_date_page
-    and_i_click_save_and_continue
-    then_i_see_role_start_date_known_field_validation_errors
-
-    when_i_choose_no
-    and_i_click_save_and_continue
-
-    # Are they still employed in that job?
-
-    then_i_see_the_employed_status_page
-    when_i_click_back
-    when_i_choose_yes
-    and_i_click_save_and_continue
-    then_i_see_role_start_date_field_validation_errors
-
-    when_i_choose_yes
-    when_i_fill_out_the_role_start_date_fields
-    and_i_click_save_and_continue
-    then_i_see_the_employed_status_page
-
-    when_i_click_save_and_continue
-    then_i_see_employment_status_field_validation_errors
-
-    when_i_choose_yes
-    and_i_click_save_and_continue
-    then_i_see_the_job_title_page
-
-    when_i_visit_the_employment_status_page
-    when_i_choose_employed
-    and_i_click_save_and_continue
-    then_i_see_the_job_title_page
-
-    when_i_visit_the_employment_status_page
-    when_i_choose_left
-    and_i_click_save_and_continue
-    then_i_see_reason_leaving_role_field_validation_errors
-
-    when_i_visit_the_employment_status_page
-    when_i_choose_left
-    when_i_choose_resigned
-    and_i_click_save_and_continue
-    then_i_see_the_job_title_page
-
-    when_i_visit_the_employment_status_page
-    when_i_choose_left
-    when_i_fill_out_the_role_end_date_fields
-    when_i_choose_resigned
-    and_i_click_save_and_continue
-
-    # What’s their job title?
+    # Their job title
 
     then_i_see_the_job_title_page
 
@@ -85,22 +29,7 @@ RSpec.feature "Teacher role", type: :system do
     when_i_fill_in_the_job_title_field
     when_i_click_save_and_continue
 
-    # Do they work in the same organisation as you?
-
-    then_i_see_the_same_organisation_page
-
-    when_i_click_save_and_continue
-    then_i_see_same_organisation_field_validation_errors
-
-    when_i_choose_no
-    when_i_click_save_and_continue
-    then_i_see_the_duties_page
-
-    when_i_visit_the_same_organisation_page
-    and_i_choose_yes
-    when_i_click_save_and_continue
-
-    # How do you want to tell us about their main duties?
+    # How do you want to give details about their main duties?
 
     then_i_see_the_duties_page
 
@@ -118,25 +47,82 @@ RSpec.feature "Teacher role", type: :system do
     and_i_choose_upload
     and_i_attach_a_job_description_file
     and_i_click_save_and_continue
-    then_i_see_the_teaching_somewhere_else_page
-
-    when_i_visit_the_check_answers_page
-    then_i_see_a_summary_list(duties_description: "File: upload1.pdf")
+    then_i_see_the_same_organisation_page
 
     when_i_visit_the_duties_page
     and_i_see_the_uploaded_filename
     and_i_choose_upload
     and_i_attach_a_second_job_description_file
     and_i_click_save_and_continue
-    then_i_see_the_teaching_somewhere_else_page
-
-    when_i_visit_the_check_answers_page
-    then_i_see_a_summary_list(duties_description: "File: upload2.pdf")
+    then_i_see_the_same_organisation_page
 
     when_i_visit_the_duties_page
     and_i_see_the_second_uploaded_filename
     and_i_choose_details
     when_i_fill_in_the_duties_field
+    and_i_click_save_and_continue
+
+    # Did they work at the same organisation as you at the time of the alleged misconduct?
+
+    then_i_see_the_same_organisation_page
+
+    when_i_click_save_and_continue
+    then_i_see_same_organisation_field_validation_errors
+
+    when_i_choose_yes
+    when_i_click_save_and_continue
+    then_i_see_the_job_start_date_page
+
+    when_i_click_save_and_continue
+    then_i_see_role_start_date_known_field_validation_errors
+
+    when_i_choose_no
+    and_i_click_save_and_continue
+
+    then_i_see_the_employed_status_page
+    when_i_click_back
+    when_i_choose_yes
+    and_i_click_save_and_continue
+    then_i_see_role_start_date_field_validation_errors
+
+    when_i_choose_yes
+    when_i_fill_out_the_role_start_date_fields
+    and_i_click_save_and_continue
+
+    # Are they still employed in that job?
+
+    then_i_see_the_employed_status_page
+
+    when_i_click_save_and_continue
+    then_i_see_employment_status_field_validation_errors
+
+    when_i_choose_yes
+    and_i_click_save_and_continue
+    then_i_see_the_check_answers_page
+
+    when_i_visit_the_employment_status_page
+    when_i_choose_employed
+    and_i_click_save_and_continue
+    then_i_see_the_check_answers_page
+
+    when_i_visit_the_employment_status_page
+    when_i_choose_left
+    and_i_click_save_and_continue
+    then_i_see_the_job_end_date_page
+
+    when_i_click_save_and_continue
+    then_i_see_role_end_date_field_validation_errors
+
+    when_i_choose_yes
+    when_i_fill_out_the_role_end_date_fields
+    and_i_click_save_and_continue
+
+    then_i_see_the_reason_leaving_role_page
+
+    when_i_click_save_and_continue
+    then_i_see_reason_leaving_role_field_validation_errors
+
+    when_i_choose_resigned
     and_i_click_save_and_continue
 
     # Do you know if they are teaching somewhere else
@@ -148,42 +134,38 @@ RSpec.feature "Teacher role", type: :system do
     when_i_choose_no
     when_i_click_save_and_continue
     then_i_see_the_check_answers_page
-    and_i_see_a_summary_list(
-      duties_description: "Main duties",
-      teaching_somewhere_else: "No"
-    )
 
     when_i_visit_the_teaching_somewhere_else_page
     and_i_choose_yes
     when_i_click_save_and_continue
 
-    # Do you know where they are teaching?
+    # Do you know the name and address of the organisation where they’re currently working?
 
-    then_i_see_the_teaching_location_page
+    then_i_see_the_teaching_location_known_page
 
     when_i_click_save_and_continue
     then_i_see_teaching_location_field_validation_errors
 
     when_i_choose_no
     and_i_click_save_and_continue
+    then_i_see_the_check_answers_page
 
-    when_i_visit_the_teaching_location_page
+    when_i_visit_the_teaching_location_known_page
     and_i_choose_yes
+    when_i_click_save_and_continue
+
+    # Where they currently work
+
+    then_i_see_the_teaching_location_page
     when_i_click_save_and_continue
     then_i_see_teaching_location_address_field_validation_errors
 
     when_i_fill_in_the_teaching_address_details
-    and_i_choose_yes
     when_i_click_save_and_continue
 
     # Check and confirm your answers
 
     then_i_see_the_check_answers_page
-    and_i_see_a_summary_list(
-      duties_description: "Main duties",
-      teaching_somewhere_else: "Yes"
-    )
-    and_i_see_a_summary_row_for_teaching_address
 
     when_i_click_save_and_continue
     then_i_see_a_completed_error
@@ -223,6 +205,10 @@ RSpec.feature "Teacher role", type: :system do
     visit edit_referral_teacher_role_teaching_somewhere_else_path(@referral)
   end
 
+  def when_i_visit_the_teaching_location_known_page
+    visit edit_referral_teacher_role_teaching_location_known_path(@referral)
+  end
+
   def when_i_visit_the_teaching_location_page
     visit edit_referral_teacher_role_teaching_location_path(@referral)
   end
@@ -237,25 +223,31 @@ RSpec.feature "Teacher role", type: :system do
     expect(page).to have_current_path(
       edit_referral_teacher_role_employment_status_path(@referral)
     )
-    expect(page).to have_title("Are they still employed in that job?")
-    expect(page).to have_content("Are they still employed in that job?")
+    expect(page).to have_title(
+      "Are they still employed in the job where the alleged misconduct took place?"
+    )
+    expect(page).to have_content(
+      "Are they still employed in the job where the alleged misconduct took place?"
+    )
   end
 
   def then_i_see_the_job_title_page
     expect(page).to have_current_path(
       edit_referral_teacher_role_job_title_path(@referral)
     )
-    expect(page).to have_title("What’s their job title?")
-    expect(page).to have_content("What’s their job title?")
+    expect(page).to have_title("Their job title")
+    expect(page).to have_content("Their job title")
   end
 
   def then_i_see_the_same_organisation_page
     expect(page).to have_current_path(
       edit_referral_teacher_role_same_organisation_path(@referral)
     )
-    expect(page).to have_title("Do they work in the same organisation as you?")
+    expect(page).to have_title(
+      "Did they work at the same organisation as you at the time of the alleged misconduct?"
+    )
     expect(page).to have_content(
-      "Do they work in the same organisation as you?"
+      "Did they work at the same organisation as you at the time of the alleged misconduct?"
     )
   end
 
@@ -264,10 +256,10 @@ RSpec.feature "Teacher role", type: :system do
       edit_referral_teacher_role_duties_path(@referral)
     )
     expect(page).to have_title(
-      "How do you want to tell us about their main duties?"
+      "How do you want to give details about their main duties?"
     )
     expect(page).to have_content(
-      "How do you want to tell us about their main duties?"
+      "How do you want to give details about their main duties?"
     )
   end
 
@@ -279,15 +271,39 @@ RSpec.feature "Teacher role", type: :system do
     expect(page).to have_content("Do you know when they started their job?")
   end
 
+  def then_i_see_the_job_end_date_page
+    expect(page).to have_current_path(
+      edit_referral_teacher_role_end_date_path(@referral)
+    )
+    expect(page).to have_title("Do you know when they left the job?")
+    expect(page).to have_content("Do you know when they left the job?")
+  end
+
+  def then_i_see_the_reason_leaving_role_page
+    expect(page).to have_current_path(
+      edit_referral_teacher_role_reason_leaving_role_path(@referral)
+    )
+    expect(page).to have_title("Reason they left the job")
+    expect(page).to have_content("Reason they left the job")
+  end
+
   def then_i_see_the_teaching_somewhere_else_page
     expect(page).to have_current_path(
       edit_referral_teacher_role_teaching_somewhere_else_path(@referral)
     )
+    expect(page).to have_title("Are they employed somewhere else?")
+    expect(page).to have_content("Are they employed somewhere else?")
+  end
+
+  def then_i_see_the_teaching_location_known_page
+    expect(page).to have_current_path(
+      edit_referral_teacher_role_teaching_location_known_path(@referral)
+    )
     expect(page).to have_title(
-      "Do you know if they are teaching somewhere else?"
+      "Do you know the name and address of the organisation where they’re currently working?"
     )
     expect(page).to have_content(
-      "Do you know if they are teaching somewhere else?"
+      "Do you know the name and address of the organisation where they’re currently working?"
     )
   end
 
@@ -295,8 +311,8 @@ RSpec.feature "Teacher role", type: :system do
     expect(page).to have_current_path(
       edit_referral_teacher_role_teaching_location_path(@referral)
     )
-    expect(page).to have_title("Do you know where they are teaching?")
-    expect(page).to have_content("Do you know where they are teaching?")
+    expect(page).to have_title("Where they currently work")
+    expect(page).to have_content("Where they currently work")
   end
 
   def then_i_see_the_check_answers_page
@@ -323,9 +339,10 @@ RSpec.feature "Teacher role", type: :system do
   def when_i_choose_no
     choose "No", visible: false
   end
+  alias_method :and_i_choose_no, :when_i_choose_no
 
   def when_i_choose_employed
-    choose "They are still employed but they’ve been suspended", visible: false
+    choose "They’re still employed but they’ve been suspended", visible: false
   end
 
   def when_i_choose_left
@@ -337,12 +354,12 @@ RSpec.feature "Teacher role", type: :system do
   end
 
   def when_i_choose_upload
-    choose "I’ll upload a job description", visible: false
+    choose "Upload file", visible: false
   end
   alias_method :and_i_choose_upload, :when_i_choose_upload
 
   def when_i_choose_details
-    choose "I’ll describe their main duties", visible: false
+    choose "Describe their main duties", visible: false
   end
   alias_method :and_i_choose_details, :when_i_choose_details
 
@@ -357,11 +374,11 @@ RSpec.feature "Teacher role", type: :system do
                :when_i_fill_out_the_role_start_date_fields
 
   def when_i_fill_in_the_job_title_field
-    fill_in "What’s their job title?", with: "Teacher"
+    fill_in "Their job title", with: "Teacher"
   end
 
   def when_i_fill_in_the_duties_field
-    fill_in "Describe their main duties", with: "Main duties"
+    fill_in "Description of their main duties", with: "Main duties"
   end
 
   def when_i_fill_in_the_teaching_address_details
@@ -375,14 +392,14 @@ RSpec.feature "Teacher role", type: :system do
 
   def and_i_attach_a_job_description_file
     attach_file(
-      "Upload job description",
+      "Upload file",
       File.absolute_path(Rails.root.join("spec/fixtures/files/upload1.pdf"))
     )
   end
 
   def and_i_attach_a_second_job_description_file
     attach_file(
-      "Upload job description",
+      "Upload file",
       File.absolute_path(Rails.root.join("spec/fixtures/files/upload2.pdf"))
     )
   end
@@ -411,7 +428,7 @@ RSpec.feature "Teacher role", type: :system do
 
   def then_i_see_role_end_date_field_validation_errors
     expect(page).to have_content(
-      "Enter their role end date in the correct format"
+      "Select yes if you know when they left the job"
     )
   end
 
@@ -472,71 +489,6 @@ RSpec.feature "Teacher role", type: :system do
 
   def and_i_see_the_second_uploaded_filename
     expect(page).to have_content("Uploaded file: upload2.pdf")
-  end
-
-  def and_i_see_a_summary_list(duties_description:, teaching_somewhere_else: "")
-    expect_summary_row(
-      key: "Job start date",
-      value: "17 January 1990",
-      change_link:
-        edit_referral_teacher_role_start_date_path(
-          @referral,
-          return_to: current_url
-        )
-    )
-
-    expect_summary_row(
-      key: "Are they still employed in that job?",
-      value: "Left role",
-      change_link:
-        edit_referral_teacher_role_employment_status_path(
-          @referral,
-          return_to: current_url
-        )
-    )
-
-    expect_summary_row(
-      key: "Do they work in the same organisation as you?",
-      value: "Yes",
-      change_link:
-        edit_referral_teacher_role_same_organisation_path(
-          @referral,
-          return_to: current_url
-        )
-    )
-
-    expect_summary_row(
-      key: "About their main duties",
-      value: duties_description,
-      change_link:
-        edit_referral_teacher_role_duties_path(
-          @referral,
-          return_to: current_url
-        )
-    )
-
-    expect_summary_row(
-      key: "Do they teach somewhere else?",
-      value: teaching_somewhere_else,
-      change_link:
-        edit_referral_teacher_role_teaching_somewhere_else_path(
-          @referral,
-          return_to: current_url
-        )
-    )
-  end
-  alias_method :then_i_see_a_summary_list, :and_i_see_a_summary_list
-
-  def and_i_see_a_summary_row_for_teaching_address
-    expect_summary_row(
-      key: "Do you know where they are teaching?",
-      value: "High School\n1428 Elm Street\nLondon\nNW1 4NP",
-      change_link:
-        edit_referral_teacher_role_teaching_location_path(
-          @referral,
-          return_to: current_url
-        )
-    )
   end
 
   def then_i_see_the_status_section_in_the_referral_summary(status: "COMPLETED")


### PR DESCRIPTION
### Context

The "About their role" journey got updated.

### Changes proposed in this pull request

* Reorder pages
* Add pages for end date, organisation address, reason leaving and new working location

### Guidance to review

* I have not addressed the back button issues.
* Accessing pages from the check answer page might not update the flow properly.
* Teaching somewhere else has been renamed to working somewhere else, but I have not updated the files and classes.
* The teacher role system spec doesn't test the content on the check answers page anymore because there are more variations of getting to that page and displaying content differently.

I will address these issues in future PRs.

### Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/iJKIsqQj/1036-update-about-their-role-section)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
