### PR TITLE
Consider preprod a test environment

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module HostingEnvironment
-  TEST_ENVIRONMENTS = %w[local dev test].freeze
+  TEST_ENVIRONMENTS = %w[local dev test preprod].freeze
   PRODUCTION_URL = I18n.t("service.url")
 
   def self.host

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -6,7 +6,7 @@ require "capybara/cuprite"
 Capybara.javascript_driver = :cuprite
 Capybara.always_include_port = false
 
-TEST_ENVIRONMENTS = "local dev test"
+TEST_ENVIRONMENTS = "local dev test preprod"
 
 RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
   it "works as expected" do


### PR DESCRIPTION
Smoke test is currently failing because we switched on the referral form feature in preprod. We expect test environments to have this switched on, and production to have it switched off for now.

Add preprod to the list of test environments.
