### PR TITLE
[1096] Fix review referral

### DIFF
--- a/app/controllers/public_referrals/confirmation_controller.rb
+++ b/app/controllers/public_referrals/confirmation_controller.rb
@@ -1,0 +1,4 @@
+module PublicReferrals
+  class ConfirmationController < Referrals::ConfirmationController
+  end
+end

--- a/app/controllers/public_referrals/declaration_controller.rb
+++ b/app/controllers/public_referrals/declaration_controller.rb
@@ -1,0 +1,4 @@
+module PublicReferrals
+  class DeclarationController < Referrals::DeclarationController
+  end
+end

--- a/app/controllers/public_referrals/declaration_controller.rb
+++ b/app/controllers/public_referrals/declaration_controller.rb
@@ -1,4 +1,17 @@
 module PublicReferrals
   class DeclarationController < Referrals::DeclarationController
+    private
+
+    def update_path
+      public_referral_declaration_path(current_referral)
+    end
+
+    def back_link
+      public_referral_review_path(current_referral)
+    end
+
+    def next_path
+      public_referral_confirmation_path(current_referral)
+    end
   end
 end

--- a/app/controllers/public_referrals/review_controller.rb
+++ b/app/controllers/public_referrals/review_controller.rb
@@ -1,0 +1,4 @@
+module PublicReferrals
+  class ReviewController < Referrals::ReviewController
+  end
+end

--- a/app/controllers/public_referrals_controller.rb
+++ b/app/controllers/public_referrals_controller.rb
@@ -11,4 +11,12 @@ class PublicReferralsController < ReferralsController
   def referral
     @referral ||= current_user.referrals.member_of_public.find(params[:id])
   end
+
+  def review_path
+    public_referral_review_path(referral)
+  end
+
+  def update_path
+    public_referral_path(referral)
+  end
 end

--- a/app/controllers/referrals/declaration_controller.rb
+++ b/app/controllers/referrals/declaration_controller.rb
@@ -10,7 +10,7 @@ module Referrals
           declaration_form_params.merge(referral: current_referral)
         )
       if @declaration_form.save
-        redirect_to referral_confirmation_path(current_referral)
+        redirect_to next_path
       else
         render :show
       end
@@ -20,6 +20,20 @@ module Referrals
 
     def declaration_form_params
       params.require(:declaration_form).permit(:declaration_agreed)
+    end
+
+    def update_path
+      referral_declaration_path(current_referral)
+    end
+    helper_method :update_path
+
+    def back_link
+      referral_review_path(current_referral)
+    end
+    helper_method :back_link
+
+    def next_path
+      referral_confirmation_path(current_referral)
     end
   end
 end

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -25,7 +25,7 @@ class ReferralsController < Referrals::BaseController
     @referral_form = ReferralForm.new(referral:)
 
     if @referral_form.save
-      redirect_to referral_review_path(referral)
+      redirect_to review_path
     else
       render :edit
     end
@@ -64,4 +64,13 @@ class ReferralsController < Referrals::BaseController
   def redirect_to_screener_if_no_id_in_session
     redirect_to referral_type_path if session[:eligibility_check_id].blank?
   end
+
+  def review_path
+    referral_review_path(referral)
+  end
+
+  def update_path
+    referral_path(referral)
+  end
+  helper_method :update_path
 end

--- a/app/views/public_referrals/review/show.html.erb
+++ b/app/views/public_referrals/review/show.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title, 'Check your answers before continuing' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Check your answers before&nbsp;continuing</h1>
+      </div>
+    </div>
+
+    <h2 class="govuk-heading-l">1. About you</h2>
+    <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
+
+    <h2 class="govuk-heading-l">2. About the teacher </h2>
+    <%= render PersonalDetailsComponent.new(referral: current_referral) %>
+    <%= render TheirRoleComponent.new(referral: current_referral) %>
+
+    <h2 class="govuk-heading-l">3. The allegation</h2>
+    <%= render PublicAllegationComponent.new(referral: current_referral) %>
+    
+    <h2 class="govuk-heading-l">4. The evidence</h2>
+    <%= render EvidenceComponent.new(referral: current_referral) %>
+
+    <%= govuk_button_link_to "Continue", public_referral_declaration_path(current_referral) %>
+  </div>
+</div>

--- a/app/views/referrals/declaration/show.html.erb
+++ b/app/views/referrals/declaration/show.html.erb
@@ -1,20 +1,20 @@
 <% content_for :page_title, "#{'Error: ' if @declaration_form.errors.any?}Before you send your referral" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, return_to_session_or(back_link) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-xl">Before you send your referral</h1>
-    <p>You must confirm that:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>you want TRA to investigate this allegation, which could result in the person you’re referring being stopped from teaching</li>
-      <li>all your answers are true to the best of your knowledge and belief</li>
-      <li>you give consent for this referral and any supporting documents to be shared with the person you’re referring and any employer (only your name will be shared with them)</li>
-      <li>you have permission from the relevant third parties for any supporting documents to be shared, for example the police or DBS</li>
-      <li>you understand that you might need to attend a hearing of a professional conduct panel to give evidence should this allegation reach that stage</li>
-    </ul>
-    <p>This declaration is required by law and won’t affect any existing GDPR or other workplace regulations.</p>
-    <%= form_with model: @declaration_form, url: referral_declaration_path(current_referral), method: :post do |f| %>
+    <%= form_with model: @declaration_form, url: update_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-xl">Before you send your referral</h1>
+      <p>You must confirm that:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>you want TRA to investigate this allegation, which could result in the person you’re referring being stopped from teaching</li>
+        <li>all your answers are true to the best of your knowledge and belief</li>
+        <li>you give consent for this referral and any supporting documents to be shared with the person you’re referring and any employer (only your name will be shared with them)</li>
+        <li>you have permission from the relevant third parties for any supporting documents to be shared, for example the police or DBS</li>
+        <li>you understand that you might need to attend a hearing of a professional conduct panel to give evidence should this allegation reach that stage</li>
+      </ul>
+      <p>This declaration is required by law and won’t affect any existing GDPR or other workplace regulations.</p>
       <%= f.govuk_check_boxes_fieldset :declaration_agreed, multiple: false, legend: { text: 'Do you agree to this declaration?', size: 'm' } do %>
         <%= f.govuk_check_box :declaration_agreed, 1, 0, multiple: false, link_errors: true, label: { text: "Yes, I agree" } %>
       <% end %>

--- a/app/views/referrals/edit.html.erb
+++ b/app/views/referrals/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @referral_form, url: referral_path(referral), method: :put do |f| %>
+    <%= form_with model: @referral_form, url: update_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl"><%= t("referral_form.heading") %></h1>
       <%= render TaskListComponent.new(sections: @referral_form.sections) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,9 @@ Rails.application.routes.draw do
             controller: :organisation_address
           resource :check_answers, path: "check-answers", only: %i[edit update]
         end
+
+        resource :review, only: %i[show], controller: :review
+        resource :declaration, only: %i[show create], controller: :declaration
       end
 
       resource :referrer, only: %i[show update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
 
         resource :review, only: %i[show], controller: :review
         resource :declaration, only: %i[show create], controller: :declaration
+        resource :confirmation, only: %i[show], controller: :confirmation
       end
 
       resource :referrer, only: %i[show update]

--- a/spec/system/public_referrals/user_submits_referral_spec.rb
+++ b/spec/system/public_referrals/user_submits_referral_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.feature "member of the public submits a referral", type: :system do
+  include CommonSteps
+
+  scenario "happy path" do
+    given_the_service_is_open
+    and_i_am_signed_in
+    and_the_referral_form_feature_is_active
+    and_i_am_a_member_of_the_public_with_an_existing_referral
+    when_i_visit_the_public_referral
+    and_i_click_review_and_send
+    then_i_see_the_missing_sections_error
+
+    when_i_have_a_complete_referral
+    and_i_click_review_and_send
+    then_i_see_the_check_answers_page
+
+    when_i_click_continue
+    then_i_see_the_declaration_page
+  end
+
+  private
+
+  def and_i_click_review_and_send
+    click_on "Review and send"
+  end
+
+  def then_i_see_the_check_answers_page
+    expect(page).to have_current_path("/public-referrals/#{@referral.id}/review")
+    expect(page).to have_title("Check your answers before continuing")
+    expect(page).to have_content("Check your answers before continuing")
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_current_path("/public-referrals/#{@referral.id}/confirmation")
+    expect(page).to have_title("We have received your referral")
+    expect(page).to have_content("We have received your referral")
+  end
+
+  def then_i_see_the_declaration_page
+    expect(page).to have_current_path("/public-referrals/#{@referral.id}/declaration")
+    expect(page).to have_title("Before you send your referral")
+    expect(page).to have_content("Before you send your referral")
+  end
+
+  def then_i_see_the_missing_declaration_error
+    expect(page).to have_content("You must agree to the declaration")
+  end
+
+  def then_i_see_the_missing_sections_error
+    expect(page).to have_content("Please complete all sections of the referral")
+  end
+
+  def when_i_click_continue
+    click_on "Continue"
+  end
+
+  def when_i_click_send_referral
+    click_on "Send referral"
+  end
+  alias_method :and_i_click_send_referral, :when_i_click_send_referral
+
+  def when_i_complete_the_declaration
+    check "Yes, I agree", allow_label_click: true
+  end
+
+  def when_i_have_a_complete_referral
+    @referral.update(attributes_for(:referral, :complete))
+    create(:organisation, completed_at: Time.current, referral: @referral)
+    create(:referrer, completed_at: Time.current, referral: @referral)
+  end
+end

--- a/spec/system/public_referrals/user_submits_referral_spec.rb
+++ b/spec/system/public_referrals/user_submits_referral_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
-RSpec.feature "member of the public submits a referral", type: :system do
+RSpec.feature "A member of the public submits a referral", type: :system do
   include CommonSteps
 
-  scenario "happy path" do
+  scenario "A successful submission" do
     given_the_service_is_open
     and_i_am_signed_in
     and_the_referral_form_feature_is_active
@@ -18,6 +18,13 @@ RSpec.feature "member of the public submits a referral", type: :system do
 
     when_i_click_continue
     then_i_see_the_declaration_page
+
+    when_i_click_send_referral
+    then_i_see_the_missing_declaration_error
+
+    when_i_complete_the_declaration
+    and_i_click_send_referral
+    then_i_see_the_confirmation_page
   end
 
   private
@@ -27,19 +34,25 @@ RSpec.feature "member of the public submits a referral", type: :system do
   end
 
   def then_i_see_the_check_answers_page
-    expect(page).to have_current_path("/public-referrals/#{@referral.id}/review")
+    expect(page).to have_current_path(
+      "/public-referrals/#{@referral.id}/review"
+    )
     expect(page).to have_title("Check your answers before continuing")
     expect(page).to have_content("Check your answers before continuing")
   end
 
   def then_i_see_the_confirmation_page
-    expect(page).to have_current_path("/public-referrals/#{@referral.id}/confirmation")
+    expect(page).to have_current_path(
+      "/public-referrals/#{@referral.id}/confirmation"
+    )
     expect(page).to have_title("We have received your referral")
     expect(page).to have_content("We have received your referral")
   end
 
   def then_i_see_the_declaration_page
-    expect(page).to have_current_path("/public-referrals/#{@referral.id}/declaration")
+    expect(page).to have_current_path(
+      "/public-referrals/#{@referral.id}/declaration"
+    )
     expect(page).to have_title("Before you send your referral")
     expect(page).to have_content("Before you send your referral")
   end


### PR DESCRIPTION
### Context

We are completing the public referral journey. The review, declaration, confirmation stages of that journey hadn't been ported over yet.

### Changes proposed in this pull request

* implement the public version of the review, declaration and confirmation steps

### Guidance to review

This PR allows user to submit a complete referral. This flow has changed in the prototype now but I've not addressed that here as we can do the employer and public together and it's mostly just reordering the steps and some content updates.

<img width="901" alt="Screenshot 2023-01-13 at 17 06 53" src="https://user-images.githubusercontent.com/5216/212378375-a0fc6e04-9757-420c-b560-74dbb9c211a2.png">

<img width="1094" alt="Screenshot 2023-01-13 at 17 07 03" src="https://user-images.githubusercontent.com/5216/212378199-b99fb4c5-bb38-4aa8-8580-89d311b7eb95.png">

<img width="1183" alt="Screenshot 2023-01-13 at 17 07 12" src="https://user-images.githubusercontent.com/5216/212378208-536c3cca-71bc-47d3-a695-460c5b645d95.png">

### Link to Trello card

https://trello.com/c/Eu0qBj3h/1096-fix-review-referral

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
