### PR TITLE
Replace "I don't know" with "I'm not sure"

### DIFF
--- a/app/forms/previous_misconduct_reported_form.rb
+++ b/app/forms/previous_misconduct_reported_form.rb
@@ -7,7 +7,7 @@ class PreviousMisconductReportedForm
   validates :referral, presence: true
   validates :previous_misconduct_reported,
             inclusion: {
-              in: %w[true false i_dont_know]
+              in: %w[true false not_sure]
             }
 
   def previous_misconduct_reported

--- a/app/forms/referrals/personal_details/name_form.rb
+++ b/app/forms/referrals/personal_details/name_form.rb
@@ -10,7 +10,7 @@ module Referrals
                     :referral
 
       validates :first_name, :last_name, presence: true
-      validates :name_has_changed, inclusion: { in: %w[yes no dont_know] }
+      validates :name_has_changed, inclusion: { in: %w[yes no] }
       validates :previous_name,
                 presence: true,
                 if: -> { name_has_changed == "yes" }

--- a/app/forms/referrals/personal_details/qts_form.rb
+++ b/app/forms/referrals/personal_details/qts_form.rb
@@ -6,7 +6,7 @@ module Referrals
 
       attr_accessor :referral, :has_qts
 
-      validates :has_qts, inclusion: { in: %w[yes no dont_know] }
+      validates :has_qts, inclusion: { in: %w[yes no not_sure] }
 
       def save
         referral.update(has_qts:) if valid?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,9 +81,7 @@ module ApplicationHelper
   end
 
   def humanize_three_way_choice(choice)
-    { "true" => "Yes", "false" => "No", "i_dont_know" => "I don’t know" }[
-      choice
-    ]
+    { "true" => "Yes", "false" => "No", "not_sure" => "I’m not sure" }[choice]
   end
 
   def return_to_session_or(url)

--- a/app/views/referrals/personal_details/qts/edit.html.erb
+++ b/app/views/referrals/personal_details/qts/edit.html.erb
@@ -9,7 +9,7 @@
         <%= f.govuk_radio_buttons_fieldset(:has_qts, legend: { size: "xl", text: "Do they have qualified teacher status (QTS)?" }) do %>
           <%= f.govuk_radio_button :has_qts, "yes", label: { text: "Yes, they have QTS" } %>
           <%= f.govuk_radio_button :has_qts, "no", label: { text: "No, they do not have QTS" } %>
-          <%= f.govuk_radio_button :has_qts, "dont_know", label: { text: "I don’t know" } %>
+          <%= f.govuk_radio_button :has_qts, "not_sure", label: { text: "I’m not sure" } %>
         <% end %>
       </div>
       <%= f.govuk_submit "Save and continue" %>

--- a/app/views/referrals/previous_misconduct_reported/edit.html.erb
+++ b/app/views/referrals/previous_misconduct_reported/edit.html.erb
@@ -8,14 +8,14 @@
 
       <div class="govuk-form-group">
         <%= f.govuk_collection_radio_buttons(
-          :previous_misconduct_reported, 
+          :previous_misconduct_reported,
           [
-            OpenStruct.new(label: 'Yes', value: 'true'), 
-            OpenStruct.new(label: 'No', value: 'false'), 
-            OpenStruct.new(label: 'I don’t know', value: 'i_dont_know')
+            OpenStruct.new(label: 'Yes', value: 'true'),
+            OpenStruct.new(label: 'No', value: 'false'),
+            OpenStruct.new(label: 'I’m not sure', value: 'not_sure')
           ],
           :value, :label,
-          legend: { text: "Has there been any previous misconduct, disciplinary action or complaints?", size: "xl" }, 
+          legend: { text: "Has there been any previous misconduct, disciplinary action or complaints?", size: "xl" },
           hint: -> do %>
             <p class="govuk-body">This includes:</p>
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -90,9 +90,9 @@ RSpec.describe Referral, type: :model do
       it { is_expected.to be_falsey }
     end
 
-    context "when previous_misconduct_reported is i_dont_know" do
+    context "when previous_misconduct_reported is not_sure" do
       let(:referral) do
-        build(:referral, previous_misconduct_reported: "i_dont_know")
+        build(:referral, previous_misconduct_reported: "not_sure")
       end
 
       it { is_expected.to be_falsey }


### PR DESCRIPTION
### Context

Based on the latest design reviews, we will be updating the wording for "I don't know" radio options to "I'm  not sure". I also removed an unused `dont_know` option for the `name_has_changed` validation that was missed in #297.

### Link to Trello card
https://trello.com/c/rWjhzVVR/1049-replace-i-dont-know-with-im-not-sure

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
