### PR TITLE
Add "About their role" public flow

### DIFF
--- a/app/components/their_role_component.rb
+++ b/app/components/their_role_component.rb
@@ -6,21 +6,18 @@ class TheirRoleComponent < ViewComponent::Base
   attr_accessor :referral
 
   def rows
-    @rows = [
-      job_title_row,
-      role_duties_row,
-      role_duties_description_row,
-      same_organisation_row
-    ]
+    @rows = [job_title_row, role_duties_row, role_duties_description_row]
+
+    @rows << same_organisation_row if referral.from_employer?
 
     unless referral.same_organisation?
       @rows << organisation_address_known_row
-      @rows << organisation_address_row
+      @rows << organisation_address_row if referral.organisation_address_known
     end
 
-    @rows << start_date_known_row
+    @rows << start_date_known_row if referral.from_employer?
     @rows << start_date_row if referral.role_start_date_known
-    @rows << employment_status_row
+    @rows << employment_status_row if referral.from_employer?
 
     return @rows unless referral.left_role?
 
@@ -46,9 +43,11 @@ class TheirRoleComponent < ViewComponent::Base
         {
           text: "Change",
           href:
-            edit_referral_teacher_role_job_title_path(
-              referral,
-              return_to: request.url
+            subsection_path(
+              action: :edit,
+              referral:,
+              return_to: request.url,
+              subsection: :teacher_role_job_title
             ),
           visually_hidden_text: "their job title"
         }
@@ -68,9 +67,11 @@ class TheirRoleComponent < ViewComponent::Base
         {
           text: "Change",
           href:
-            edit_referral_teacher_role_duties_path(
-              referral,
-              return_to: request.url
+            subsection_path(
+              action: :edit,
+              referral:,
+              return_to: request.url,
+              subsection: :teacher_role_duties
             ),
           visually_hidden_text:
             "how do you want to give details about their main duties"
@@ -91,9 +92,11 @@ class TheirRoleComponent < ViewComponent::Base
         {
           text: "Change",
           href:
-            edit_referral_teacher_role_duties_path(
-              referral,
-              return_to: request.url
+            subsection_path(
+              action: :edit,
+              referral:,
+              return_to: request.url,
+              subsection: :teacher_role_duties
             ),
           visually_hidden_text: "the description of their role"
         }
@@ -136,9 +139,11 @@ class TheirRoleComponent < ViewComponent::Base
         {
           text: "Change",
           href:
-            edit_referral_teacher_role_organisation_address_known_path(
-              referral,
-              return_to: request.url
+            subsection_path(
+              action: :edit,
+              referral:,
+              return_to: request.url,
+              subsection: :teacher_role_organisation_address_known
             ),
           visually_hidden_text:
             "if you know the name and address of the organisation where the alleged misconduct took place"
@@ -160,16 +165,19 @@ class TheirRoleComponent < ViewComponent::Base
         {
           text: "Change",
           href:
-            edit_referral_teacher_role_organisation_address_path(
-              referral,
-              return_to: request.url
+            subsection_path(
+              action: :edit,
+              referral:,
+              return_to: request.url,
+              subsection: :teacher_role_organisation_address
             ),
           visually_hidden_text:
-            "where they were employed at the time of the alleged misconduct"
+            "name and address of the organisation where the alleged misconduct took place"
         }
       ],
       key: {
-        text: "Where they were employed at the time of the alleged misconduct"
+        text:
+          "Name and address of the organisation where the alleged misconduct took place"
       },
       value: {
         text: referral_organisation_address(referral)

--- a/app/controllers/public_referrals/teacher_role/check_answers_controller.rb
+++ b/app/controllers/public_referrals/teacher_role/check_answers_controller.rb
@@ -1,0 +1,19 @@
+module PublicReferrals
+  module TeacherRole
+    class CheckAnswersController < Referrals::TeacherRole::CheckAnswersController
+      private
+
+      def next_path
+        edit_public_referral_path(current_referral)
+      end
+
+      def update_path
+        public_referral_teacher_role_check_answers_path(current_referral)
+      end
+
+      def back_link
+        edit_public_referral_path(current_referral)
+      end
+    end
+  end
+end

--- a/app/controllers/public_referrals/teacher_role/duties_controller.rb
+++ b/app/controllers/public_referrals/teacher_role/duties_controller.rb
@@ -1,0 +1,21 @@
+module PublicReferrals
+  module TeacherRole
+    class DutiesController < Referrals::TeacherRole::DutiesController
+      private
+
+      def next_path
+        edit_public_referral_teacher_role_organisation_address_known_path(
+          current_referral
+        )
+      end
+
+      def update_path
+        public_referral_teacher_role_duties_path(current_referral)
+      end
+
+      def back_link
+        edit_public_referral_teacher_role_job_title_path(current_referral)
+      end
+    end
+  end
+end

--- a/app/controllers/public_referrals/teacher_role/job_title_controller.rb
+++ b/app/controllers/public_referrals/teacher_role/job_title_controller.rb
@@ -1,0 +1,19 @@
+module PublicReferrals
+  module TeacherRole
+    class JobTitleController < Referrals::TeacherRole::JobTitleController
+      private
+
+      def next_path
+        edit_public_referral_teacher_role_duties_path(current_referral)
+      end
+
+      def update_path
+        public_referral_teacher_role_job_title_path(current_referral)
+      end
+
+      def back_link
+        edit_public_referral_path(current_referral)
+      end
+    end
+  end
+end

--- a/app/controllers/public_referrals/teacher_role/organisation_address_controller.rb
+++ b/app/controllers/public_referrals/teacher_role/organisation_address_controller.rb
@@ -1,0 +1,21 @@
+module PublicReferrals
+  module TeacherRole
+    class OrganisationAddressController < Referrals::TeacherRole::OrganisationAddressController
+      private
+
+      def next_path
+        edit_public_referral_teacher_role_check_answers_path(current_referral)
+      end
+
+      def update_path
+        public_referral_teacher_role_organisation_address_path(current_referral)
+      end
+
+      def back_link
+        edit_public_referral_teacher_role_organisation_address_known_path(
+          current_referral
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/public_referrals/teacher_role/organisation_address_known_controller.rb
+++ b/app/controllers/public_referrals/teacher_role/organisation_address_known_controller.rb
@@ -1,0 +1,27 @@
+module PublicReferrals
+  module TeacherRole
+    class OrganisationAddressKnownController < Referrals::TeacherRole::OrganisationAddressKnownController
+      private
+
+      def next_path
+        if current_referral.organisation_address_known?
+          edit_public_referral_teacher_role_organisation_address_path(
+            current_referral
+          )
+        else
+          edit_public_referral_teacher_role_check_answers_path(current_referral)
+        end
+      end
+
+      def update_path
+        public_referral_teacher_role_organisation_address_known_path(
+          current_referral
+        )
+      end
+
+      def back_link
+        edit_public_referral_teacher_role_duties_path(current_referral)
+      end
+    end
+  end
+end

--- a/app/controllers/referrals/teacher_role/check_answers_controller.rb
+++ b/app/controllers/referrals/teacher_role/check_answers_controller.rb
@@ -16,7 +16,7 @@ module Referrals
             )
           )
         if @teacher_role_check_answers_form.save
-          redirect_to edit_referral_path(current_referral)
+          redirect_to next_page
         else
           render :edit
         end
@@ -29,6 +29,20 @@ module Referrals
           :teacher_role_complete
         )
       end
+
+      def next_path
+        edit_referral_path(current_referral)
+      end
+
+      def update_path
+        referral_teacher_role_check_answers_path(current_referral)
+      end
+      helper_method :update_path
+
+      def back_link
+        edit_referral_path(current_referral)
+      end
+      helper_method :back_link
     end
   end
 end

--- a/app/controllers/referrals/teacher_role/duties_controller.rb
+++ b/app/controllers/referrals/teacher_role/duties_controller.rb
@@ -34,6 +34,16 @@ module Referrals
       def next_path
         edit_referral_teacher_role_same_organisation_path(current_referral)
       end
+
+      def update_path
+        referral_teacher_role_duties_path(current_referral)
+      end
+      helper_method :update_path
+
+      def back_link
+        edit_referral_teacher_role_job_title_path(current_referral)
+      end
+      helper_method :back_link
     end
   end
 end

--- a/app/controllers/referrals/teacher_role/job_title_controller.rb
+++ b/app/controllers/referrals/teacher_role/job_title_controller.rb
@@ -28,6 +28,16 @@ module Referrals
       def next_path
         edit_referral_teacher_role_duties_path(current_referral)
       end
+
+      def update_path
+        referral_teacher_role_job_title_path(current_referral)
+      end
+      helper_method :update_path
+
+      def back_link
+        edit_referral_path(current_referral)
+      end
+      helper_method :back_link
     end
   end
 end

--- a/app/controllers/referrals/teacher_role/organisation_address_controller.rb
+++ b/app/controllers/referrals/teacher_role/organisation_address_controller.rb
@@ -45,6 +45,18 @@ module Referrals
       def next_path
         edit_referral_teacher_role_start_date_path(current_referral)
       end
+
+      def update_path
+        referral_teacher_role_organisation_address_path(current_referral)
+      end
+      helper_method :update_path
+
+      def back_link
+        edit_referral_teacher_role_organisation_address_known_path(
+          current_referral
+        )
+      end
+      helper_method :back_link
     end
   end
 end

--- a/app/controllers/referrals/teacher_role/organisation_address_known_controller.rb
+++ b/app/controllers/referrals/teacher_role/organisation_address_known_controller.rb
@@ -46,6 +46,16 @@ module Referrals
 
         super
       end
+
+      def update_path
+        referral_teacher_role_organisation_address_known_path(current_referral)
+      end
+      helper_method :update_path
+
+      def back_link
+        edit_referral_teacher_role_same_organisation_path(current_referral)
+      end
+      helper_method :back_link
     end
   end
 end

--- a/app/controllers/referrals/teacher_role/start_date_controller.rb
+++ b/app/controllers/referrals/teacher_role/start_date_controller.rb
@@ -44,6 +44,16 @@ module Referrals
       def next_path
         edit_referral_teacher_role_employment_status_path(current_referral)
       end
+
+      def update_path
+        referral_teacher_role_start_date_path(current_referral)
+      end
+      helper_method :update_path
+
+      def back_link
+        edit_referral_teacher_role_same_organisation_path(current_referral)
+      end
+      helper_method :back_link
     end
   end
 end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -88,7 +88,7 @@ class ReferralForm
         section.items.append(
           ReferralSectionItem.new(
             I18n.t("referral_form.about_their_role"),
-            edit_referral_teacher_role_job_title_path(referral),
+            path_for_teacher_role,
             section_status(:teacher_role_complete)
           )
         )
@@ -154,5 +154,13 @@ class ReferralForm
     return start_path if status == :not_started_yet
 
     check_answers_path
+  end
+
+  def path_for_teacher_role
+    if referral.from_employer?
+      edit_referral_teacher_role_job_title_path(referral)
+    else
+      edit_public_referral_teacher_role_job_title_path(referral)
+    end
   end
 end

--- a/app/views/referrals/teacher_role/check_answers/edit.html.erb
+++ b/app/views/referrals/teacher_role/check_answers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @teacher_role_check_answers_form.errors.any?}Check and confirm your answers" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(back_link) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -10,7 +10,7 @@
 
     <%= render TheirRoleComponent.new(referral: current_referral) %>
 
-    <%= form_with model: @teacher_role_check_answers_form, url: referral_teacher_role_check_answers_path, method: :put do |f| %>
+    <%= form_with model: @teacher_role_check_answers_form, url: update_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset :teacher_role_complete,
         legend: { size: "m", text: "Have you completed this section?" },

--- a/app/views/referrals/teacher_role/duties/edit.html.erb
+++ b/app/views/referrals/teacher_role/duties/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @duties_form.errors.any?}How do you want to give details about their main duties?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_job_title_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(back_link) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @duties_form, url: referral_teacher_role_duties_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @duties_form, url: update_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/job_title/edit.html.erb
+++ b/app/views/referrals/teacher_role/job_title/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @job_title_form.errors.any?}Their job title" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(back_link) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @job_title_form, url: referral_teacher_role_job_title_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @job_title_form, url: update_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/organisation_address/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @organisation_address_form.errors.any?}Where they were employed at the time of the alleged misconduct" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_organisation_address_known_path(current_referral)) %>
+<% content_for :page_title, "#{'Error: ' if @organisation_address_form.errors.any?}Name and address of the organisation where the alleged misconduct took place" %>
+<% content_for :back_link_url, return_to_session_or(back_link) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @organisation_address_form, url: referral_teacher_role_organisation_address_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @organisation_address_form, url: update_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>
       <h1 class="govuk-heading-l">
-        Where they were employed at the time of the alleged misconduct
+        Name and address of the organisation where the alleged misconduct took place
       </h1>
 
       <%= f.govuk_text_field :organisation_name, label: { text: "Organisation name", size: "m" } %>

--- a/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @organisation_address_known_form.errors.any?}Do you know the name and address of the organisation?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_same_organisation_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(back_link) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @organisation_address_known_form, url: referral_teacher_role_organisation_address_known_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @organisation_address_known_form, url: update_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,7 +213,7 @@ en:
         "referrals/teacher_role/organisation_address_form":
           attributes:
             organisation_name:
-              blank: Enter organisation name
+              blank: Enter the organisation name
             organisation_address_line_1:
               blank: Enter the first line of their organisation's address
             organisation_town_or_city:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,23 @@ Rails.application.routes.draw do
           resource :considerations, only: %i[edit update]
           resource :check_answers, path: "check-answers", only: %i[edit update]
         end
+
+        namespace :teacher_role, path: "teacher-role" do
+          resource :job_title,
+            path: "job-title",
+            only: %i[edit update],
+            controller: :job_title
+          resource :duties, only: %i[edit update]
+          resource :organisation_address_known,
+            path: "organisation-address-known",
+            only: %i[edit update],
+            controller: :organisation_address_known
+          resource :organisation_address,
+            path: "organisation-address",
+            only: %i[edit update],
+            controller: :organisation_address
+          resource :check_answers, path: "check-answers", only: %i[edit update]
+        end
       end
 
       resource :referrer, only: %i[show update]

--- a/spec/forms/referrals/teacher_role/organisation_address_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/organisation_address_form_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Referrals::TeacherRole::OrganisationAddressForm, type: :model do
 
       it "adds an error" do
         expect(form.errors[:organisation_name]).to eq(
-          ["Enter organisation name"]
+          ["Enter the organisation name"]
         )
       end
     end

--- a/spec/system/public_referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_teacher_role_details_spec.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Teacher role", type: :system do
+  include CommonSteps
+  include SummaryListHelpers
+  include TaskListHelpers
+
+  scenario "A member of the public adds teacher role details to a referral" do
+    given_the_service_is_open
+    and_i_am_signed_in
+    and_the_referral_form_feature_is_active
+    and_i_am_a_member_of_the_public_with_an_existing_referral
+    and_i_visit_the_public_referral
+    then_i_see_the_public_referral_summary
+    and_i_see_the_status_section_in_the_referral_summary(
+      status: "NOT STARTED YET"
+    )
+
+    when_i_edit_teacher_role_details
+
+    # Their job title
+
+    then_i_see_the_job_title_page
+
+    when_i_click_save_and_continue
+    then_i_see_job_title_field_validation_errors
+
+    when_i_fill_in_the_job_title_field
+    and_i_click_save_and_continue
+
+    # How do you want to give details about their main duties?
+
+    then_i_see_the_duties_page
+
+    when_i_click_save_and_continue
+    then_i_see_duties_format_field_validation_errors
+
+    when_i_choose_upload
+    and_i_click_save_and_continue
+    then_i_see_duties_upload_field_validation_errors
+
+    when_i_choose_details
+    and_i_click_save_and_continue
+    then_i_see_duties_details_field_validation_errors
+
+    when_i_choose_upload
+    and_i_attach_a_job_description_file
+    and_i_click_save_and_continue
+    then_i_see_the_organisation_address_known_page
+
+    when_i_visit_the_duties_page
+    and_i_see_the_uploaded_filename
+    and_i_choose_upload
+    and_i_attach_a_second_job_description_file
+    and_i_click_save_and_continue
+    then_i_see_the_organisation_address_known_page
+
+    when_i_visit_the_duties_page
+    and_i_see_the_second_uploaded_filename
+    and_i_choose_details
+    and_i_fill_in_the_duties_field
+    and_i_click_save_and_continue
+
+    # Do you know the name and address of the organisation where the alleged misconduct took place?
+
+    then_i_see_the_organisation_address_known_page
+
+    when_i_click_save_and_continue
+    then_i_see_organisation_address_known_field_validation_errors
+
+    when_i_choose_no
+    and_i_click_save_and_continue
+    then_i_see_the_check_answers_page
+
+    when_i_visit_the_organisation_address_known_page
+    and_i_choose_yes
+    and_i_click_save_and_continue
+
+    # Name and address of the organisation where the alleged misconduct took place
+
+    then_i_see_the_organisation_address_page
+
+    when_i_click_save_and_continue
+    then_i_see_organisation_address_fields_validation_errors
+
+    when_i_fill_in_the_organisation_address_details
+    and_i_click_save_and_continue
+
+    # Check and confirm your answers
+
+    then_i_see_the_check_answers_page
+
+    when_i_click_save_and_continue
+    then_i_see_a_completed_error
+
+    when_i_choose_yes
+    and_i_click_save_and_continue
+    then_i_see_the_public_referral_summary
+    and_i_see_the_status_section_in_the_referral_summary
+
+    # Not completed
+
+    when_i_visit_the_check_answers_page
+    and_i_choose_no
+    and_i_click_save_and_continue
+    then_i_see_the_public_referral_summary
+    and_i_see_the_status_section_in_the_referral_summary(status: "INCOMPLETE")
+
+    # Check answers back link
+
+    when_i_visit_the_check_answers_page
+    and_i_click_back
+    then_i_see_the_public_referral_summary
+  end
+
+  private
+
+  def when_i_visit_the_job_title_page
+    visit edit_public_referral_teacher_role_job_title_path(@referral)
+  end
+
+  def when_i_visit_the_duties_page
+    visit edit_public_referral_teacher_role_duties_path(@referral)
+  end
+
+  def when_i_visit_the_organisation_address_known_page
+    visit edit_public_referral_teacher_role_organisation_address_known_path(
+            @referral
+          )
+  end
+
+  def when_i_visit_the_check_answers_page
+    visit edit_public_referral_teacher_role_check_answers_path(@referral)
+  end
+
+  # Page URL/Title
+
+  def then_i_see_the_job_title_page
+    expect(page).to have_current_path(
+      edit_public_referral_teacher_role_job_title_path(@referral)
+    )
+    expect(page).to have_title("Their job title")
+    expect(page).to have_content("Their job title")
+  end
+
+  def then_i_see_the_duties_page
+    expect(page).to have_current_path(
+      edit_public_referral_teacher_role_duties_path(@referral)
+    )
+    expect(page).to have_title(
+      "How do you want to give details about their main duties?"
+    )
+    expect(page).to have_content(
+      "How do you want to give details about their main duties?"
+    )
+  end
+
+  def then_i_see_the_organisation_address_known_page
+    expect(page).to have_current_path(
+      edit_public_referral_teacher_role_organisation_address_known_path(
+        @referral
+      )
+    )
+    expect(page).to have_title(
+      "Do you know the name and address of the organisation?"
+    )
+    expect(page).to have_content(
+      "Do you know the name and address of the organisation where the alleged misconduct took place?"
+    )
+  end
+
+  def then_i_see_the_organisation_address_page
+    expect(page).to have_current_path(
+      edit_public_referral_teacher_role_organisation_address_path(@referral)
+    )
+    expect(page).to have_title(
+      "Name and address of the organisation where the alleged misconduct took place"
+    )
+    expect(page).to have_content(
+      "Name and address of the organisation where the alleged misconduct took place"
+    )
+  end
+
+  def then_i_see_the_check_answers_page
+    expect(page).to have_current_path(
+      edit_public_referral_teacher_role_check_answers_path(@referral)
+    )
+    expect(page).to have_title("Check and confirm your answers")
+    expect(page).to have_content("Check and confirm your answers")
+  end
+
+  # Clicks
+
+  def when_i_edit_teacher_role_details
+    within(all(".app-task-list__section")[1]) { click_on "About their role" }
+  end
+
+  # Radios
+
+  def when_i_choose_yes
+    choose "Yes", visible: false
+  end
+  alias_method :and_i_choose_yes, :when_i_choose_yes
+
+  def when_i_choose_no
+    choose "No", visible: false
+  end
+  alias_method :and_i_choose_no, :when_i_choose_no
+
+  def when_i_choose_upload
+    choose "Upload file", visible: false
+  end
+  alias_method :and_i_choose_upload, :when_i_choose_upload
+
+  def when_i_choose_details
+    choose "Describe their main duties", visible: false
+  end
+  alias_method :and_i_choose_details, :when_i_choose_details
+
+  # Text inputs
+
+  def when_i_fill_in_the_job_title_field
+    fill_in "Their job title", with: "Teacher"
+  end
+
+  def and_i_fill_in_the_duties_field
+    fill_in "Description of their main duties", with: "Morganisationes"
+  end
+
+  def when_i_fill_in_the_organisation_address_details
+    fill_in "Organisation name", with: "High School"
+    fill_in "Address line 1", with: "1428 Elm Street"
+    fill_in "Town or city", with: "London"
+    fill_in "Postcode", with: "NW1 4NP"
+  end
+
+  # File uploads
+
+  def and_i_attach_a_job_description_file
+    attach_file(
+      "Upload file",
+      File.absolute_path(Rails.root.join("spec/fixtures/files/upload1.pdf"))
+    )
+  end
+
+  def and_i_attach_a_second_job_description_file
+    attach_file(
+      "Upload file",
+      File.absolute_path(Rails.root.join("spec/fixtures/files/upload2.pdf"))
+    )
+  end
+
+  # Validation errors
+
+  def then_i_see_job_title_field_validation_errors
+    expect(page).to have_content("Enter their job title")
+  end
+
+  def then_i_see_duties_format_field_validation_errors
+    expect(page).to have_content(
+      "Select how you want to give details about their main duties"
+    )
+  end
+
+  def then_i_see_duties_upload_field_validation_errors
+    expect(page).to have_content(
+      "Select a file containing a description of their main duties"
+    )
+  end
+
+  def then_i_see_duties_details_field_validation_errors
+    expect(page).to have_content("Enter a description of their main duties")
+  end
+
+  def then_i_see_organisation_address_known_field_validation_errors
+    expect(page).to have_content(
+      "Select yes if you know the name and address of the organisation"
+    )
+  end
+
+  def then_i_see_organisation_address_fields_validation_errors
+    expect(page).to have_content("Enter the organisation name")
+    expect(page).to have_content(
+      "Enter the first line of their organisation's address"
+    )
+    expect(page).to have_content("Enter a town or city for their organisation")
+    expect(page).to have_content("Enter a postcode for their organisation")
+  end
+
+  def then_i_see_a_completed_error
+    expect(page).to have_content("Select yes if you’ve completed this section")
+  end
+
+  # Page content
+
+  def and_i_see_the_uploaded_filename
+    expect(page).to have_content("Uploaded file: upload1.pdf")
+  end
+
+  def and_i_see_the_second_uploaded_filename
+    expect(page).to have_content("Uploaded file: upload2.pdf")
+  end
+
+  def and_i_see_the_status_section_in_the_referral_summary(status: "COMPLETED")
+    expect_task_row(
+      section: "About the person you’re referring",
+      item_position: 2,
+      name: "About their role",
+      tag: status
+    )
+  end
+end

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Teacher role", type: :system do
     and_i_have_an_existing_referral
     and_i_visit_the_referral
     then_i_see_the_referral_summary
-    then_i_see_the_status_section_in_the_referral_summary(
+    and_i_see_the_status_section_in_the_referral_summary(
       status: "NOT STARTED YET"
     )
 
@@ -27,7 +27,7 @@ RSpec.feature "Teacher role", type: :system do
     then_i_see_job_title_field_validation_errors
 
     when_i_fill_in_the_job_title_field
-    when_i_click_save_and_continue
+    and_i_click_save_and_continue
 
     # How do you want to give details about their main duties?
 
@@ -44,7 +44,7 @@ RSpec.feature "Teacher role", type: :system do
     and_i_click_save_and_continue
     then_i_see_duties_details_field_validation_errors
 
-    and_i_choose_upload
+    when_i_choose_upload
     and_i_attach_a_job_description_file
     and_i_click_save_and_continue
     then_i_see_the_same_organisation_page
@@ -59,7 +59,7 @@ RSpec.feature "Teacher role", type: :system do
     when_i_visit_the_duties_page
     and_i_see_the_second_uploaded_filename
     and_i_choose_details
-    when_i_fill_in_the_duties_field
+    and_i_fill_in_the_duties_field
     and_i_click_save_and_continue
 
     # Did they work at the same organisation as you at the time of the alleged misconduct?
@@ -70,7 +70,39 @@ RSpec.feature "Teacher role", type: :system do
     then_i_see_same_organisation_field_validation_errors
 
     when_i_choose_yes
+    and_i_click_save_and_continue
+    then_i_see_the_job_start_date_page
+
+    # Do you know the name and address of the organisation where the alleged misconduct took place?
+
+    when_i_visit_the_same_organisation_page
+    and_i_choose_no
+    and_i_click_save_and_continue
+    then_i_see_the_organisation_address_known_page
+
     when_i_click_save_and_continue
+    then_i_see_organisation_address_known_field_validation_errors
+
+    when_i_choose_no
+    and_i_click_save_and_continue
+    then_i_see_the_job_start_date_page
+
+    when_i_visit_the_organisation_address_known_page
+    and_i_choose_yes
+    and_i_click_save_and_continue
+
+    # Name and address of the organisation where the alleged misconduct took place
+
+    then_i_see_the_organisation_address_page
+
+    when_i_click_save_and_continue
+    then_i_see_organisation_address_fields_validation_errors
+
+    when_i_fill_in_the_teaching_address_details
+    and_i_click_save_and_continue
+
+    # Do you know when they started their job?
+
     then_i_see_the_job_start_date_page
 
     when_i_click_save_and_continue
@@ -81,12 +113,12 @@ RSpec.feature "Teacher role", type: :system do
 
     then_i_see_the_employed_status_page
     when_i_click_back
-    when_i_choose_yes
+    and_i_choose_yes
     and_i_click_save_and_continue
     then_i_see_role_start_date_field_validation_errors
 
     when_i_choose_yes
-    when_i_fill_out_the_role_start_date_fields
+    and_i_fill_out_the_role_start_date_fields
     and_i_click_save_and_continue
 
     # Are they still employed in that job?
@@ -101,12 +133,12 @@ RSpec.feature "Teacher role", type: :system do
     then_i_see_the_check_answers_page
 
     when_i_visit_the_employment_status_page
-    when_i_choose_employed
+    and_i_choose_employed
     and_i_click_save_and_continue
     then_i_see_the_check_answers_page
 
     when_i_visit_the_employment_status_page
-    when_i_choose_left
+    and_i_choose_left
     and_i_click_save_and_continue
     then_i_see_the_job_end_date_page
 
@@ -114,7 +146,7 @@ RSpec.feature "Teacher role", type: :system do
     then_i_see_role_end_date_field_validation_errors
 
     when_i_choose_yes
-    when_i_fill_out_the_role_end_date_fields
+    and_i_fill_out_the_role_end_date_fields
     and_i_click_save_and_continue
 
     then_i_see_the_reason_leaving_role_page
@@ -132,12 +164,12 @@ RSpec.feature "Teacher role", type: :system do
     then_i_see_working_somewhere_else_field_validation_errors
 
     when_i_choose_no
-    when_i_click_save_and_continue
+    and_i_click_save_and_continue
     then_i_see_the_check_answers_page
 
     when_i_visit_the_working_somewhere_else_page
     and_i_choose_yes
-    when_i_click_save_and_continue
+    and_i_click_save_and_continue
 
     # Do you know the name and address of the organisation where they’re currently working?
 
@@ -152,16 +184,16 @@ RSpec.feature "Teacher role", type: :system do
 
     when_i_visit_the_work_location_known_page
     and_i_choose_yes
-    when_i_click_save_and_continue
+    and_i_click_save_and_continue
 
     # Where they currently work
 
     then_i_see_the_work_location_page
     when_i_click_save_and_continue
-    then_i_see_work_location_address_field_validation_errors
+    then_i_see_work_location_address_fields_validation_errors
 
     when_i_fill_in_the_teaching_address_details
-    when_i_click_save_and_continue
+    and_i_click_save_and_continue
 
     # Check and confirm your answers
 
@@ -173,18 +205,20 @@ RSpec.feature "Teacher role", type: :system do
     when_i_choose_yes
     and_i_click_save_and_continue
     then_i_see_the_referral_summary
-    then_i_see_the_status_section_in_the_referral_summary
+    and_i_see_the_status_section_in_the_referral_summary
 
     # Not completed
+
     when_i_visit_the_check_answers_page
-    when_i_choose_no
+    and_i_choose_no
     and_i_click_save_and_continue
     then_i_see_the_referral_summary
-    then_i_see_the_status_section_in_the_referral_summary(status: "INCOMPLETE")
+    and_i_see_the_status_section_in_the_referral_summary(status: "INCOMPLETE")
 
     # Check answers back link
+
     when_i_visit_the_check_answers_page
-    when_i_click_back
+    and_i_click_back
     then_i_see_the_referral_summary
   end
 
@@ -200,6 +234,10 @@ RSpec.feature "Teacher role", type: :system do
 
   def when_i_visit_the_same_organisation_page
     visit edit_referral_teacher_role_same_organisation_path(@referral)
+  end
+
+  def when_i_visit_the_organisation_address_known_page
+    visit edit_referral_teacher_role_organisation_address_known_path(@referral)
   end
 
   def when_i_visit_the_duties_page
@@ -253,6 +291,30 @@ RSpec.feature "Teacher role", type: :system do
     )
     expect(page).to have_content(
       "Did they work at the same organisation as you at the time of the alleged misconduct?"
+    )
+  end
+
+  def then_i_see_the_organisation_address_known_page
+    expect(page).to have_current_path(
+      edit_referral_teacher_role_organisation_address_known_path(@referral)
+    )
+    expect(page).to have_title(
+      "Do you know the name and address of the organisation?"
+    )
+    expect(page).to have_content(
+      "Do you know the name and address of the organisation where the alleged misconduct took place?"
+    )
+  end
+
+  def then_i_see_the_organisation_address_page
+    expect(page).to have_current_path(
+      edit_referral_teacher_role_organisation_address_path(@referral)
+    )
+    expect(page).to have_title(
+      "Name and address of the organisation where the alleged misconduct took place"
+    )
+    expect(page).to have_content(
+      "Name and address of the organisation where the alleged misconduct took place"
     )
   end
 
@@ -346,11 +408,11 @@ RSpec.feature "Teacher role", type: :system do
   end
   alias_method :and_i_choose_no, :when_i_choose_no
 
-  def when_i_choose_employed
+  def and_i_choose_employed
     choose "They’re still employed but they’ve been suspended", visible: false
   end
 
-  def when_i_choose_left
+  def and_i_choose_left
     choose "No, they have left the organisation", visible: false
   end
 
@@ -370,19 +432,19 @@ RSpec.feature "Teacher role", type: :system do
 
   # Text inputs
 
-  def when_i_fill_out_the_role_start_date_fields
+  def and_i_fill_out_the_role_start_date_fields
     fill_in "Day", with: "17"
     fill_in "Month", with: "1"
     fill_in "Year", with: "1990"
   end
-  alias_method :when_i_fill_out_the_role_end_date_fields,
-               :when_i_fill_out_the_role_start_date_fields
+  alias_method :and_i_fill_out_the_role_end_date_fields,
+               :and_i_fill_out_the_role_start_date_fields
 
   def when_i_fill_in_the_job_title_field
     fill_in "Their job title", with: "Teacher"
   end
 
-  def when_i_fill_in_the_duties_field
+  def and_i_fill_in_the_duties_field
     fill_in "Description of their main duties", with: "Main duties"
   end
 
@@ -447,6 +509,21 @@ RSpec.feature "Teacher role", type: :system do
     )
   end
 
+  def then_i_see_organisation_address_known_field_validation_errors
+    expect(page).to have_content(
+      "Select yes if you know the name and address of the organisation"
+    )
+  end
+
+  def then_i_see_organisation_address_fields_validation_errors
+    expect(page).to have_content("Enter the organisation name")
+    expect(page).to have_content(
+      "Enter the first line of their organisation's address"
+    )
+    expect(page).to have_content("Enter a town or city for their organisation")
+    expect(page).to have_content("Enter a postcode for their organisation")
+  end
+
   def then_i_see_duties_format_field_validation_errors
     expect(page).to have_content(
       "Select how you want to give details about their main duties"
@@ -475,7 +552,7 @@ RSpec.feature "Teacher role", type: :system do
     )
   end
 
-  def then_i_see_work_location_address_field_validation_errors
+  def then_i_see_work_location_address_fields_validation_errors
     expect(page).to have_content("Enter the organisation name")
     expect(page).to have_content("Enter the first line of the address")
     expect(page).to have_content("Enter the town or city")
@@ -496,7 +573,7 @@ RSpec.feature "Teacher role", type: :system do
     expect(page).to have_content("Uploaded file: upload2.pdf")
   end
 
-  def then_i_see_the_status_section_in_the_referral_summary(status: "COMPLETED")
+  def and_i_see_the_status_section_in_the_referral_summary(status: "COMPLETED")
     expect_task_row(
       section: "About the person you’re referring",
       item_position: 3,


### PR DESCRIPTION
### Context

This PR updates the public flow for the teacher role journey.

### Changes proposed in this pull request

The following changes have been implemented:

- Remove start date page
- Remove employment status page
- Remove same organisation page
- Update organisation pages
- Update check answers page to align to prototype

I also added a few missing system spec scenarios from the employment flow.

### Link to Trello card

https://trello.com/c/2tz9YoQp/1093-about-their-role-public-flow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
