### PR TITLE
Public form evidence flow

### DIFF
--- a/app/controllers/public_referrals/evidence/check_answers_controller.rb
+++ b/app/controllers/public_referrals/evidence/check_answers_controller.rb
@@ -1,0 +1,6 @@
+module PublicReferrals
+  module Evidence
+    class CheckAnswersController < Referrals::Evidence::CheckAnswersController
+    end
+  end
+end

--- a/app/controllers/public_referrals/evidence/start_controller.rb
+++ b/app/controllers/public_referrals/evidence/start_controller.rb
@@ -1,0 +1,6 @@
+module PublicReferrals
+  module Evidence
+    class StartController < Referrals::Evidence::StartController
+    end
+  end
+end

--- a/app/controllers/public_referrals/evidence/upload_controller.rb
+++ b/app/controllers/public_referrals/evidence/upload_controller.rb
@@ -1,0 +1,6 @@
+module PublicReferrals
+  module Evidence
+    class UploadController < Referrals::Evidence::UploadController
+    end
+  end
+end

--- a/app/controllers/public_referrals/evidence/uploaded_controller.rb
+++ b/app/controllers/public_referrals/evidence/uploaded_controller.rb
@@ -1,0 +1,6 @@
+module PublicReferrals
+  module Evidence
+    class UploadedController < Referrals::Evidence::UploadedController
+    end
+  end
+end

--- a/app/controllers/referrals/evidence/check_answers_controller.rb
+++ b/app/controllers/referrals/evidence/check_answers_controller.rb
@@ -34,21 +34,20 @@ module Referrals
         evidence.document.purge
         evidence.destroy
 
+        subsection =
+          (
+            if current_referral.evidences.any?
+              :evidence_uploaded
+            else
+              :evidence_upload
+            end
+          )
         redirect_path =
-          if current_referral.evidences.any?
-            subsection_path(
-              referral: current_referral,
-              action: :edit,
-              subsection: :evidence_uploaded
-            )
-          else
-            subsection_path(
-              referral: current_referral,
-              action: :edit,
-              subsection: :evidence_upload
-            )
-          end
-
+          subsection_path(
+            referral: current_referral,
+            action: :edit,
+            subsection:
+          )
         redirect_to(redirect_path, flash: { success: "#{filename} deleted" })
       end
 

--- a/app/controllers/referrals/evidence/check_answers_controller.rb
+++ b/app/controllers/referrals/evidence/check_answers_controller.rb
@@ -1,6 +1,8 @@
 module Referrals
   module Evidence
     class CheckAnswersController < Referrals::BaseController
+      include ReferralHelper
+
       def edit
         @evidence_check_answers_form =
           CheckAnswersForm.new(
@@ -16,7 +18,9 @@ module Referrals
           )
 
         if @evidence_check_answers_form.save
-          redirect_to edit_referral_path(current_referral)
+          redirect_to(
+            subsection_path(referral: current_referral, action: :edit)
+          )
         else
           render :edit
         end
@@ -32,9 +36,17 @@ module Referrals
 
         redirect_path =
           if current_referral.evidences.any?
-            edit_referral_evidence_uploaded_path(current_referral)
+            subsection_path(
+              referral: current_referral,
+              action: :edit,
+              subsection: :evidence_uploaded
+            )
           else
-            edit_referral_evidence_upload_path(current_referral)
+            subsection_path(
+              referral: current_referral,
+              action: :edit,
+              subsection: :evidence_upload
+            )
           end
 
         redirect_to(redirect_path, flash: { success: "#{filename} deleted" })

--- a/app/controllers/referrals/evidence/start_controller.rb
+++ b/app/controllers/referrals/evidence/start_controller.rb
@@ -1,6 +1,8 @@
 module Referrals
   module Evidence
     class StartController < Referrals::BaseController
+      include ReferralHelper
+
       def edit
         @evidence_start_form =
           StartForm.new(has_evidence: current_referral.has_evidence)
@@ -11,14 +13,21 @@ module Referrals
           StartForm.new(start_params.merge(referral: current_referral))
 
         if @evidence_start_form.save
-          if @evidence_start_form.has_evidence
-            redirect_to edit_referral_evidence_upload_path(current_referral)
-          else
-            current_referral.update(evidences: [])
-            redirect_to edit_referral_evidence_check_answers_path(
-                          current_referral
-                        )
-          end
+          redirect_path =
+            if @evidence_start_form.has_evidence
+              subsection_path(
+                referral: current_referral,
+                action: :edit,
+                subsection: :evidence_upload
+              )
+            else
+              subsection_path(
+                referral: current_referral,
+                action: :edit,
+                subsection: :evidence_check_answers
+              )
+            end
+          redirect_to redirect_path
         else
           render :edit
         end

--- a/app/controllers/referrals/evidence/upload_controller.rb
+++ b/app/controllers/referrals/evidence/upload_controller.rb
@@ -1,6 +1,8 @@
 module Referrals
   module Evidence
     class UploadController < Referrals::BaseController
+      include ReferralHelper
+
       def edit
         @evidence_upload_form = UploadForm.new(referral: current_referral)
       end
@@ -10,7 +12,13 @@ module Referrals
           UploadForm.new(upload_params.merge(referral: current_referral))
 
         if @evidence_upload_form.save
-          redirect_to edit_referral_evidence_uploaded_path(current_referral)
+          redirect_to(
+            subsection_path(
+              referral: current_referral,
+              action: :edit,
+              subsection: :evidence_uploaded
+            )
+          )
         else
           render :edit
         end

--- a/app/controllers/referrals/evidence/uploaded_controller.rb
+++ b/app/controllers/referrals/evidence/uploaded_controller.rb
@@ -11,11 +11,12 @@ module Referrals
         @uploaded_form = UploadedForm.new(more_evidence_params)
 
         if @uploaded_form.valid?
-          subsection = if @uploaded_form.more_evidence?
-            :evidence_upload
-          else
-            :evidence_check_answers
-          end
+          subsection =
+            if @uploaded_form.more_evidence?
+              :evidence_upload
+            else
+              :evidence_check_answers
+            end
 
           redirect_to(
             subsection_path(

--- a/app/controllers/referrals/evidence/uploaded_controller.rb
+++ b/app/controllers/referrals/evidence/uploaded_controller.rb
@@ -1,6 +1,8 @@
 module Referrals
   module Evidence
     class UploadedController < Referrals::BaseController
+      include ReferralHelper
+
       def edit
         @uploaded_form = UploadedForm.new
       end
@@ -9,13 +11,19 @@ module Referrals
         @uploaded_form = UploadedForm.new(more_evidence_params)
 
         if @uploaded_form.valid?
-          if @uploaded_form.more_evidence?
-            redirect_to edit_referral_evidence_upload_path(current_referral)
+          subsection = if @uploaded_form.more_evidence?
+            :evidence_upload
           else
-            redirect_to edit_referral_evidence_check_answers_path(
-                          current_referral
-                        )
+            :evidence_check_answers
           end
+
+          redirect_to(
+            subsection_path(
+              referral: current_referral,
+              action: :edit,
+              subsection:
+            )
+          )
         else
           render :edit
         end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -92,39 +92,47 @@ class ReferralForm
   end
 
   def the_allegation_section
-    ReferralSection.new(
-      3,
-      I18n.t("referral_form.the_allegation"),
-      [
-        ReferralSectionItem.new(
-          I18n.t("referral_form.details_of_the_allegation"),
-          edit_referral_allegation_details_path(referral),
-          section_status(:allegation_details_complete)
-        ),
-        ReferralSectionItem.new(
-          I18n.t("referral_form.previous_allegations"),
-          edit_referral_previous_misconduct_reported_path(referral),
-          referral.previous_misconduct_status
-        ),
-        ReferralSectionItem.new(
-          I18n.t("referral_form.evidence_and_supporting_information"),
-          path_for_section_status(
-            section_status(:evidence_details_complete),
-            subsection_path(
-              referral:,
-              action: :edit,
-              subsection: :evidence_start
-            ),
-            subsection_path(
-              referral:,
-              action: :edit,
-              subsection: :evidence_check_answers
+    ReferralSection
+      .new(3, I18n.t("referral_form.the_allegation"))
+      .tap do |section|
+        section.items = [
+          ReferralSectionItem.new(
+            I18n.t("referral_form.details_of_the_allegation"),
+            edit_referral_allegation_details_path(referral),
+            section_status(:allegation_details_complete)
+          )
+        ]
+
+        if referral.from_employer?
+          section.items.append(
+            ReferralSectionItem.new(
+              I18n.t("referral_form.previous_allegations"),
+              edit_referral_previous_misconduct_reported_path(referral),
+              referral.previous_misconduct_status
             )
-          ),
-          section_status(:evidence_details_complete)
+          )
+        end
+
+        section.items.append(
+          ReferralSectionItem.new(
+            I18n.t("referral_form.evidence_and_supporting_information"),
+            path_for_section_status(
+              section_status(:evidence_details_complete),
+              subsection_path(
+                referral:,
+                action: :edit,
+                subsection: :evidence_start
+              ),
+              subsection_path(
+                referral:,
+                action: :edit,
+                subsection: :evidence_check_answers
+              )
+            ),
+            section_status(:evidence_details_complete)
+          )
         )
-      ]
-    )
+      end
   end
 
   def section_status(section_complete_method)

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -92,39 +92,39 @@ class ReferralForm
   end
 
   def the_allegation_section
-    ReferralSection
-      .new(3, I18n.t("referral_form.the_allegation"))
-      .tap do |section|
-        section.items = [
-          ReferralSectionItem.new(
-            I18n.t("referral_form.details_of_the_allegation"),
-            edit_referral_allegation_details_path(referral),
-            section_status(:allegation_details_complete)
-          )
-        ]
-
-        if referral.from_employer?
-          section.items.append(
-            ReferralSectionItem.new(
-              I18n.t("referral_form.previous_allegations"),
-              edit_referral_previous_misconduct_reported_path(referral),
-              referral.previous_misconduct_status
-            )
-          )
-        end
-
-        section.items.append(
-          ReferralSectionItem.new(
-            I18n.t("referral_form.evidence_and_supporting_information"),
-            path_for_section_status(
-              section_status(:evidence_details_complete),
-              edit_referral_evidence_start_path(referral),
-              edit_referral_evidence_check_answers_path(referral)
+    ReferralSection.new(
+      3,
+      I18n.t("referral_form.the_allegation"),
+      [
+        ReferralSectionItem.new(
+          I18n.t("referral_form.details_of_the_allegation"),
+          edit_referral_allegation_details_path(referral),
+          section_status(:allegation_details_complete)
+        ),
+        ReferralSectionItem.new(
+          I18n.t("referral_form.previous_allegations"),
+          edit_referral_previous_misconduct_reported_path(referral),
+          referral.previous_misconduct_status
+        ),
+        ReferralSectionItem.new(
+          I18n.t("referral_form.evidence_and_supporting_information"),
+          path_for_section_status(
+            section_status(:evidence_details_complete),
+            subsection_path(
+              referral:,
+              action: :edit,
+              subsection: :evidence_start
             ),
-            section_status(:evidence_details_complete)
-          )
+            subsection_path(
+              referral:,
+              action: :edit,
+              subsection: :evidence_check_answers
+            )
+          ),
+          section_status(:evidence_details_complete)
         )
-      end
+      ]
+    )
   end
 
   def section_status(section_complete_method)

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -18,7 +18,7 @@ module ReferralHelper
     end
   end
 
-  def subsection_path(referral:, subsection:, action: nil, return_to: nil)
+  def subsection_path(referral:, subsection: nil, action: nil, return_to: nil)
     referrer_scope = referral.from_employer? ? "referral" : "public_referral"
     path_name = [action, referrer_scope, subsection, "path"].compact_blank.join(
       "_"

--- a/app/views/public_referrals/evidence/check_answers/edit.html.erb
+++ b/app/views/public_referrals/evidence/check_answers/edit.html.erb
@@ -1,0 +1,34 @@
+<% content_for :page_title, "#{'Error: ' if @evidence_check_answers_form.errors.any?}Check and confirm your answers" %>
+<% content_for :back_link_url, return_to_session_or(edit_public_referral_evidence_uploaded_path(current_referral)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l">Evidence and supporting information</span>
+      Check and confirm your answers
+    </h1>
+
+    <%= govuk_button_to(
+      "Add more evidence",
+      edit_public_referral_evidence_upload_path(current_referral),
+      method: "get",
+      class: "govuk-button--secondary govuk-!-margin-bottom-8"
+    ) %>
+
+    <%= render EvidenceComponent.new(referral: current_referral) %>
+
+    <%= form_with model: @evidence_check_answers_form, url: public_referral_evidence_check_answers_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(
+        :evidence_details_complete,
+        legend: { text: "Have you completed this section?", size: "m" },
+        hint: { text: "You can still make changes to a completed section" },
+      ) do %>
+        <%= f.govuk_radio_button :evidence_details_complete, "true", label: { text: "Yes, I’ve completed this section" } %>
+        <%= f.govuk_radio_button :evidence_details_complete, "false", label: { text: "No, I’ll come back to it later" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/public_referrals/evidence/check_answers/edit.html.erb
+++ b/app/views/public_referrals/evidence/check_answers/edit.html.erb
@@ -13,7 +13,7 @@
       edit_public_referral_evidence_upload_path(current_referral),
       method: "get",
       class: "govuk-button--secondary govuk-!-margin-bottom-8"
-    ) %>
+    ) if current_referral.has_evidence %>
 
     <%= render EvidenceComponent.new(referral: current_referral) %>
 

--- a/app/views/public_referrals/evidence/start/edit.html.erb
+++ b/app/views/public_referrals/evidence/start/edit.html.erb
@@ -1,0 +1,34 @@
+<% content_for :page_title, "#{'Error: ' if @evidence_start_form.errors.any?}Evidence and supporting information" %>
+<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <h1 class="govuk-heading-l">
+      Evidence and supporting information
+    </h1>
+
+    <p>For example:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>complaint made to the school</li>
+      <li>correspondence with the school</li>
+      <li>school complaints policy</li>
+      <li>complaint made to the police</li>
+      <li>complaint made to the local authority or any other agency or body</li>
+      <li>signed witness statements</li>
+    </ul>
+
+    <%= form_with model: @evidence_start_form, url: public_referral_evidence_start_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(
+        :has_evidence,
+        legend: { text: "Do you have evidence to upload?", size: "m" },
+      ) do %>
+        <%= f.govuk_radio_button :has_evidence, "true", label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :has_evidence, "false", label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/public_referrals/evidence/start/edit.html.erb
+++ b/app/views/public_referrals/evidence/start/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_start_form.errors.any?}Evidence and supporting information" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(edit_public_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/public_referrals/evidence/upload/edit.html.erb
+++ b/app/views/public_referrals/evidence/upload/edit.html.erb
@@ -1,0 +1,42 @@
+<% content_for :page_title, "#{'Error: ' if @evidence_upload_form.errors.any?}Upload evidence and supporting information" %>
+<% content_for :back_link_url, return_to_session_or(edit_public_referral_evidence_start_path(current_referral)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <span class="govuk-caption-l">Evidence and supporting information</span>
+    <h1 class="govuk-heading-l">Upload evidence</h1>
+
+    <p>For example:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>complaint made to the school</li>
+      <li>correspondence with the school</li>
+      <li>school complaints policy</li>
+      <li>complaint made to the police</li>
+      <li>complaint made to the local authority or any other agency or body</li>
+      <li>signed witness statements</li>
+    </ul>
+
+    <p>Make sure the file names describe the content, for example ‘signed witness statement’.</p>
+
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive"></span>
+        Do not include explicit content, for example indecent photos. You’ll be asked for these separately if needed.
+      </strong>
+    </div>
+
+    <%= form_with model: @evidence_upload_form, url: public_referral_evidence_upload_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_file_field(
+          :evidence_uploads,
+          multiple: true,
+          label: { text: "Upload files", size: "m" }
+      ) %>
+
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/public_referrals/evidence/uploaded/edit.html.erb
+++ b/app/views/public_referrals/evidence/uploaded/edit.html.erb
@@ -1,0 +1,38 @@
+<% content_for :page_title, "Uploaded evidence" %>
+<% content_for :back_link_url, return_to_session_or(edit_public_referral_evidence_upload_path(current_referral)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop ">
+    <span class="govuk-caption-l">Evidence and supporting information</span>
+    <h1 class="govuk-heading-l">Uploaded evidence</h1>
+    <h2 class="govuk-heading-m">Files added</h2>
+
+    <dl class="govuk-summary-list">
+      <% current_referral.evidences.each_with_index do |evidence, idx| %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            File <%= idx + 1 %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= govuk_link_to(evidence.filename, rails_blob_path(evidence.document, disposition: "attachment")) %>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <%= govuk_link_to(referral_evidence_delete_path(current_referral, evidence, return_to: request.url)) do %>
+              Delete<span class="govuk-visually-hidden"> <%= evidence.filename %></span>
+            <% end %>
+          </dd>
+        </div>
+        </li>
+      <% end %>
+    </dl>
+
+    <%= form_with url: edit_public_referral_evidence_uploaded_path(current_referral), method: :get do |f| %>
+      <%= f.govuk_radio_buttons_fieldset(:more_evidence, legend: { size: "m", text: "Do you have evidence to upload?" }) do %>
+        <%= f.govuk_radio_button :more_evidence, "yes", label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :more_evidence, "no", label: { text: "No" } %>
+      <% end %>
+
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/public_referrals/evidence/uploaded/edit.html.erb
+++ b/app/views/public_referrals/evidence/uploaded/edit.html.erb
@@ -26,8 +26,10 @@
       <% end %>
     </dl>
 
-    <%= form_with url: edit_public_referral_evidence_uploaded_path(current_referral), method: :get do |f| %>
-      <%= f.govuk_radio_buttons_fieldset(:more_evidence, legend: { size: "m", text: "Do you have evidence to upload?" }) do %>
+    <%= form_with model: @uploaded_form, url: public_referral_evidence_uploaded_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(:more_evidence, legend: { size: "m", text: "Do you want to upload another file?" }) do %>
         <%= f.govuk_radio_button :more_evidence, "yes", label: { text: "Yes" } %>
         <%= f.govuk_radio_button :more_evidence, "no", label: { text: "No" } %>
       <% end %>

--- a/app/views/referrals/evidence/check_answers/edit.html.erb
+++ b/app/views/referrals/evidence/check_answers/edit.html.erb
@@ -13,7 +13,7 @@
       edit_referral_evidence_upload_path(current_referral),
       method: "get",
       class: "govuk-button--secondary govuk-!-margin-bottom-8"
-    ) %>
+    ) if current_referral.has_evidence %>
 
     <%= render EvidenceComponent.new(referral: current_referral) %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,15 @@ Rails.application.routes.draw do
         resource :name, only: %i[edit update], controller: :name
         resource :check_answers, path: "check-answers", only: %i[edit update]
       end
+
+      namespace :evidence do
+        resource :start, only: %i[edit update], controller: :start
+        resource :upload, only: %i[edit update], controller: :upload
+        resource :uploaded, only: %i[edit update], controller: :uploaded
+        resource :check_answers,
+                 only: %i[edit update],
+                 controller: :check_answers
+      end
     end
   end
 

--- a/spec/helpers/referral_helper_spec.rb
+++ b/spec/helpers/referral_helper_spec.rb
@@ -37,9 +37,7 @@ RSpec.describe ReferralHelper, type: :helper do
     it "allows optional subsection" do
       link = helper.subsection_path(referral:, action: :edit)
 
-      expect(link).to eq(
-        "/referrals/#{referral.id}/edit"
-      )
+      expect(link).to eq("/referrals/#{referral.id}/edit")
     end
 
     it "includes a return to link" do

--- a/spec/helpers/referral_helper_spec.rb
+++ b/spec/helpers/referral_helper_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe ReferralHelper, type: :helper do
       )
     end
 
+    it "allows optional subsection" do
+      link = helper.subsection_path(referral:, action: :edit)
+
+      expect(link).to eq(
+        "/referrals/#{referral.id}/edit"
+      )
+    end
+
     it "includes a return to link" do
       subsection_link =
         helper.subsection_path(

--- a/spec/system/public_referrals/user_adds_evidence_spec.rb
+++ b/spec/system/public_referrals/user_adds_evidence_spec.rb
@@ -258,7 +258,7 @@ RSpec.feature "Evidence", type: :system do
 
   def and_the_evidence_section_state_is(state)
     within(all(".app-task-list__section")[2]) do
-      within(all(".app-task-list__item")[2]) do
+      within(all(".app-task-list__item")[1]) do
         expect(find(".app-task-list__task-name a").text).to eq(
           "Evidence and supporting information"
         )

--- a/spec/system/public_referrals/user_adds_evidence_spec.rb
+++ b/spec/system/public_referrals/user_adds_evidence_spec.rb
@@ -5,13 +5,13 @@ RSpec.feature "Evidence", type: :system do
   include CommonSteps
   include SummaryListHelpers
 
-  scenario "An employer adds evidence to a referral" do
+  scenario "A member of public adds evidence to referral" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_referral_form_feature_is_active
-    and_i_have_an_existing_referral
-    and_i_visit_the_referral
-    then_i_see_the_referral_summary
+    and_i_am_a_member_of_the_public_with_an_existing_referral
+    and_i_visit_the_public_referral
+    then_i_see_the_public_referral_summary
 
     when_i_edit_the_evidence
     then_i_am_asked_if_i_have_evidence_to_upload
@@ -29,9 +29,6 @@ RSpec.feature "Evidence", type: :system do
     when_i_upload_evidence_files
     and_i_click_save_and_continue
     then_i_see_a_list_of_the_uploaded_files
-
-    when_i_click_save_and_continue
-    then_i_see_uploaded_evidence_form_validation_errors
 
     when_i_have_more_evidence_to_upload
     and_i_click_save_and_continue
@@ -67,7 +64,7 @@ RSpec.feature "Evidence", type: :system do
 
     when_i_choose_not_to_confirm
     and_i_click_save_and_continue
-    then_i_see_the_referral_summary
+    then_i_see_the_public_referral_summary
     and_the_evidence_section_state_is(:incomplete)
 
     when_i_edit_the_evidence
@@ -86,6 +83,7 @@ RSpec.feature "Evidence", type: :system do
 
   def then_i_am_asked_if_i_have_evidence_to_upload
     expect(page).to have_content("Evidence and supporting information")
+    expect(page).to have_content("complaint made to the school")
   end
 
   def then_i_see_evidence_start_form_validation_errors
@@ -134,12 +132,6 @@ RSpec.feature "Evidence", type: :system do
       expect(page).to have_link("upload2.pdf")
       expect(page).to have_link("upload.txt")
     end
-  end
-
-  def then_i_see_uploaded_evidence_form_validation_errors
-    expect(page).to have_content(
-      "Select yes if you have more evidence to upload"
-    )
   end
 
   def when_i_have_more_evidence_to_upload


### PR DESCRIPTION
### Context

Public referral flow allows the user to upload evidence. The form page content is slightly different for public users, otherwise the flow is identical.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds the public referral evidence flow.

![image](https://user-images.githubusercontent.com/93511/209963404-28147289-05f6-412c-ac77-fcd42af3e5e1.png)
 

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/XJDfaYrI/1027-public-employer-form-add-more-evidence

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
