### PR TITLE
Fix file deletions for public evidence

### DIFF
--- a/app/components/evidence_component.rb
+++ b/app/components/evidence_component.rb
@@ -1,5 +1,6 @@
 class EvidenceComponent < ViewComponent::Base
   include ActiveModel::Model
+  include ReferralHelper
 
   attr_accessor :referral
 
@@ -15,7 +16,12 @@ class EvidenceComponent < ViewComponent::Base
         {
           text: "Change",
           href:
-            edit_referral_evidence_start_path(referral, return_to: request.url)
+            subsection_path(
+              action: :edit,
+              referral:,
+              return_to: request.path,
+              subsection: :evidence_start
+            )
         }
       ],
       key: {
@@ -35,9 +41,11 @@ class EvidenceComponent < ViewComponent::Base
         {
           text: "Change",
           href:
-            edit_referral_evidence_uploaded_path(
-              referral,
-              return_to: request.url
+            subsection_path(
+              action: :edit,
+              referral:,
+              return_to: request.path,
+              subsection: :evidence_uploaded
             )
         }
       ],

--- a/app/views/public_referrals/evidence/uploaded/edit.html.erb
+++ b/app/views/public_referrals/evidence/uploaded/edit.html.erb
@@ -17,7 +17,7 @@
             <%= govuk_link_to(evidence.filename, rails_blob_path(evidence.document, disposition: "attachment")) %>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <%= govuk_link_to(referral_evidence_delete_path(current_referral, evidence, return_to: request.url)) do %>
+            <%= govuk_link_to(public_referral_evidence_delete_path(current_referral, evidence, return_to: request.url)) do %>
               Delete<span class="govuk-visually-hidden"> <%= evidence.filename %></span>
             <% end %>
           </dd>

--- a/app/views/referrals/evidence/check_answers/delete.html.erb
+++ b/app/views/referrals/evidence/check_answers/delete.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Are you sure you want to delete #{evidence.filename}" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_evidence_uploaded_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(subsection_path(action: :edit, referral: current_referral, subsection: :evidence_uploaded)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -9,12 +9,12 @@
 
     <%= govuk_button_to(
       "Yes I’m sure – delete it",
-      referral_evidence_destroy_path(current_referral, evidence),
+      subsection_path(referral: current_referral, subsection: :evidence_destroy),
       method: :delete,
       class: "govuk-button--warning"
     ) %>
     <p>
-      <%= govuk_link_to "Cancel", edit_referral_evidence_check_answers_path(current_referral) %>
+      <%= govuk_link_to "Cancel", subsection_path(action: :edit, referral: current_referral, subsection: :evidence_check_answers) %>
     </p>
   </div>
 </div>

--- a/spec/system/public_referrals/user_adds_evidence_spec.rb
+++ b/spec/system/public_referrals/user_adds_evidence_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Evidence", type: :system do
   include CommonSteps
   include SummaryListHelpers
 
-  xscenario "A member of public adds evidence to referral" do
+  scenario "A member of public adds evidence to referral" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_referral_form_feature_is_active
@@ -191,14 +191,20 @@ RSpec.feature "Evidence", type: :system do
       key: "Do you have anything to upload?",
       value: "Yes",
       change_link:
-        edit_referral_evidence_start_path(@referral, return_to: current_url)
+        edit_public_referral_evidence_start_path(
+          @referral,
+          return_to: current_path
+        )
     )
 
     expect_summary_row(
       key: "Uploaded evidence",
       value: "upload2.pdf\nupload.txt",
       change_link:
-        edit_referral_evidence_uploaded_path(@referral, return_to: current_url)
+        edit_public_referral_evidence_uploaded_path(
+          @referral,
+          return_to: current_path
+        )
     )
   end
 

--- a/spec/system/referrals/user_adds_evidence_spec.rb
+++ b/spec/system/referrals/user_adds_evidence_spec.rb
@@ -199,14 +199,14 @@ RSpec.feature "Evidence", type: :system do
       key: "Do you have anything to upload?",
       value: "Yes",
       change_link:
-        edit_referral_evidence_start_path(@referral, return_to: current_url)
+        edit_referral_evidence_start_path(@referral, return_to: current_path)
     )
 
     expect_summary_row(
       key: "Uploaded evidence",
       value: "upload2.pdf\nupload.txt",
       change_link:
-        edit_referral_evidence_uploaded_path(@referral, return_to: current_url)
+        edit_referral_evidence_uploaded_path(@referral, return_to: current_path)
     )
   end
 


### PR DESCRIPTION
The public flow for adding evidence has an issue with deleting uploaded
files.

The links point to the employer flow, which leads to 404s.

This change enables the tests and ensures the paths are all correct.

### Link to Trello card

https://trello.com/c/HzpGmD6I/1095-fix-file-deletion-in-public-supporting-information-section

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="935" alt="Screenshot 2023-01-13 at 10 50 23 am" src="https://user-images.githubusercontent.com/3126/212302662-671f3555-cd7f-4f6b-b152-fc3fc1a3e564.png">
