### PR TITLE
Remove job title from the public flow

### DIFF
--- a/app/controllers/referrals/referrer_name_controller.rb
+++ b/app/controllers/referrals/referrer_name_controller.rb
@@ -24,7 +24,11 @@ module Referrals
     end
 
     def next_path
-      edit_referral_referrer_job_title_path(current_referral)
+      if current_referral.from_employer?
+        return edit_referral_referrer_job_title_path(current_referral)
+      end
+
+      edit_referral_referrer_phone_path(current_referral)
     end
   end
 end

--- a/spec/system/public_referrals/user_adds_your_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_your_details_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.feature "Public flow: Your details", type: :system do
+  include CommonSteps
+  include SummaryListHelpers
+
+  scenario "adding your details" do
+    given_the_service_is_open
+    and_i_am_signed_in
+    and_the_referral_form_feature_is_active
+    and_i_am_a_member_of_the_public_with_an_existing_referral
+    and_i_visit_the_referral
+    and_i_click_on_the_your_details_task
+    then_i_see_the_your_name_page
+
+    when_i_enter_my_name
+    and_i_click_save_and_continue
+    then_i_see_the_what_is_your_phone_number_page
+  end
+
+  private
+
+  def and_i_click_on_the_your_details_task
+    click_link "Your details"
+  end
+
+  def then_i_see_the_what_is_your_phone_number_page
+    expect(page).to have_current_path(
+      "/referrals/#{@referral.id}/referrer-phone/edit"
+    )
+    expect(page).to have_title(
+      "What is your main contact number? - Refer serious misconduct by a teacher in England"
+    )
+    expect(page).to have_content("What is your main contact number?")
+  end
+
+  def then_i_see_the_your_name_page
+    expect(page).to have_current_path(
+      "/referrals/#{@referral.id}/referrer-name/edit",
+      ignore_query: true
+    )
+    expect(page).to have_title(
+      "What is your name? - Refer serious misconduct by a teacher in England"
+    )
+    expect(page).to have_content("What is your name?")
+  end
+
+  def when_i_click_on_your_details
+    click_link "Your details"
+  end
+
+  def when_i_enter_my_name
+    fill_in "What is your name?", with: "Test Name"
+  end
+end


### PR DESCRIPTION
When someone is referring as a member of the public, we don't need to
collect their job title. It is not relevant.

I considered creating a new route and controller for this flow, as per
the approach in #297.

This seemed overkill as the only difference we have in this particular
case is to change the value of `next_path` for the name controller.

It seems like we're missing an orchestration object where we could
define the questions and their order in a more declarative fashion.

I opted not to do that here as it doesn't seem like the right time to do
it.

Instead, I went for the simplest change possible, which is to use a
conditional statement to determine the next question in the name
controller.

### Link to Trello card

[Trello](https://trello.com/c/FRqOOzVo/1044-s-m-public-form-only-remove-job-title-page)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
