### PR TITLE
Don't show employer form section items on public form hub page

### DIFF
--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -32,78 +32,99 @@ class ReferralForm
   end
 
   def about_you_section
-    ReferralSection.new(
-      1,
-      I18n.t("referral_form.about_you"),
-      [
-        ReferralSectionItem.new(
-          I18n.t("referral_form.your_details"),
-          edit_referral_referrer_name_path(referral),
-          referral.referrer_status
-        ),
-        ReferralSectionItem.new(
-          I18n.t("referral_form.your_organisation"),
-          edit_referral_organisation_name_path(referral),
-          referral.organisation_status
-        )
-      ]
-    )
+    ReferralSection
+      .new(1, I18n.t("referral_form.about_you"))
+      .tap do |section|
+        section.items = [
+          ReferralSectionItem.new(
+            I18n.t("referral_form.your_details"),
+            edit_referral_referrer_name_path(referral),
+            referral.referrer_status
+          )
+        ]
+
+        if referral.from_employer?
+          section.items.append(
+            ReferralSectionItem.new(
+              I18n.t("referral_form.your_organisation"),
+              edit_referral_organisation_name_path(referral),
+              referral.organisation_status
+            )
+          )
+        end
+      end
   end
 
   def about_the_person_you_are_referring_section
-    ReferralSection.new(
-      2,
-      I18n.t("referral_form.about_the_person_you_are_referring"),
-      [
-        ReferralSectionItem.new(
-          I18n.t("referral_form.personal_details"),
-          subsection_path(
-            referral:,
-            subsection: :personal_details_name,
-            action: :edit
-          ),
-          section_status(:personal_details_complete)
-        ),
-        ReferralSectionItem.new(
-          I18n.t("referral_form.contact_details"),
-          edit_referral_contact_details_email_path(referral),
-          section_status(:contact_details_complete)
-        ),
-        ReferralSectionItem.new(
-          I18n.t("referral_form.about_their_role"),
-          edit_referral_teacher_role_start_date_path(referral),
-          section_status(:teacher_role_complete)
+    ReferralSection
+      .new(2, I18n.t("referral_form.about_the_person_you_are_referring"))
+      .tap do |section|
+        section.items = [
+          ReferralSectionItem.new(
+            I18n.t("referral_form.personal_details"),
+            subsection_path(
+              referral:,
+              subsection: :personal_details_name,
+              action: :edit
+            ),
+            section_status(:personal_details_complete)
+          )
+        ]
+
+        if referral.from_employer?
+          section.items.append(
+            ReferralSectionItem.new(
+              I18n.t("referral_form.contact_details"),
+              edit_referral_contact_details_email_path(referral),
+              section_status(:contact_details_complete)
+            )
+          )
+        end
+
+        section.items.append(
+          ReferralSectionItem.new(
+            I18n.t("referral_form.about_their_role"),
+            edit_referral_teacher_role_start_date_path(referral),
+            section_status(:teacher_role_complete)
+          )
         )
-      ]
-    )
+      end
   end
 
   def the_allegation_section
-    ReferralSection.new(
-      3,
-      I18n.t("referral_form.the_allegation"),
-      [
-        ReferralSectionItem.new(
-          I18n.t("referral_form.details_of_the_allegation"),
-          edit_referral_allegation_details_path(referral),
-          section_status(:allegation_details_complete)
-        ),
-        ReferralSectionItem.new(
-          I18n.t("referral_form.previous_allegations"),
-          edit_referral_previous_misconduct_reported_path(referral),
-          referral.previous_misconduct_status
-        ),
-        ReferralSectionItem.new(
-          I18n.t("referral_form.evidence_and_supporting_information"),
-          path_for_section_status(
-            section_status(:evidence_details_complete),
-            edit_referral_evidence_start_path(referral),
-            edit_referral_evidence_check_answers_path(referral)
-          ),
-          section_status(:evidence_details_complete)
+    ReferralSection
+      .new(3, I18n.t("referral_form.the_allegation"))
+      .tap do |section|
+        section.items = [
+          ReferralSectionItem.new(
+            I18n.t("referral_form.details_of_the_allegation"),
+            edit_referral_allegation_details_path(referral),
+            section_status(:allegation_details_complete)
+          )
+        ]
+
+        if referral.from_employer?
+          section.items.append(
+            ReferralSectionItem.new(
+              I18n.t("referral_form.previous_allegations"),
+              edit_referral_previous_misconduct_reported_path(referral),
+              referral.previous_misconduct_status
+            )
+          )
+        end
+
+        section.items.append(
+          ReferralSectionItem.new(
+            I18n.t("referral_form.evidence_and_supporting_information"),
+            path_for_section_status(
+              section_status(:evidence_details_complete),
+              edit_referral_evidence_start_path(referral),
+              edit_referral_evidence_check_answers_path(referral)
+            ),
+            section_status(:evidence_details_complete)
+          )
         )
-      ]
-    )
+      end
   end
 
   def section_status(section_complete_method)

--- a/spec/forms/referral_form_spec.rb
+++ b/spec/forms/referral_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ReferralForm do
-  describe "save" do
+  describe "#save" do
     subject(:save) { form.save }
 
     let(:form) { described_class.new(referral:) }
@@ -13,6 +13,54 @@ RSpec.describe ReferralForm do
       let(:referral) { create(:referral, :complete) }
 
       it { is_expected.to be_truthy }
+    end
+  end
+
+  describe "#sections" do
+    subject(:sections) { form.sections }
+
+    let(:form) { described_class.new(referral:) }
+
+    context "when referral is from employer" do
+      let(:referral) { create(:referral) }
+
+      it "returns employer form section items" do
+        labels = sections.flat_map(&:items).pluck(:label)
+        expect(labels).to eq(
+          [
+            "Your details",
+            "Your organisation",
+            "Personal details",
+            "Contact details",
+            "About their role",
+            "Details of the allegation",
+            "Previous allegations",
+            "Evidence and supporting information"
+          ]
+        )
+      end
+    end
+
+    context "when referral is from member of public" do
+      let(:referral) do
+        create(
+          :referral,
+          eligibility_check: create(:eligibility_check, :public)
+        )
+      end
+
+      it "returns public form section items" do
+        labels = sections.flat_map(&:items).pluck(:label)
+        expect(labels).to eq(
+          [
+            "Your details",
+            "Personal details",
+            "About their role",
+            "Details of the allegation",
+            "Evidence and supporting information"
+          ]
+        )
+      end
     end
   end
 end


### PR DESCRIPTION

### Context
The task list on the public form hub page has fewer section items than the employer form.

<!-- Why are you making this change? -->

### Changes proposed in this pull request
 Add conditional checks to ReferralForm so that we only show those that are relevant.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/SiOxJOXb
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
