### PR TITLE
Add routing for public form task list

### DIFF
--- a/app/controllers/concerns/referral_paths.rb
+++ b/app/controllers/concerns/referral_paths.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module ReferralPaths
+  extend ActiveSupport::Concern
+
+  def edit_path_for(referral)
+    if referral.from_member_of_public?
+      edit_public_referral_path(referral)
+    else
+      edit_referral_path(referral)
+    end
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,16 +11,25 @@ class PagesController < ApplicationController
   def you_should_know
     @continue_path =
       if FeatureFlags::FeatureFlag.active?(:referral_form)
-        new_referral_path
+        if eligibility_check.reporting_as_public?
+          new_public_referral_path
+        else
+          new_referral_path
+        end
       else
         complete_path
       end
   end
 
   def complete
-    @eligibility_check =
-      EligibilityCheck.find_by(id: session[:eligibility_check_id])
-    return redirect_to(start_path) if @eligibility_check.nil?
+    return redirect_to(start_path) if eligibility_check.nil?
     session[:eligibility_check_id] = nil
+  end
+
+  private
+
+  def eligibility_check
+    @eligibility_check ||=
+      EligibilityCheck.find_by(id: session[:eligibility_check_id])
   end
 end

--- a/app/controllers/public_referrals/personal_details/check_answers_controller.rb
+++ b/app/controllers/public_referrals/personal_details/check_answers_controller.rb
@@ -3,7 +3,7 @@ module PublicReferrals
     class CheckAnswersController < Referrals::PersonalDetails::CheckAnswersController
       def back_link
         session[:return_to] ||
-          edit_public_referrals_personal_details_name_path(current_referral)
+          edit_public_referral_personal_details_name_path(current_referral)
       end
     end
   end

--- a/app/controllers/public_referrals/personal_details/name_controller.rb
+++ b/app/controllers/public_referrals/personal_details/name_controller.rb
@@ -2,13 +2,13 @@ module PublicReferrals
   module PersonalDetails
     class NameController < Referrals::PersonalDetails::NameController
       def next_path
-        edit_public_referrals_personal_details_check_answers_path(
+        edit_public_referral_personal_details_check_answers_path(
           current_referral
         )
       end
 
       def update_path
-        public_referrals_personal_details_name_path(current_referral)
+        public_referral_personal_details_name_path(current_referral)
       end
     end
   end

--- a/app/controllers/public_referrals_controller.rb
+++ b/app/controllers/public_referrals_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class PublicReferralsController < ReferralsController
+  def new
+    super
+    @create_path = public_referrals_path
+  end
+end

--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -13,7 +13,8 @@ module Referrals
     private
 
     def current_referral
-      @current_referral ||= current_user.referrals.find(params[:referral_id])
+      id = params[:referral_id] || params[:public_referral_id]
+      @current_referral ||= current_user.referrals.find(id)
     end
     helper_method :current_referral
 

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -1,18 +1,20 @@
 class ReferralsController < Referrals::BaseController
+  include ReferralPaths
+
   before_action :check_referral_form_feature_flag_enabled
   before_action :redirect_to_referral_if_exists, only: %i[new create]
   before_action :redirect_to_screener_if_no_id_in_session, only: %i[new create]
 
   def new
+    @create_path = referrals_path
   end
 
   def create
-    eligibility_check =
-      EligibilityCheck.find_by!(id: session.delete(:eligibility_check_id))
-    referral =
-      current_user.referrals.create!(eligibility_check_id: eligibility_check.id)
-
-    redirect_to edit_referral_path(referral)
+    new_referral =
+      current_user.create_referral!(
+        eligibility_check_id: session.delete(:eligibility_check_id)
+      )
+    redirect_to edit_path_for(new_referral)
   end
 
   def edit
@@ -45,7 +47,7 @@ class ReferralsController < Referrals::BaseController
   def redirect_to_referral_if_exists
     latest_referral = current_user.latest_referral
 
-    redirect_to edit_referral_path(latest_referral) if latest_referral
+    redirect_to edit_path_for(latest_referral) if latest_referral
   end
 
   def referral

--- a/app/controllers/support_interface/test_users_controller.rb
+++ b/app/controllers/support_interface/test_users_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module SupportInterface
   class TestUsersController < SupportInterfaceController
+    include ReferralPaths
+
     before_action :redirect_unless_test_environment
 
     def index
@@ -31,7 +33,7 @@ module SupportInterface
     def after_sign_in_path
       latest_referral = current_user.latest_referral
 
-      latest_referral ? edit_referral_path(latest_referral) : who_path
+      latest_referral ? edit_path_for(latest_referral) : who_path
     end
   end
 end

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -1,4 +1,6 @@
 class Users::OtpController < DeviseController
+  include ReferralPaths
+
   prepend_before_action :require_no_authentication, only: %i[new create]
   prepend_before_action :allow_params_authentication!, only: :create
   prepend_before_action(only: [:create]) do
@@ -57,7 +59,7 @@ class Users::OtpController < DeviseController
   def latest_referral_path(resource)
     latest_referral = resource.latest_referral
 
-    latest_referral ? edit_referral_path(latest_referral) : who_path
+    latest_referral ? edit_path_for(latest_referral) : who_path
   end
 
   def user_params

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -25,7 +25,7 @@ module ReferralHelper
   end
 
   def subsection_path(referral:, subsection:, action: nil, return_to: nil)
-    referrer_scope = referral.from_employer? ? "referral" : "public_referrals"
+    referrer_scope = referral.from_employer? ? "referral" : "public_referral"
     path_name = [action, referrer_scope, subsection, "path"].compact_blank.join(
       "_"
     )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,4 +31,9 @@ class User < ApplicationRecord
     secret_key = Devise::Otp.generate_key
     update(secret_key:, otp_created_at: Time.zone.now)
   end
+
+  def create_referral!(eligibility_check_id:)
+    eligibility_check = EligibilityCheck.find_by!(id: eligibility_check_id)
+    referrals.create!(eligibility_check_id: eligibility_check.id)
+  end
 end

--- a/app/views/referrals/new.html.erb
+++ b/app/views/referrals/new.html.erb
@@ -6,6 +6,6 @@
       <h1 class="govuk-heading-l">Your progress is saved as you go</h1>
       <p>You don’t have to complete your referral in a single session. Your answers will automatically be saved and you can return at any time by logging back in.</p>
       <p class="govuk-!-margin-bottom-6">We’ll send you an email with a link to access your referral.</p>
-      <%= govuk_button_to('Continue', referrals_path, method: :post) %>
+      <%= govuk_button_to('Continue', @create_path, method: :post) %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,8 @@ Rails.application.routes.draw do
 
   root to: redirect("/start")
 
+  resources :public_referrals, except: %i[index show], path: "public-referrals"
+
   resources :referrals, except: %i[index show] do
     get "/delete", to: "referrals#delete", on: :member
     get "/deleted", to: "referrals#deleted", on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,13 +69,22 @@ Rails.application.routes.draw do
 
   root to: redirect("/start")
 
-  resources :public_referrals, except: %i[index show], path: "public-referrals"
+  resources :public_referrals,
+            except: %i[index show],
+            path: "public-referrals" do
+    scope module: :public_referrals do
+      namespace :personal_details, path: "personal-details" do
+        resource :name, only: %i[edit update], controller: :name
+        resource :check_answers, path: "check-answers", only: %i[edit update]
+      end
+    end
+  end
 
   resources :referrals, except: %i[index show] do
     get "/delete", to: "referrals#delete", on: :member
     get "/deleted", to: "referrals#deleted", on: :collection
 
-    scope module: "referrals" do
+    scope module: :referrals do
       namespace :personal_details, path: "personal-details" do
         resource :name, only: %i[edit update], controller: :name
         resource :age, only: %i[edit update], controller: :age
@@ -174,13 +183,6 @@ Rails.application.routes.draw do
       resource :declaration, only: %i[show create], controller: :declaration
       resource :confirmation, only: %i[show], controller: :confirmation
       resource :review, only: %i[show], controller: :review
-    end
-  end
-
-  namespace :public_referrals, path: "public-referrals/:referral_id" do
-    namespace :personal_details, path: "personal-details" do
-      resource :name, only: %i[edit update], controller: :name
-      resource :check_answers, path: "check-answers", only: %i[edit update]
     end
   end
 

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -40,12 +40,25 @@ module CommonSteps
   end
   alias_method :when_i_visit_the_referral, :and_i_visit_the_referral
 
+  def and_i_visit_the_public_referral
+    visit edit_public_referral_path(@referral)
+  end
+  alias_method :when_i_visit_the_public_referral,
+               :and_i_visit_the_public_referral
+
   def then_i_see_the_referral_summary
     expect(page).to have_current_path(edit_referral_path(@referral))
     expect(page).to have_title(
       "Refer serious misconduct by a teacher in England"
     )
     expect(page).to have_content("Your allegation of serious misconduct")
+  end
+
+  def then_i_see_the_public_referral_summary
+    expect(page).to have_current_path(edit_public_referral_path(@referral))
+    expect(page).to have_title(
+      "Refer serious misconduct by a teacher in England"
+    )
   end
 
   def when_i_click_save_and_continue

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -8,6 +8,10 @@ module CommonSteps
     sign_in(@user)
   end
 
+  def when_i_visit_the_service
+    visit root_path
+  end
+
   def and_the_referral_form_feature_is_active
     FeatureFlags::FeatureFlag.activate(:referral_form)
   end

--- a/spec/system/public_referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_personal_details_spec.rb
@@ -10,8 +10,8 @@ RSpec.feature "Personal details", type: :system do
     and_i_am_signed_in
     and_the_referral_form_feature_is_active
     and_i_am_a_member_of_the_public_with_an_existing_referral
-    and_i_visit_the_referral
-    then_i_see_the_referral_summary
+    and_i_visit_the_public_referral
+    then_i_see_the_public_referral_summary
 
     when_i_edit_personal_details
     and_i_am_asked_their_name
@@ -66,7 +66,7 @@ RSpec.feature "Personal details", type: :system do
       key: "Name",
       value: "Jane Smith",
       change_link:
-        edit_public_referrals_personal_details_name_path(
+        edit_public_referral_personal_details_name_path(
           @referral,
           return_to: current_url
         )

--- a/spec/system/screener/user_completes_eligibility_screener_as_employer_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_as_employer_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Eligibility screener", type: :system do
+  include CommonSteps
+
+  scenario "User completes eligibility screener as employer" do
+    given_the_service_is_open
+    and_the_eligibility_screener_feature_is_active
+    and_the_referral_form_feature_is_active
+    and_i_am_signed_in
+    when_i_visit_the_service
+
+    when_i_press_start
+    then_i_can_complete_the_screener_as_an_employer
+    and_i_have_started_an_employer_referral
+  end
+
+  private
+
+  def when_i_press_start
+    click_on "Start now"
+  end
+
+  def then_i_can_complete_the_screener_as_an_employer
+    choose "I’m referring as an employer", visible: false
+    click_on "Continue"
+
+    4.times do
+      choose "I’m not sure", visible: false
+      click_on "Continue"
+    end
+
+    expect(page).to have_content "What completing this referral means for you"
+    click_on "Continue"
+    expect(page).to have_content "Your progress is saved as you go"
+    click_on "Continue"
+  end
+
+  def and_i_have_started_an_employer_referral
+    referral = @user.latest_referral
+
+    expect(page).to have_current_path edit_referral_path(referral)
+    expect(referral).to be_from_employer
+  end
+end

--- a/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.feature "Eligibility screener", type: :system do
   include CommonSteps
 
-  scenario "User completes eligibility screener" do
+  scenario "User completes eligibility screener as member of public" do
     given_the_service_is_open
     and_the_eligibility_screener_feature_is_active
     and_the_referral_form_feature_is_active

--- a/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
@@ -270,9 +270,9 @@ RSpec.feature "Eligibility screener", type: :system do
   end
 
   def then_i_have_started_a_member_of_public_referral
-    referral = User.last.latest_referral
+    referral = @user.latest_referral
 
-    expect(page).to have_current_path edit_referral_path(referral)
+    expect(page).to have_current_path edit_public_referral_path(referral)
     expect(referral).to be_from_member_of_public
   end
 end


### PR DESCRIPTION
### Context

Prior to adding the public form task list as a hub for the various sections, we need to ensure we're directing users down the correct routes depending on the type of referral they're completing.

### Changes proposed in this pull request

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->
Going through the screener results in either a public or employer
referral being created. This commit ensures that referrals are
handled by separate public or employer controllers. This structure is
being trialled so we can assess ways to deal with the complexity of two
distinct journeys that share many of the same steps.

Key changes:

- Add a PublicReferralsController that inherits from the existing
  ReferralsController
- Add a helper to pick the correct edit route for redirects
- Ensure we end up on the correct new referral page immediately after
  the screener

See full commit list for other, related changes.
### Guidance to review

The system specs outline the intended behaviour, but this can be tested locally by completing the screener with both employer and public referrals. These should lead to task lists sitting at  `/referrals/:id/edit` and `/public-referrals/:id/edit` paths, respectively.

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/SiOxJOXb
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
