### PR TITLE
Add a link to the uploaded allegation

### DIFF
--- a/app/components/what_happened_component.rb
+++ b/app/components/what_happened_component.rb
@@ -19,14 +19,14 @@ class WhatHappenedComponent < ViewComponent::Base
                 referral,
                 return_to: request.url
               ),
-            visually_hidden_text: "summary"
+            visually_hidden_text: "how I want to report the allegation"
           }
         ],
         key: {
           text: "Summary"
         },
         value: {
-          text: allegation_check_answers_form.allegation_details
+          text: allegation_details
         }
       },
       {
@@ -49,5 +49,21 @@ class WhatHappenedComponent < ViewComponent::Base
         }
       }
     ]
+  end
+
+  def allegation_details
+    if referral.allegation_upload.attached?
+      [
+        "File:",
+        govuk_link_to(
+          referral.allegation_upload.filename,
+          rails_blob_path(referral.allegation_upload, disposition: "attachment")
+        )
+      ].join(" ").html_safe
+    elsif referral.allegation_details.present?
+      referral.allegation_details.truncate(150)
+    else
+      "Incomplete"
+    end
   end
 end

--- a/app/forms/referrals/allegation/check_answers_form.rb
+++ b/app/forms/referrals/allegation/check_answers_form.rb
@@ -24,16 +24,6 @@ module Referrals
           errors.add(:base, :allegation_incomplete)
         end
       end
-
-      def allegation_details
-        if referral.allegation_upload.attached?
-          "File: #{referral.allegation_upload.filename}"
-        elsif referral.allegation_details.present?
-          referral.allegation_details.truncate(150)
-        else
-          "Incomplete"
-        end
-      end
     end
   end
 end

--- a/spec/system/referrals/user_adds_an_allegation_spec.rb
+++ b/spec/system/referrals/user_adds_an_allegation_spec.rb
@@ -30,6 +30,20 @@ RSpec.feature "Allegation", type: :system do
     and_i_click_save_and_continue
     then_i_am_asked_to_confirm_the_allegation_details
 
+    when_i_click_change_allegation_details
+    then_i_am_asked_how_i_want_to_make_the_allegation
+
+    when_i_choose_upload_the_allegation
+    and_i_click_save_and_continue
+    then_i_am_asked_to_upload_an_allegation_file
+
+    when_i_click_save_and_continue
+    then_i_see_the_upload_form_validation_errors
+
+    when_i_upload_the_allegation
+    and_i_click_save_and_continue
+    then_i_see_the_uploaded_filename
+
     when_i_click_save_and_continue
     then_i_see_check_answers_form_validation_errors
 
@@ -109,5 +123,34 @@ RSpec.feature "Allegation", type: :system do
         expect(find(".app-task-list__tag").text).to eq("COMPLETED")
       end
     end
+  end
+
+  def when_i_click_change_allegation_details
+    click_on "Change how I want to report the allegation"
+  end
+
+  def when_i_choose_upload_the_allegation
+    choose "I’ll upload the allegation details", visible: false
+  end
+
+  def then_i_am_asked_to_upload_an_allegation_file
+    expect(page).to have_content("Upload allegation details")
+  end
+
+  def then_i_see_the_upload_form_validation_errors
+    expect(page).to have_content(
+      "Select a file containing details of your allegation"
+    )
+  end
+
+  def then_i_see_the_uploaded_filename
+    expect(page).to have_content("upload1.pdf")
+  end
+
+  def when_i_upload_the_allegation
+    attach_file(
+      "Upload allegation details",
+      [Rails.root.join("spec/fixtures/files/upload1.pdf")]
+    )
   end
 end


### PR DESCRIPTION
When a user uploads a file as their allegation, we don't currently link
to the file.

This is inconsistent with other uploaded files in the app.

Of note in this change is that I moved the location of the
`allegation_details` method from the associated form object to the view
component.

This is to ensure access to the view context so that the link to the
filename can be rendered easily.

### Link to Trello card

https://trello.com/c/tNTGJhUO/1100-employer-allegation-check-answers-not-creating-a-link-for-the-file

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
