### PR TITLE
Improve deployment reliability

### DIFF
--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -157,17 +157,25 @@ runs:
         attempt_counter=0
         max_attempts=$RETRIES
 
-        SHA_URL="${{ env.app_fqdn }}/_sha"
-        APP_SHA=$(curl $SHA_URL --silent)
-        until [[ "$EXPECTED_SHA" == "$APP_SHA" ]]; do
-            if [ ${attempt_counter} -eq ${max_attempts} ];then
-              echo "Max attempts reached"
-              exit 1
-            fi
-            echo "Attempt $attempt_counter: new site not up, retrying in 5 seconds ..."
-            sleep 5
-            attempt_counter=$(($attempt_counter+1))
-            APP_SHA=$(curl $SHA_URL --silent)
+        HEALTH_URL="${{ env.app_fqdn }}/health/all.json"
+        HEALTH_RESPONSE=$(curl $HEALTH_URL --silent)
+        APP_SHA=$(echo $HEALTH_RESPONSE | jq .version.message | grep -Po "Version: \K\w*")
+        APP_STATUS=$(echo $HEALTH_RESPONSE | jq .default.success)
+        APP_DATABASE_STATUS=$(echo $HEALTH_RESPONSE | jq .database.success)
+        until [[ "$EXPECTED_SHA" == "$APP_SHA" && "$APP_STATUS" == "true" && "$APP_DATABASE_STATUS" == "true" ]]; do
+          if [ ${attempt_counter} -eq ${max_attempts} ];then
+            echo "Max attempts reached"
+            exit 1
+          fi
+          echo "Attempt $attempt_counter: new site not up, retrying in 5 seconds ..."
+          sleep 5
+          attempt_counter=$(($attempt_counter+1))
+
+          HEALTH_RESPONSE=$(curl $HEALTH_URL --silent)
+          APP_SHA=$(echo $HEALTH_RESPONSE | jq .version.message | grep -Po "Version: \K\w*")
+          APP_STATUS=$(echo $HEALTH_RESPONSE | jq .default.success)
+          APP_DATABASE_STATUS=$(echo $HEALTH_RESPONSE | jq .database.success)
+          echo "sha: $APP_SHA; app_status: $APP_STATUS; app_database_status: $APP_DATABASE_STATUS"
         done
       shell: bash
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ ENV RAILS_ENV=production
 # Add the commit sha to the env
 ARG GIT_SHA
 ENV GIT_SHA=$GIT_SHA
+ENV SHA=$GIT_SHA
 
 # Add the timezone (prod image) as it's not configured by default in Alpine
 RUN apk add --update --no-cache tzdata && \

--- a/lib/tasks/schema_load_or_migrate.rake
+++ b/lib/tasks/schema_load_or_migrate.rake
@@ -15,5 +15,7 @@ db_namespace =
             db_namespace["schema:load"].invoke
           end
         end
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
     end
   end

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -9,7 +9,7 @@ locals {
       HOSTING_ENVIRONMENT_NAME              = local.hosting_environment
       RAILS_SERVE_STATIC_FILES              = "true"
       ConnectionStrings__Redis              = azurerm_redis_cache.redis.primary_connection_string
-      WEBSITE_SWAP_WARMUP_PING_PATH         = "/health"
+      WEBSITE_SWAP_WARMUP_PING_PATH         = "/health/all"
       WEBSITE_SWAP_WARMUP_PING_STATUSES     = "200"
       AZURE_STORAGE_ACCOUNT_NAME            = azurerm_storage_account.allegations.name,
       AZURE_STORAGE_ACCESS_KEY              = azurerm_storage_account.allegations.primary_access_key,

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -3,6 +3,8 @@
   "key_vault_name": "s165d01-rsm-dv-kv",
   "resource_group_name": "s165d01-rsm-dv-rg",
   "storage_account_name": "s165d01rsmtfstatedv",
+  "enable_blue_green": true,
+  "app_service_plan_sku": "P1v2",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
   "resource_prefix": "s165d01-rsm",

--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -3,6 +3,8 @@
   "key_vault_name": "s165d01-rsm-dv-kv",
   "key_vault_resource_group": "s165d01-rsm-dv-rg",
   "storage_account_name": "s165d01rsmtfstatedv",
+  "enable_blue_green": true,
+  "app_service_plan_sku": "S1",
   "storage_log_categories": [],
   "resource_prefix": "s165d01-rsm",
   "create_env_resource_group": true

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -3,6 +3,8 @@
   "key_vault_name": "s165t01-rsm-ts-kv",
   "resource_group_name": "s165t01-rsm-ts-rg",
   "storage_account_name": "s165t01rsmtfstatets",
+  "enable_blue_green": true,
+  "app_service_plan_sku": "P1v2",
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
   "resource_prefix": "s165t01-rsm",


### PR DESCRIPTION
### Context

The deployment process for the main branch into permanent environments and feature branches into review environments is unreliable.  Investigations have identified that when blue green is not enabled and Basic app service plans are used the container restarts several times after deployment.  This means that the initial site up check succeeds but the smoke tests fail as they are executed during a period when the container is restarting.

The following App Service Plan SKUs were tested:

B3 - unresponsive for 1:45, smoke tests timed out
S1 - never unresponsive but site up check took 11:14 to complete, total deployment time 22 minutes
S1 w/blue-green - never unresponsive, deployment took 12 mins
P1v2 - unresponsive for 30 seconds prior to new image coming up, deployment took 8 minutes
P1v2 w/blue-green - never unresponsive, deployment took 10 minutes

### Changes proposed in this pull request

- Increase dev and test ASPs to P1v2 with blue green, the increased cost is justified to ensure fast, reliable deployments to production
- Enable blue green for review apps with an S1 ASP.  Slower deployments are acceptable for review apps, using a cheaper ASP will help to keep costs under control
- Improve the post deployment site up check so that it checks the sha, app and database status all from the /health/all endpoint

### Guidance to review

Testing was conducted under the `improve-review-smoke-test-reliability` branch, logs can be viewed there.  Site availiability was testing using the following command executed locally:

```
while ($true) { $Response = Invoke-WebRequest https://s165d01-rsm-review-pr-346-app.azurewebsites.net/health/all.json; Write-Host "$(Get-Date): $($Response.StatusCode) $(($Response.Content | ConvertFrom-Json).version.message)"; Start-Sleep -Seconds 1 }
```

### Link to Trello card

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
