### PR TITLE
[1094] Implement public version of details of the allegation task list section

### DIFF
--- a/app/components/public_allegation_component.html.erb
+++ b/app/components/public_allegation_component.html.erb
@@ -1,0 +1,3 @@
+<%= render(SummaryCardComponent.new(rows:)) do %>
+  <%= render SummaryCardHeaderComponent.new(title: "What happened") %>
+<% end %>

--- a/app/components/public_allegation_component.rb
+++ b/app/components/public_allegation_component.rb
@@ -1,0 +1,108 @@
+class PublicAllegationComponent < ViewComponent::Base
+  include ActiveModel::Model
+
+  attr_accessor :referral
+
+  def allegation_check_answers_form
+    @allegation_check_answers_form ||=
+      Referrals::Allegation::CheckAnswersForm.new(referral:)
+  end
+
+  def details_format
+    case referral.allegation_format
+    when "details"
+      "Describe the allegation"
+    when "upload"
+      "File upload"
+    else
+      "Incomplete"
+    end
+  end
+
+  def file_upload?
+    referral.allegation_format == "upload"
+  end
+
+  def details_described?
+    referral.allegation_format == "details"
+  end
+
+  def details_text
+    return file_link if file_upload?
+    return referral.allegation_details if details_described?
+
+    "Incomplete"
+  end
+
+  def file_link
+    upload = referral.allegation_upload
+    govuk_link_to(
+      upload.filename,
+      rails_blob_path(upload, disposition: "attachment")
+    )
+  end
+
+  def rows
+    [
+      {
+        actions: [
+          {
+            text: "Change",
+            href:
+              edit_public_referral_allegation_details_path(
+                referral,
+                return_to: request.path
+              ),
+            visually_hidden_text:
+              "How do you want to give details about the allegation?"
+          }
+        ],
+        key: {
+          text: "How do you want to give details about the allegation?"
+        },
+        value: {
+          text: details_format
+        }
+      },
+      {
+        actions: [
+          {
+            text: "Change",
+            href:
+              edit_public_referral_allegation_details_path(
+                referral,
+                return_to: request.path
+              ),
+            visually_hidden_text: "Description of the allegation"
+          }
+        ],
+        key: {
+          text: "Description of the allegation"
+        },
+        value: {
+          text: details_text
+        }
+      },
+      {
+        actions: [
+          {
+            text: "Change",
+            href:
+              edit_public_referral_allegation_considerations_path(
+                referral,
+                return_to: request.path
+              ),
+            visually_hidden_text:
+              "Details about how this complaint has been considered"
+          }
+        ],
+        key: {
+          text: "Details about how this complaint has been considered"
+        },
+        value: {
+          text: referral.allegation_consideration_details || "Incomplete"
+        }
+      }
+    ]
+  end
+end

--- a/app/controllers/public_referrals/allegation/check_answers_controller.rb
+++ b/app/controllers/public_referrals/allegation/check_answers_controller.rb
@@ -1,0 +1,6 @@
+module PublicReferrals
+  module Allegation
+    class CheckAnswersController < Referrals::Allegation::CheckAnswersController
+    end
+  end
+end

--- a/app/controllers/public_referrals/allegation/check_answers_controller.rb
+++ b/app/controllers/public_referrals/allegation/check_answers_controller.rb
@@ -1,6 +1,9 @@
 module PublicReferrals
   module Allegation
     class CheckAnswersController < Referrals::Allegation::CheckAnswersController
+      def next_path
+        edit_public_referral_path(current_referral)
+      end
     end
   end
 end

--- a/app/controllers/public_referrals/allegation/considerations_controller.rb
+++ b/app/controllers/public_referrals/allegation/considerations_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module PublicReferrals
+  module Allegation
+    class ConsiderationsController < Referrals::BaseController
+      def edit
+        @allegation_considerations_form =
+          Referrals::Allegation::ConsiderationsForm.new
+      end
+
+      def next_path
+        public_referral_allegation_considerations_path(current_referral)
+      end
+      helper_method :next_path
+
+      def update_path
+        public_referral_allegation_considerations_path(current_referral)
+      end
+      helper_method :update_path
+
+      def back_link
+        edit_public_referral_path(current_referral)
+      end
+      helper_method :back_link
+    end
+  end
+end

--- a/app/controllers/public_referrals/allegation/considerations_controller.rb
+++ b/app/controllers/public_referrals/allegation/considerations_controller.rb
@@ -4,24 +4,36 @@ module PublicReferrals
   module Allegation
     class ConsiderationsController < Referrals::BaseController
       def edit
+        @allegation_considerations_form = Referrals::Allegation::ConsiderationsForm.new(
+          referral: current_referral,
+          allegation_consideration_details: current_referral.allegation_consideration_details
+        )
+      end
+
+      def update
         @allegation_considerations_form =
-          Referrals::Allegation::ConsiderationsForm.new
+          Referrals::Allegation::ConsiderationsForm.new(
+            allegation_considerations_params.merge(referral: current_referral)
+          )
+
+        if @allegation_considerations_form.save
+          redirect_to next_page
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def allegation_considerations_params
+        params.require(:referrals_allegation_considerations_form).permit(
+          :allegation_consideration_details,
+        )
       end
 
       def next_path
-        public_referral_allegation_considerations_path(current_referral)
+        edit_public_referral_allegation_check_answers_path(current_referral)
       end
-      helper_method :next_path
-
-      def update_path
-        public_referral_allegation_considerations_path(current_referral)
-      end
-      helper_method :update_path
-
-      def back_link
-        edit_public_referral_path(current_referral)
-      end
-      helper_method :back_link
     end
   end
 end

--- a/app/controllers/public_referrals/allegation/considerations_controller.rb
+++ b/app/controllers/public_referrals/allegation/considerations_controller.rb
@@ -4,10 +4,12 @@ module PublicReferrals
   module Allegation
     class ConsiderationsController < Referrals::BaseController
       def edit
-        @allegation_considerations_form = Referrals::Allegation::ConsiderationsForm.new(
-          referral: current_referral,
-          allegation_consideration_details: current_referral.allegation_consideration_details
-        )
+        @allegation_considerations_form =
+          Referrals::Allegation::ConsiderationsForm.new(
+            referral: current_referral,
+            allegation_consideration_details:
+              current_referral.allegation_consideration_details
+          )
       end
 
       def update
@@ -27,7 +29,7 @@ module PublicReferrals
 
       def allegation_considerations_params
         params.require(:referrals_allegation_considerations_form).permit(
-          :allegation_consideration_details,
+          :allegation_consideration_details
         )
       end
 

--- a/app/controllers/public_referrals/allegation/details_controller.rb
+++ b/app/controllers/public_referrals/allegation/details_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module PublicReferrals
+  module Allegation
+    class DetailsController < Referrals::Allegation::DetailsController
+    end
+  end
+end

--- a/app/controllers/public_referrals/allegation/details_controller.rb
+++ b/app/controllers/public_referrals/allegation/details_controller.rb
@@ -3,6 +3,19 @@
 module PublicReferrals
   module Allegation
     class DetailsController < Referrals::Allegation::DetailsController
+      def next_path
+        edit_public_referral_allegation_considerations_path(current_referral)
+      end
+
+      def update_path
+        public_referral_allegation_details_path(current_referral)
+      end
+      helper_method :update_path
+
+      def back_link
+        edit_public_referral_path(current_referral)
+      end
+      helper_method :back_link
     end
   end
 end

--- a/app/controllers/referrals/allegation/check_answers_controller.rb
+++ b/app/controllers/referrals/allegation/check_answers_controller.rb
@@ -16,7 +16,7 @@ module Referrals
           )
 
         if @allegation_check_answers_form.save
-          redirect_to edit_referral_path(current_referral)
+          redirect_to next_path
         else
           render :edit
         end
@@ -28,6 +28,10 @@ module Referrals
         params.fetch(:referrals_allegation_check_answers_form, {}).permit(
           :allegation_details_complete
         )
+      end
+
+      def next_path
+        edit_referral_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/allegation/details_controller.rb
+++ b/app/controllers/referrals/allegation/details_controller.rb
@@ -36,6 +36,16 @@ module Referrals
       def next_path
         edit_referral_allegation_dbs_path(current_referral)
       end
+
+      def back_link
+        edit_referral_path(current_referral)
+      end
+      helper_method :back_link
+
+      def update_path
+        referral_allegation_details_path(current_referral)
+      end
+      helper_method :update_path
     end
   end
 end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -102,7 +102,11 @@ class ReferralForm
         section.items = [
           ReferralSectionItem.new(
             I18n.t("referral_form.details_of_the_allegation"),
-            edit_referral_allegation_details_path(referral),
+            subsection_path(
+              referral:,
+              subsection: :allegation_details,
+              action: :edit
+            ),
             section_status(:allegation_details_complete)
           )
         ]

--- a/app/forms/referrals/allegation/considerations_form.rb
+++ b/app/forms/referrals/allegation/considerations_form.rb
@@ -4,8 +4,7 @@ module Referrals
     class ConsiderationsForm
       include ActiveModel::Model
 
-      validates :allegation_consideration_details,
-                presence: true
+      validates :allegation_consideration_details, presence: true
 
       attr_accessor :referral, :allegation_consideration_details
 

--- a/app/forms/referrals/allegation/considerations_form.rb
+++ b/app/forms/referrals/allegation/considerations_form.rb
@@ -4,7 +4,8 @@ module Referrals
     class ConsiderationsForm
       include ActiveModel::Model
 
-      validates :consideration_details, presence: true
+      validates :allegation_consideration_details,
+                presence: true
 
       attr_accessor :referral, :allegation_consideration_details
 

--- a/app/forms/referrals/allegation/considerations_form.rb
+++ b/app/forms/referrals/allegation/considerations_form.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Referrals
+  module Allegation
+    class ConsiderationsForm
+      include ActiveModel::Model
+
+      validates :consideration_details, presence: true
+
+      attr_accessor :referral, :allegation_consideration_details
+
+      def save
+        return false if invalid?
+
+        referral.update(allegation_consideration_details:)
+      end
+    end
+  end
+end

--- a/app/views/public_referrals/allegation/check_answers/edit.html.erb
+++ b/app/views/public_referrals/allegation/check_answers/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, "#{'Error: ' if @allegation_check_answers_form.errors.any?}Check and confirm your answers" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      Check and confirm your answers
+    </h1>
+    <%= form_with model: @allegation_check_answers_form, url: public_referral_allegation_check_answers_path(current_referral), method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= render PublicAllegationComponent.new(referral: current_referral) %>
+
+      <%= f.govuk_radio_buttons_fieldset(
+        :allegation_details_complete,
+        legend: { text: "Have you completed this section?", size: "m" },
+        hint: { text: "You can still make changes to a completed section" },
+      ) do %>
+      <%= f.govuk_radio_button :allegation_details_complete, "true", label: { text: "Yes, I’ve completed this section" } %>
+      <%= f.govuk_radio_button :allegation_details_complete, "false", label: { text: "No, I’ll come back to it later" } %>
+    <% end %>
+    <%= f.govuk_submit "Save and continue" %>
+  <% end %>
+  </div>
+</div>

--- a/app/views/public_referrals/allegation/considerations/edit.html.erb
+++ b/app/views/public_referrals/allegation/considerations/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_considerations_form.errors.any?}How this complaint has been considered?" %>
-<% content_for :back_link_url, return_to_session_or(back_link) %>
+<% content_for :back_link_url, return_to_session_or(edit_public_referral_path(current_referral)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @allegation_considerations_form, url: update_path, method: :put do |f| %>
+    <%= form_with model: @allegation_considerations_form, url: public_referral_allegation_considerations_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <span class="govuk-caption-l">The allegation</span>
       <h1 class="govuk-heading-l">How has this complaint been considered?</h1>
@@ -14,7 +14,7 @@
         <li>the outcomes of the complaint</li>
       </ul>
       <div class="govuk-form-group">
-        <%= f.govuk_text_area :allegation_considerations,
+        <%= f.govuk_text_area :allegation_consideration_details,
           label: { text: "Details about how this complaint has been considered", size: "m" },
           rows: 20 %>
       </div>

--- a/app/views/public_referrals/allegation/considerations/edit.html.erb
+++ b/app/views/public_referrals/allegation/considerations/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, "#{'Error: ' if @allegation_considerations_form.errors.any?}How this complaint has been considered?" %>
+<% content_for :back_link_url, return_to_session_or(back_link) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: @allegation_considerations_form, url: update_path, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+      <span class="govuk-caption-l">The allegation</span>
+      <h1 class="govuk-heading-l">How has this complaint been considered?</h1>
+      <p>Include details about:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the local procedures you followed, for example if you made a complaint to the headteacher, local authority or police</li>
+        <li>when you made the complaint</li>
+        <li>the outcomes of the complaint</li>
+      </ul>
+      <div class="govuk-form-group">
+        <%= f.govuk_text_area :allegation_considerations,
+          label: { text: "Details about how this complaint has been considered", size: "m" },
+          rows: 20 %>
+      </div>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/allegation/details/edit.html.erb
+++ b/app/views/referrals/allegation/details/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_details_form.errors.any?}How do you want to tell us about your allegation?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(back_link) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @allegation_details_form, url: referral_allegation_details_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @allegation_details_form, url: update_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset(:allegation_format, legend: { size: "xl", text: "How do you want to tell us about your allegation?" }) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -335,6 +335,10 @@ en:
           attributes:
             evidence_details_complete:
               inclusion: Select yes if you’ve completed this section
+        "referrals/allegation/considerations_form":
+          attributes:
+            allegation_consideration_details:
+              blank: Enter details of how the complaint was considered
 
   activerecord:
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,12 @@ Rails.application.routes.draw do
           resource :uploaded, only: %i[edit update], controller: :uploaded
           resource :check_answers, only: %i[edit update], controller: :check_answers
         end
+
+        namespace :allegation do
+          resource :details, only: %i[edit]# update]
+          # resource :dbs, only: %i[edit update]
+          # resource :check_answers, path: "check-answers", only: %i[edit update]
+        end
       end
 
       resource :referrer, only: %i[show update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,7 @@ Rails.application.routes.draw do
         namespace :allegation do
           resource :details, only: %i[edit update]
           resource :considerations, only: %i[edit update]
-          # resource :check_answers, path: "check-answers", only: %i[edit update]
+          resource :check_answers, path: "check-answers", only: %i[edit update]
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,8 +89,8 @@ Rails.application.routes.draw do
         end
 
         namespace :allegation do
-          resource :details, only: %i[edit]# update]
-          # resource :dbs, only: %i[edit update]
+          resource :details, only: %i[edit update]
+          resource :considerations, only: %i[edit update]
           # resource :check_answers, path: "check-answers", only: %i[edit update]
         end
       end

--- a/db/migrate/20230112202954_add_refferals_allegation_consideration_details.rb
+++ b/db/migrate/20230112202954_add_refferals_allegation_consideration_details.rb
@@ -1,0 +1,5 @@
+class AddRefferalsAllegationConsiderationDetails < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrals, :allegation_consideration_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_29_124830) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_12_202954) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -146,6 +146,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_29_124830) do
     t.string "organisation_town_or_city"
     t.string "organisation_postcode", limit: 11
     t.boolean "role_end_date_known"
+    t.text "allegation_consideration_details"
     t.index ["eligibility_check_id"], name: "index_referrals_on_eligibility_check_id"
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end

--- a/spec/forms/referrals/allegation/considerations_form_spec.rb
+++ b/spec/forms/referrals/allegation/considerations_form_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Referrals::Allegation::ConsiderationsForm, type: :model do
+  let(:referral) { build(:referral) }
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:allegation_consideration_details) { nil }
+
+    let(:form) do
+      described_class.new(
+        referral:,
+        allegation_consideration_details:,
+      )
+    end
+
+    context "with no allegation consideration details" do
+      before { save }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:allegation_consideration_details]).to eq(
+          ["Enter details of how the complaint was considered"]
+        )
+      end
+    end
+
+    context "with allegation consideration details" do
+      let(:allegation_consideration_details) { "Some details" }
+
+      before { save }
+
+
+      it { is_expected.to be_truthy }
+
+      it "adds does not add an error" do
+        expect(form.errors[:allegation_consideration_details]).to be_empty
+      end
+    end
+  end
+end

--- a/spec/forms/referrals/allegation/considerations_form_spec.rb
+++ b/spec/forms/referrals/allegation/considerations_form_spec.rb
@@ -10,10 +10,7 @@ RSpec.describe Referrals::Allegation::ConsiderationsForm, type: :model do
     let(:allegation_consideration_details) { nil }
 
     let(:form) do
-      described_class.new(
-        referral:,
-        allegation_consideration_details:,
-      )
+      described_class.new(referral:, allegation_consideration_details:)
     end
 
     context "with no allegation consideration details" do
@@ -32,7 +29,6 @@ RSpec.describe Referrals::Allegation::ConsiderationsForm, type: :model do
       let(:allegation_consideration_details) { "Some details" }
 
       before { save }
-
 
       it { is_expected.to be_truthy }
 

--- a/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
+++ b/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
@@ -15,6 +15,13 @@ RSpec.feature "Details of the allegation", type: :system do
 
     when_i_edit_details_of_the_allegation
     then_i_am_asked_how_i_want_to_make_the_allegation
+
+    when_i_click_save_and_continue
+    then_i_see_allegation_form_validation_errors
+
+    when_i_fill_out_allegation_details
+    and_i_click_save_and_continue
+    then_i_am_asked_how_the_complaint_has_been_considered
   end
 
   private
@@ -29,5 +36,18 @@ RSpec.feature "Details of the allegation", type: :system do
     expect(page).to have_content(
       "How do you want to tell us about your allegation?"
     )
+  end
+
+  def then_i_see_allegation_form_validation_errors
+    expect(page).to have_content("There is a problem")
+  end
+
+  def when_i_fill_out_allegation_details
+    choose "I’ll give details of the allegation", visible: false
+    fill_in "Details of the allegation", with: "Something something something"
+  end
+
+  def then_i_am_asked_how_the_complaint_has_been_considered
+    expect(page).to have_content("How has this complaint been considered?")
   end
 end

--- a/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
+++ b/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
@@ -29,6 +29,14 @@ RSpec.feature "Details of the allegation", type: :system do
     when_i_fill_out_allegation_considerations
     and_i_click_save_and_continue
     then_i_am_asked_to_confirm_the_allegation_details
+
+    when_i_click_save_and_continue
+    then_i_see_check_answers_form_validation_errors
+
+    when_i_choose_to_confirm
+    and_i_click_save_and_continue
+    then_i_see_the_public_referral_summary
+    and_the_allegation_section_is_complete
   end
 
   private
@@ -64,9 +72,62 @@ RSpec.feature "Details of the allegation", type: :system do
 
   def then_i_am_asked_to_confirm_the_allegation_details
     expect(page).to have_content("Check and confirm your answers")
+    expect_summary_row(
+      key: "How do you want to give details about the allegation?",
+      value: "Describe the allegation",
+      change_link:
+        edit_public_referral_allegation_details_path(
+          @referral,
+          return_to: current_path
+        )
+    )
+
+    expect_summary_row(
+      key: "Description of the allegation",
+      value: "Something something something",
+      change_link:
+        edit_public_referral_allegation_details_path(
+          @referral,
+          return_to: current_path
+        )
+    )
+
+    expect_summary_row(
+      key: "Details about how this complaint has been considered",
+      value: "considered stuff",
+      change_link:
+        edit_public_referral_allegation_considerations_path(
+          @referral,
+          return_to: current_path
+        )
+    )
   end
 
   def when_i_fill_out_allegation_considerations
-    fill_in "Details about how this complaint has been considered", with: "considered stuff"
+    fill_in "Details about how this complaint has been considered",
+            with: "considered stuff"
+  end
+
+  def then_i_see_check_answers_form_validation_errors
+    expect(page).to have_content("Select yes if you’ve completed this section")
+  end
+
+  def when_i_choose_to_confirm
+    choose "Yes, I’ve completed this section", visible: false
+  end
+
+  def and_the_allegation_section_is_complete
+    within(all(".app-task-list__section")[2]) do
+      within(all(".app-task-list__item")[0]) do
+        expect(find(".app-task-list__task-name a").text).to eq(
+          "Details of the allegation"
+        )
+        expect(find(".app-task-list__tag").text).to eq("COMPLETED")
+      end
+    end
+  end
+
+  def then_i_see_the_public_referral_summary
+    expect(page).to have_current_path(edit_public_referral_path(@referral))
   end
 end

--- a/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
+++ b/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Details of the allegation", type: :system do
+  include CommonSteps
+  include SummaryListHelpers
+
+  scenario "A member of the public adds details of the allegation to a referral" do
+    given_the_service_is_open
+    and_i_am_signed_in
+    and_the_referral_form_feature_is_active
+    and_i_am_a_member_of_the_public_with_an_existing_referral
+    and_i_visit_the_public_referral
+    then_i_see_the_public_referral_summary
+
+    when_i_edit_details_of_the_allegation
+    then_i_am_asked_how_i_want_to_make_the_allegation
+  end
+
+  private
+
+  def when_i_edit_details_of_the_allegation
+    within(all(".app-task-list__section")[2]) do
+      click_on "Details of the allegation"
+    end
+  end
+
+  def then_i_am_asked_how_i_want_to_make_the_allegation
+    expect(page).to have_content(
+      "How do you want to tell us about your allegation?"
+    )
+  end
+end

--- a/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
+++ b/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
@@ -22,6 +22,13 @@ RSpec.feature "Details of the allegation", type: :system do
     when_i_fill_out_allegation_details
     and_i_click_save_and_continue
     then_i_am_asked_how_the_complaint_has_been_considered
+
+    when_i_click_save_and_continue
+    then_i_see_the_allegation_considerations_form_validation_errors
+
+    when_i_fill_out_allegation_considerations
+    and_i_click_save_and_continue
+    then_i_am_asked_to_confirm_the_allegation_details
   end
 
   private
@@ -49,5 +56,17 @@ RSpec.feature "Details of the allegation", type: :system do
 
   def then_i_am_asked_how_the_complaint_has_been_considered
     expect(page).to have_content("How has this complaint been considered?")
+  end
+
+  def then_i_see_the_allegation_considerations_form_validation_errors
+    expect(page).to have_content("There is a problem")
+  end
+
+  def then_i_am_asked_to_confirm_the_allegation_details
+    expect(page).to have_content("Check and confirm your answers")
+  end
+
+  def when_i_fill_out_allegation_considerations
+    fill_in "Details about how this complaint has been considered", with: "considered stuff"
   end
 end


### PR DESCRIPTION
### Context

We are building out the public referral flow of the service. We require allegation information and we hadn't implemented the public version of this which is quite different from the employer version.

### Changes proposed in this pull request

* Add the public flow
* Add public controllers overriding behaviour as necessary
* Add a public allegation component as the one we're using for the employer flow is quite different and it would require a fair bit of logic for branching between public and employer
* Add `Referral#allegation_consideration_details` to store the allegation consideration entry

### Guidance to review

I've fleshed out the main bits of the journey which should all be functional now as per the screenshots.

There are some things I haven't done as part of this PR. 

* the back link is missing from the check answers page. I can add that but we're going to look at the back links across the whole journey so it can be picked up in there
* I've left the generic `Referral::Allegation::CheckAnswers` form. There is some view related stuff in there that probably belongs more appropriately in the `WhatHappenedComponent` (which we should rename incidentally). It also has only one validation rule based on the details type not being 'incomplete'. The rules for a 'valid' check answers are probably broader than that and are different for each flow. Given you can't get to check answers in the normal flow without completing the forms I wonder if we really need to validate too much at this point. That said, you can access it with a URL so maybe we do. I can card that up to look at both journeys if we decide we do.
* There aren't any component specs to speak of so I haven't added them for the new one in this PR. Not sure if we made a decision not to do them. I can add or we can add them for all components later.
* I've styled the totally new views as per the prototype but haven't gone back to do the ones that we're using from the employer form or that I've copied in. We've got cards to sort that out later.

<img width="883" alt="Screenshot 2023-01-13 at 10 35 09" src="https://user-images.githubusercontent.com/5216/212300776-c259a9e5-9edd-4347-af9c-4442dfeb78c6.png">

<img width="1116" alt="Screenshot 2023-01-13 at 10 35 17" src="https://user-images.githubusercontent.com/5216/212300793-74dfae8c-3b19-4cf0-84e7-62391b73ab9f.png">

<img width="1030" alt="Screenshot 2023-01-13 at 10 35 40" src="https://user-images.githubusercontent.com/5216/212300813-9c935355-cea6-4c72-ab8c-dea8a09b939e.png">

<img width="1049" alt="Screenshot 2023-01-13 at 10 35 51" src="https://user-images.githubusercontent.com/5216/212300836-b8d41167-646c-4103-bebe-c6b64a2de226.png">

### Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/12Au756f/1094-implement-public-version-of-details-of-the-allegation-task-list-section)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
