### PR TITLE
Update the phone number question

### DIFF
--- a/app/components/about_you_component.rb
+++ b/app/components/about_you_component.rb
@@ -67,7 +67,7 @@ class AboutYouComponent < ViewComponent::Base
           }
         ],
         key: {
-          text: "Main contact number"
+          text: "Your phone number"
         },
         value: {
           text: referrer.phone

--- a/app/forms/referrer_phone_form.rb
+++ b/app/forms/referrer_phone_form.rb
@@ -5,7 +5,12 @@ class ReferrerPhoneForm
   attr_writer :phone
 
   validates :referral, presence: true
-  validates :phone, presence: true
+  validates :phone,
+            format: {
+              with: /\A(\+44\s?)?(?:\d\s?){10,11}\z/,
+              if: -> { phone&.present? }
+            },
+            presence: true
 
   def phone
     @phone ||= referrer&.phone

--- a/app/views/referrals/referrer_phone/edit.html.erb
+++ b/app/views/referrals/referrer_phone/edit.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title, "#{'Error: ' if @referrer_phone_form.errors.any?}What is your main contact number?" %>
+<% content_for :page_title, "#{'Error: ' if @referrer_phone_form.errors.any?}Your phone number" %>
 <% content_for :back_link_url, return_to_session_or(edit_referral_referrer_job_title_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @referrer_phone_form, url: referral_referrer_phone_path(current_referral), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_field :phone, label: { size: 'xl', text: "What is your main contact number?" }, hint: { text: 'We will only use this number to contact you about your referral' }, class: 'govuk-input--width-20' %>
+      <%= f.govuk_text_field :phone, caption: { size: 'l', text: 'Your details' }, label: { size: 'l', text: "Your phone number" }, hint: { text: 'The TRA will only use this number to contact you about your referral' }, class: 'govuk-input--width-20' %>
       <%= f.govuk_submit 'Save and continue' %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,7 +248,8 @@ en:
         referrer_phone_form:
           attributes:
             phone:
-              blank: Enter your main contact number
+              blank: Enter your phone number, like 07700 900 982
+              invalid: Enter your phone number in the correct format
         "referrals/referrer_name_form":
           attributes:
             name:

--- a/spec/forms/referrer_phone_form_spec.rb
+++ b/spec/forms/referrer_phone_form_spec.rb
@@ -3,19 +3,44 @@ require "rails_helper"
 RSpec.describe ReferrerPhoneForm, type: :model do
   let(:referral) { build(:referral, referrer:) }
   let(:referrer) { build(:referrer) }
+  let(:phone) { "07700 123456" }
 
   describe "validations" do
-    subject { described_class.new(referral:) }
+    subject(:form) { described_class.new(referral:, phone:) }
 
     it { is_expected.to validate_presence_of(:referral) }
     it { is_expected.to validate_presence_of(:phone) }
+
+    context "when the phone number is blank" do
+      let(:phone) { "" }
+
+      it "adds an error" do
+        form.validate
+        expect(form.errors[:phone]).to eq(
+          ["Enter your phone number, like 07700 900 982"]
+        )
+      end
+    end
+
+    context "when the phone number is in an incorrect format" do
+      let(:phone) { "invalid" }
+
+      it { is_expected.to be_invalid }
+
+      it "adds an error" do
+        form.validate
+        expect(form.errors[:phone]).to eq(
+          ["Enter your phone number in the correct format"]
+        )
+      end
+    end
   end
 
   describe "#save" do
     subject(:save) { form.save }
 
     let(:form) { described_class.new(phone:, referral:) }
-    let(:phone) { "123456789" }
+    let(:phone) { "07700123456" }
     let(:referral) { build(:referral, referrer:) }
     let(:referrer) { build(:referrer) }
 

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
 
   def and_i_see_my_answers_on_the_referrer_check_your_answers_page
     expect(page).to have_content("Your name\tTest Name")
-    expect(page).to have_content("Main contact number\t01234567890")
+    expect(page).to have_content("Your phone number\t01234567890")
   end
 
   def and_i_see_your_details_flagged_as_incomplete
@@ -115,10 +115,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
   end
 
   def then_i_see_the_phone_number_prefilled
-    expect(page).to have_field(
-      "What is your main contact number?",
-      with: "01234567890"
-    )
+    expect(page).to have_field("Your phone number", with: "01234567890")
   end
 
   def then_i_see_the_name_error_message
@@ -138,7 +135,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
   end
 
   def then_i_see_the_phone_error_message
-    expect(page).to have_content("Enter your main contact number")
+    expect(page).to have_content("Enter your phone number, like 07700 900 982")
   end
 
   def then_i_see_the_what_is_your_phone_number_page
@@ -146,9 +143,9 @@ RSpec.feature "Employer Referral: About You", type: :system do
       "/referrals/#{@referral.id}/referrer-phone/edit"
     )
     expect(page).to have_title(
-      "What is your main contact number? - Refer serious misconduct by a teacher in England"
+      "Your phone number - Refer serious misconduct by a teacher in England"
     )
-    expect(page).to have_content("What is your main contact number?")
+    expect(page).to have_content("Your phone number")
   end
 
   def then_i_see_your_details_flagged_as_complete
@@ -175,6 +172,6 @@ RSpec.feature "Employer Referral: About You", type: :system do
   end
 
   def when_i_enter_my_phone_number
-    fill_in "What is your main contact number?", with: "01234567890"
+    fill_in "Your phone number", with: "01234567890"
   end
 end


### PR DESCRIPTION
The designs have updated the phone number question copy for both the
form and the error messages.

See the design (here)[https://refer-misconduct-prototype.herokuapp.com/report/your-details/telephone].

The changes here will be the same for both the employer and public
forms.

<img width="998" alt="Screenshot 2023-01-05 at 11 47 26 am" src="https://user-images.githubusercontent.com/3126/210776032-93dd3aa3-34ea-4323-ba16-80346649a230.png">

<img width="1007" alt="Screenshot 2023-01-05 at 11 47 42 am" src="https://user-images.githubusercontent.com/3126/210776064-6a746739-2a0d-4a69-b1ff-d288afdb29b0.png">

<img width="1026" alt="Screenshot 2023-01-05 at 11 47 35 am" src="https://user-images.githubusercontent.com/3126/210776237-b41627c1-e595-43e7-935c-35034568afb2.png">

<img width="1036" alt="Screenshot 2023-01-05 at 11 47 58 am" src="https://user-images.githubusercontent.com/3126/210776128-8d217caa-114b-4f4e-b00d-834a2ef2a977.png">


### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
