### PR TITLE
Add error scenario for uploading more evidence

### DIFF
--- a/app/controllers/referrals/evidence/uploaded_controller.rb
+++ b/app/controllers/referrals/evidence/uploaded_controller.rb
@@ -2,16 +2,29 @@ module Referrals
   module Evidence
     class UploadedController < Referrals::BaseController
       def edit
-        case params[:more_evidence]
-        when "yes"
-          redirect_to edit_referral_evidence_upload_path(current_referral)
-        when "no"
-          redirect_to edit_referral_evidence_check_answers_path(
-                        current_referral
-                      )
+        @uploaded_form = UploadedForm.new
+      end
+
+      def update
+        @uploaded_form = UploadedForm.new(more_evidence_params)
+
+        if @uploaded_form.valid?
+          if @uploaded_form.more_evidence?
+            redirect_to edit_referral_evidence_upload_path(current_referral)
+          else
+            redirect_to edit_referral_evidence_check_answers_path(
+                          current_referral
+                        )
+          end
         else
           render :edit
         end
+      end
+
+      def more_evidence_params
+        params.fetch(:referrals_evidence_uploaded_form, {}).permit(
+          :more_evidence
+        )
       end
     end
   end

--- a/app/forms/referrals/evidence/uploaded_form.rb
+++ b/app/forms/referrals/evidence/uploaded_form.rb
@@ -1,0 +1,15 @@
+module Referrals
+  module Evidence
+    class UploadedForm
+      include ActiveModel::Model
+
+      attr_accessor :more_evidence
+
+      validates :more_evidence, inclusion: { in: %w[yes no] }
+
+      def more_evidence?
+        @more_evidence == "yes"
+      end
+    end
+  end
+end

--- a/app/views/referrals/evidence/uploaded/edit.html.erb
+++ b/app/views/referrals/evidence/uploaded/edit.html.erb
@@ -26,7 +26,9 @@
       <% end %>
     </dl>
 
-    <%= form_with url: edit_referral_evidence_uploaded_path(current_referral), method: :get do |f| %>
+    <%= form_with model: @uploaded_form, url: referral_evidence_uploaded_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
       <%= f.govuk_radio_buttons_fieldset(:more_evidence, legend: { size: "m", text: "Do you want to upload another file?" }) do %>
         <%= f.govuk_radio_button :more_evidence, "yes", label: { text: "Yes" } %>
         <%= f.govuk_radio_button :more_evidence, "no", label: { text: "No" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,6 +320,10 @@ en:
               mismatch_content_type: The selected file does not match its contents
               file_size_too_big: The selected file must be smaller than %{max_file_size}
               file_count: You can only upload %{max_files} files
+        "referrals/evidence/uploaded_form":
+          attributes:
+            more_evidence:
+              inclusion: Select yes if you have more evidence to upload
         "referrals/evidence/categories_form":
           attributes:
             categories:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,7 +195,7 @@ Rails.application.routes.draw do
       namespace :evidence do
         resource :start, only: %i[edit update], controller: :start
         resource :upload, only: %i[edit update], controller: :upload
-        resource :uploaded, only: %i[edit], controller: :uploaded
+        resource :uploaded, only: %i[edit update], controller: :uploaded
         resource :check_answers, path: "check-answers", only: %i[edit update]
       end
 

--- a/spec/system/referrals/user_adds_evidence_spec.rb
+++ b/spec/system/referrals/user_adds_evidence_spec.rb
@@ -30,6 +30,9 @@ RSpec.feature "Evidence", type: :system do
     and_i_click_save_and_continue
     then_i_see_a_list_of_the_uploaded_files
 
+    when_i_click_save_and_continue
+    then_i_see_uploaded_evidence_form_validation_errors
+
     when_i_have_more_evidence_to_upload
     and_i_click_save_and_continue
     then_i_am_asked_to_upload_evidence_files
@@ -131,6 +134,12 @@ RSpec.feature "Evidence", type: :system do
       expect(page).to have_link("upload2.pdf")
       expect(page).to have_link("upload.txt")
     end
+  end
+
+  def then_i_see_uploaded_evidence_form_validation_errors
+    expect(page).to have_content(
+      "Select yes if you have more evidence to upload"
+    )
   end
 
   def when_i_have_more_evidence_to_upload


### PR DESCRIPTION

### Context

If a user uploads evidence they are presented with a list of uploads, they may also choose to upload more evidence, this additional evidence form needs error handling in case the user selects nothing but submits the form.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds a backing form for the 'uploaded' evidence step and validates that a yes/no answer has been given.

![image](https://user-images.githubusercontent.com/93511/209946840-1bca313f-64d2-420b-9e42-f1e905919d42.png)


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
