### PR TITLE
Remove prevent_double_click from views

### DIFF
--- a/app/views/have_complained/new.html.erb
+++ b/app/views/have_complained/new.html.erb
@@ -12,7 +12,7 @@
           :label,
           legend: { tag: 'h1', size: 'l', text: 'Have you already made a complaint to the school, school governors or your local council?' },
         ) %>
-      <%= f.govuk_submit prevent_double_click: false %>
+      <%= f.govuk_submit %>
     <% end %>
   </div>
 </div>

--- a/app/views/is_teacher/new.html.erb
+++ b/app/views/is_teacher/new.html.erb
@@ -23,7 +23,7 @@
         <%= f.govuk_radio_button :is_teacher, "no", label: { text: "No" } %>
         <%= f.govuk_radio_button :is_teacher, "not_sure", label: { text: "I’m not sure" } %>
       <% end %>
-      <%= f.govuk_submit prevent_double_click: false %>
+      <%= f.govuk_submit %>
     <% end %>
   </div>
 </div>

--- a/app/views/pages/you_should_know.html.erb
+++ b/app/views/pages/you_should_know.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, serious_path %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-xl">What completing this referral means for you</h1>
     <p class="govuk_body">
       If TRA decide to investigate this allegation, it could result in the person you’re referring being banned from teaching.

--- a/app/views/referrals/allegation/dbs/edit.html.erb
+++ b/app/views/referrals/allegation/dbs/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_allegation_details_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @allegation_dbs_form, url: referral_allegation_dbs_path(current_referral), method: :put do |f| %>
       <h1 class="govuk-heading-xl">Telling DBS about this case</h1>
       <p>DBS (Disclosure and Barring Service) need to know about any allegations that involve harm to a child, or the risk of harm to a child.</p>

--- a/app/views/referrals/allegation/details/edit.html.erb
+++ b/app/views/referrals/allegation/details/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @allegation_details_form, url: referral_allegation_details_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <div class="govuk-form-group">

--- a/app/views/referrals/contact_details/address/edit.html.erb
+++ b/app/views/referrals/contact_details/address/edit.html.erb
@@ -18,7 +18,7 @@
         <% end %>
         <%= f.govuk_radio_button :address_known, false, label: { text: "No" } %>
       <% end %>
-      <%= f.govuk_submit "Save and continue", prevent_double_click: false %>
+      <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/contact_details/check_answers/edit.html.erb
+++ b/app/views/referrals/contact_details/check_answers/edit.html.erb
@@ -18,7 +18,7 @@
         <%= f.govuk_radio_button :contact_details_complete, true, label: { text: "Yes, I’ve completed this section" } %>
         <%= f.govuk_radio_button :contact_details_complete, false, label: { text: "No, I’ll come back to it later" } %>
       <% end %>
-      <%= f.govuk_submit "Save and continue", prevent_double_click: false %>
+      <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/contact_details/email/edit.html.erb
+++ b/app/views/referrals/contact_details/email/edit.html.erb
@@ -13,7 +13,7 @@
         <% end %>
         <%= f.govuk_radio_button :email_known, false, label: { text: "No" } %>
       <% end %>
-      <%= f.govuk_submit "Save and continue", prevent_double_click: false %>
+      <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/contact_details/telephone/edit.html.erb
+++ b/app/views/referrals/contact_details/telephone/edit.html.erb
@@ -13,7 +13,7 @@
         <% end %>
         <%= f.govuk_radio_button :phone_known, false, label: { text: "No" } %>
       <% end %>
-      <%= f.govuk_submit "Save and continue", prevent_double_click: false %>
+      <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/evidence/start/edit.html.erb
+++ b/app/views/referrals/evidence/start/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">
       Evidence and supporting information
     </h1>

--- a/app/views/referrals/evidence/upload/edit.html.erb
+++ b/app/views/referrals/evidence/upload/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_evidence_start_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <span class="govuk-caption-l">Evidence and supporting information</span>
     <h1 class="govuk-heading-l">Upload evidence</h1>
 

--- a/app/views/referrals/evidence/uploaded/edit.html.erb
+++ b/app/views/referrals/evidence/uploaded/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_evidence_upload_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <span class="govuk-caption-l">Evidence and supporting information</span>
     <h1 class="govuk-heading-l">Uploaded evidence</h1>
     <h2 class="govuk-heading-m">Files added</h2>

--- a/app/views/referrals/new.html.erb
+++ b/app/views/referrals/new.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, url_for(:back) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
       <h1 class="govuk-heading-l">Your progress is saved as you go</h1>
       <p>You don’t have to complete your referral in a single session. Your answers will automatically be saved and you can return at any time by logging back in.</p>
       <p class="govuk-!-margin-bottom-6">We’ll send you an email with a link to access your referral.</p>

--- a/app/views/referrals/organisation_address/edit.html.erb
+++ b/app/views/referrals/organisation_address/edit.html.erb
@@ -12,7 +12,7 @@
       <%= f.govuk_text_field :street_2, label: { text: "Address line 2 (optional)" } %>
       <%= f.govuk_text_field :city, label: { text: "Town or city" } %>
       <%= f.govuk_text_field :postcode, label: { text: "Postcode" } %>
-      <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>
+      <%= f.govuk_submit 'Save and continue' %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/organisation_name/edit.html.erb
+++ b/app/views/referrals/organisation_name/edit.html.erb
@@ -8,7 +8,7 @@
 
       <%= f.govuk_text_field :name, label: { size: 'xl', text: "What’s the name of your organisation?" } %>
 
-      <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>
+      <%= f.govuk_submit 'Save and continue' %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/personal_details/age/edit.html.erb
+++ b/app/views/referrals/personal_details/age/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_personal_details_name_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @personal_details_age_form, url: referral_personal_details_age_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <div class="govuk-form-group">

--- a/app/views/referrals/personal_details/name/edit.html.erb
+++ b/app/views/referrals/personal_details/name/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @personal_details_name_form, url: update_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <span class="govuk-caption-l">Personal details</span>

--- a/app/views/referrals/personal_details/trn/edit.html.erb
+++ b/app/views/referrals/personal_details/trn/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_personal_details_age_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @personal_details_trn_form, url: referral_personal_details_trn_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <div class="govuk-form-group">

--- a/app/views/referrals/previous_misconduct_reported/edit.html.erb
+++ b/app/views/referrals/previous_misconduct_reported/edit.html.erb
@@ -26,7 +26,7 @@
           <% end
         ) %>
       </div>
-      <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>
+      <%= f.govuk_submit 'Save and continue' %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/referrer_job_title/edit.html.erb
+++ b/app/views/referrals/referrer_job_title/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @referrer_job_title_form, url: referral_referrer_job_title_path(current_referral), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :job_title, label: { size: 'xl', text: "What is your job title?" }, hint: { text: 'For example, ‘Headteacher’' } %>
-      <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>
+      <%= f.govuk_submit 'Save and continue' %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/referrer_name/edit.html.erb
+++ b/app/views/referrals/referrer_name/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @referrer_name_form, url: referral_referrer_name_path(current_referral), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :name, label: { size: 'xl', text: "What is your name?" } %>
-      <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>
+      <%= f.govuk_submit 'Save and continue' %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/referrer_phone/edit.html.erb
+++ b/app/views/referrals/referrer_phone/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @referrer_phone_form, url: referral_referrer_phone_path(current_referral), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :phone, label: { size: 'xl', text: "What is your main contact number?" }, hint: { text: 'We will only use this number to contact you about your referral' }, class: 'govuk-input--width-20' %>
-      <%= f.govuk_submit 'Save and continue', prevent_double_click: false %>
+      <%= f.govuk_submit 'Save and continue' %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/teacher_role/check_answers/edit.html.erb
+++ b/app/views/referrals/teacher_role/check_answers/edit.html.erb
@@ -18,7 +18,7 @@
         <%= f.govuk_radio_button :teacher_role_complete, true, label: { text: "Yes, I’ve completed this section" } %>
         <%= f.govuk_radio_button :teacher_role_complete, false, label: { text: "No, I’ll come back to it later" } %>
       <% end %>
-      <%= f.govuk_submit "Save and continue", prevent_double_click: false %>
+      <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/teacher_role/duties/edit.html.erb
+++ b/app/views/referrals/teacher_role/duties/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_same_organisation_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @duties_form, url: referral_teacher_role_duties_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/referrals/teacher_role/employment_status/edit.html.erb
+++ b/app/views/referrals/teacher_role/employment_status/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_start_date_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @employment_status_form, url: referral_teacher_role_employment_status_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/referrals/teacher_role/end_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/end_date/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @role_end_date_form, url: referral_teacher_role_end_date_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/referrals/teacher_role/job_title/edit.html.erb
+++ b/app/views/referrals/teacher_role/job_title/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_employment_status_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @job_title_form, url: referral_teacher_role_job_title_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/referrals/teacher_role/organisation_address/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_job_title_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @organisation_address_form, url: referral_teacher_role_organisation_address_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_job_title_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @organisation_address_known_form, url: referral_teacher_role_organisation_address_known_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/referrals/teacher_role/reason_leaving_role/edit.html.erb
+++ b/app/views/referrals/teacher_role/reason_leaving_role/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_start_date_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @reason_leaving_role_form, url: referral_teacher_role_reason_leaving_role_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/referrals/teacher_role/same_organisation/edit.html.erb
+++ b/app/views/referrals/teacher_role/same_organisation/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_job_title_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @same_organisation_form, url: referral_teacher_role_same_organisation_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/referrals/teacher_role/start_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/start_date/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @role_start_date_form, url: referral_teacher_role_start_date_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/work_location/edit.html.erb
+++ b/app/views/referrals/teacher_role/work_location/edit.html.erb
@@ -16,7 +16,7 @@
       <%= f.govuk_text_field :work_address_line_2, label: { text: "Address line 2 (optional)", size: "m" } %>
       <%= f.govuk_text_field :work_town_or_city, label: { text: "Town or city", size: "m" } %>
       <%= f.govuk_text_field :work_postcode, label: { text: "Postcode", size: "m" } %>
-      <%= f.govuk_submit "Save and continue", prevent_double_click: false %>
+      <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/teacher_role/work_location_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/work_location_known/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_job_title_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @work_location_known_form, url: referral_teacher_role_work_location_known_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/referrals/teacher_role/working_somewhere_else/edit.html.erb
+++ b/app/views/referrals/teacher_role/working_somewhere_else/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_duties_path(current_referral)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @working_somewhere_else_form, url: referral_teacher_role_working_somewhere_else_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/reporting_as/new.html.erb
+++ b/app/views/reporting_as/new.html.erb
@@ -11,7 +11,7 @@
         :label,
         legend: { tag: 'h1', size: 'xl', text: 'Are you making a referral as an employer or member of the public?' }
       ) %>
-      <%= f.govuk_submit prevent_double_click: false %>
+      <%= f.govuk_submit %>
     <% end %>
   </div>
 </div>

--- a/app/views/serious_misconduct/new.html.erb
+++ b/app/views/serious_misconduct/new.html.erb
@@ -58,7 +58,7 @@
           </p>
         <% end %>
       <% end %>
-      <%= f.govuk_submit prevent_double_click: false %>
+      <%= f.govuk_submit %>
     <% end %>
   </div>
 </div>

--- a/app/views/teaching_in_england/new.html.erb
+++ b/app/views/teaching_in_england/new.html.erb
@@ -15,7 +15,7 @@
           </p>
         <% end %>
       <% end %>
-      <%= f.govuk_submit prevent_double_click: false %>
+      <%= f.govuk_submit %>
     <% end %>
   </div>
 </div>

--- a/app/views/unsupervised_teaching/new.html.erb
+++ b/app/views/unsupervised_teaching/new.html.erb
@@ -26,7 +26,7 @@
           </p>
         <% end %>
       <% end %>
-      <%= f.govuk_submit prevent_double_click: false %>
+      <%= f.govuk_submit %>
     <% end %>
   </div>
 </div>

--- a/lib/generators/form/templates/new_form.html.erb
+++ b/lib/generators/form/templates/new_form.html.erb
@@ -16,7 +16,7 @@
           hint: { text: 'Change this hint' }
         ) %>
       <% end -%>
-<%%= f.govuk_submit prevent_double_click: false %>
+<%%= f.govuk_submit %>
     <%% end %>
   </div>
 </div>


### PR DESCRIPTION
### Context

This option, initially used to make some system tests pass, doesn't seem to be needed anymore.

### Changes proposed in this pull request

- remove prevent_double_click
- remove extra space from class attribute value
### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
