### PR TITLE
Fix truncate invalid argument

### DIFF
--- a/app/forms/referrals/allegation/check_answers_form.rb
+++ b/app/forms/referrals/allegation/check_answers_form.rb
@@ -29,7 +29,7 @@ module Referrals
         if referral.allegation_upload.attached?
           "File: #{referral.allegation_upload.filename}"
         elsif referral.allegation_details.present?
-          referral.allegation_details.truncate(150, " ")
+          referral.allegation_details.truncate(150)
         else
           "Incomplete"
         end

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -12,7 +12,7 @@ module ReferralHelper
         rails_blob_path(referral.duties_upload, disposition: "attachment")
       )
     elsif referral.duties_details.present?
-      referral.duties_details.truncate(150, " ")
+      referral.duties_details.truncate(150)
     else
       "Incomplete"
     end


### PR DESCRIPTION
For whatever reason it had an empty space string as a second argument. It was triggering this error: `TypeError: no implicit conversion of Symbol into Integer`