### PR TITLE
Use scoped routes where possible

### DIFF
--- a/app/components/contact_details_component.rb
+++ b/app/components/contact_details_component.rb
@@ -10,11 +10,7 @@ class ContactDetailsComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href:
-              edit_referral_contact_details_email_path(
-                referral,
-                return_to: request.url
-              ),
+            href: path_for(:email),
             visually_hidden_text: "email"
           }
         ],
@@ -29,11 +25,7 @@ class ContactDetailsComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href:
-              edit_referral_contact_details_telephone_path(
-                referral,
-                return_to: request.url
-              ),
+            href: path_for(:telephone),
             visually_hidden_text: "telephone"
           }
         ],
@@ -48,11 +40,7 @@ class ContactDetailsComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href:
-              edit_referral_contact_details_address_path(
-                referral,
-                return_to: request.url
-              ),
+            href: path_for(:address),
             visually_hidden_text: "address"
           }
         ],
@@ -64,5 +52,22 @@ class ContactDetailsComponent < ViewComponent::Base
         }
       }
     ]
+  end
+
+  def path_for(part)
+    [
+      :edit,
+      referral.routing_scope,
+      referral,
+      :contact_details,
+      part,
+      { return_to: }
+    ]
+  end
+
+  def return_to
+    polymorphic_path(
+      [:edit, referral.routing_scope, referral, :contact_details_check_answers]
+    )
   end
 end

--- a/app/components/organisation_component.rb
+++ b/app/components/organisation_component.rb
@@ -12,11 +12,14 @@ class OrganisationComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href:
-              edit_referral_organisation_name_path(
-                referral,
-                return_to: request.url
-              ),
+            href: [
+              :edit,
+              referral.routing_scope,
+              referral,
+              :organisation,
+              :name,
+              { return_to: }
+            ],
             visually_hidden_text: "name"
           }
         ],
@@ -31,11 +34,14 @@ class OrganisationComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href:
-              edit_referral_organisation_address_path(
-                referral,
-                return_to: request.url
-              ),
+            href: [
+              :edit,
+              referral.routing_scope,
+              referral,
+              :organisation,
+              :address,
+              { return_to: }
+            ],
             visually_hidden_text: "address"
           }
         ],
@@ -47,5 +53,9 @@ class OrganisationComponent < ViewComponent::Base
         }
       }
     ]
+  end
+
+  def return_to
+    polymorphic_path([referral.routing_scope, referral, :organisation])
   end
 end

--- a/app/components/previous_misconduct_component.rb
+++ b/app/components/previous_misconduct_component.rb
@@ -10,11 +10,14 @@ class PreviousMisconductComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href:
-              edit_referral_previous_misconduct_reported_path(
-                referral,
-                return_to: request.url
-              ),
+            href: [
+              :edit,
+              referral.routing_scope,
+              referral,
+              :previous_misconduct,
+              :reported,
+              { return_to: }
+            ],
             visually_hidden_text: "reported"
           }
         ],
@@ -31,11 +34,14 @@ class PreviousMisconductComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href:
-              edit_referral_previous_misconduct_detailed_account_path(
-                referral,
-                return_to: request.url
-              ),
+            href: [
+              :edit,
+              referral.routing_scope,
+              referral,
+              :previous_misconduct,
+              :detailed_account,
+              { return_to: }
+            ],
             visually_hidden_text: "details"
           }
         ],
@@ -61,5 +67,9 @@ class PreviousMisconductComponent < ViewComponent::Base
     end
 
     "Not answered yet"
+  end
+
+  def return_to
+    polymorphic_path([referral.routing_scope, referral, :previous_misconduct])
   end
 end

--- a/app/components/their_role_component.rb
+++ b/app/components/their_role_component.rb
@@ -42,16 +42,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            polymorphic_path(
-              [
-                :edit,
-                referral.routing_scope,
-                referral,
-                :teacher_role_job_title
-              ],
-              return_to: request.url
-            ),
+          href: path_for(:job_title),
           visually_hidden_text: "their job title"
         }
       ],
@@ -69,11 +60,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            polymorphic_path(
-              [:edit, referral.routing_scope, referral, :teacher_role_duties],
-              return_to: request.url
-            ),
+          href: path_for(:duties),
           visually_hidden_text:
             "how do you want to give details about their main duties"
         }
@@ -92,11 +79,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            polymorphic_path(
-              [:edit, referral.routing_scope, referral, :teacher_role_duties],
-              return_to: request.url
-            ),
+          href: path_for(:duties),
           visually_hidden_text: "the description of their role"
         }
       ],
@@ -114,11 +97,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            edit_referral_teacher_role_same_organisation_path(
-              referral,
-              return_to: request.url
-            ),
+          href: path_for(:same_organisation),
           visually_hidden_text: "working in the same organisation"
         }
       ],
@@ -137,16 +116,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            polymorphic_path(
-              [
-                :edit,
-                referral.routing_scope,
-                referral,
-                :teacher_role_organisation_address_known
-              ],
-              return_to: request.url
-            ),
+          href: path_for(:organisation_address_known),
           visually_hidden_text:
             "if you know the name and address of the organisation where the alleged misconduct took place"
         }
@@ -166,16 +136,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            polymorphic_path(
-              [
-                :edit,
-                referral.routing_scope,
-                referral,
-                :teacher_role_organisation_address
-              ],
-              return_to: request.url
-            ),
+          href: path_for(:organisation_address),
           visually_hidden_text:
             "name and address of the organisation where the alleged misconduct took place"
         }
@@ -195,11 +156,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            edit_referral_teacher_role_start_date_path(
-              referral,
-              return_to: request.url
-            ),
+          href: path_for(:start_date),
           visually_hidden_text: "if you know when they started their job"
         }
       ],
@@ -217,11 +174,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            edit_referral_teacher_role_start_date_path(
-              referral,
-              return_to: request.url
-            ),
+          href: path_for(:start_date),
           visually_hidden_text: "their job start date"
         }
       ],
@@ -239,11 +192,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            edit_referral_teacher_role_employment_status_path(
-              referral,
-              return_to: request.url
-            ),
+          href: path_for(:employment_status),
           visually_hidden_text:
             "if they are still employed in the job where the alleged misconduct took place"
         }
@@ -263,11 +212,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            edit_referral_teacher_role_end_date_path(
-              referral,
-              return_to: request.url
-            ),
+          href: path_for(:end_date),
           visually_hidden_text: "if you know when they left the job"
         }
       ],
@@ -285,11 +230,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            edit_referral_teacher_role_end_date_path(
-              referral,
-              return_to: request.url
-            ),
+          href: path_for(:end_date),
           visually_hidden_text: "their job end date"
         }
       ],
@@ -307,11 +248,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            edit_referral_teacher_role_reason_leaving_role_path(
-              referral,
-              return_to: request.url
-            ),
+          href: path_for(:reason_leaving_role),
           visually_hidden_text: "the reason they left the job"
         }
       ],
@@ -329,11 +266,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            edit_referral_teacher_role_working_somewhere_else_path(
-              referral,
-              return_to: request.url
-            ),
+          href: path_for(:working_somewhere_else),
           visually_hidden_text: "if they are they employed somewhere else"
         }
       ],
@@ -351,11 +284,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            edit_referral_teacher_role_work_location_known_path(
-              referral,
-              return_to: request.url
-            ),
+          href: path_for(:work_location_known),
           visually_hidden_text:
             "if you know the name and address of the organisation where they’re currently working"
         }
@@ -375,11 +304,7 @@ class TheirRoleComponent < ViewComponent::Base
       actions: [
         {
           text: "Change",
-          href:
-            edit_referral_teacher_role_work_location_path(
-              referral,
-              return_to: request.url
-            ),
+          href: path_for(:work_location),
           visually_hidden_text: "where they currently work"
         }
       ],
@@ -390,5 +315,22 @@ class TheirRoleComponent < ViewComponent::Base
         text: teaching_address(referral)
       }
     }
+  end
+
+  def path_for(part)
+    [
+      :edit,
+      referral.routing_scope,
+      referral,
+      :teacher_role,
+      part,
+      { return_to: }
+    ]
+  end
+
+  def return_to
+    polymorphic_path(
+      [:edit, referral.routing_scope, referral, :teacher_role, :check_answers]
+    )
   end
 end

--- a/app/components/what_happened_component.rb
+++ b/app/components/what_happened_component.rb
@@ -14,11 +14,14 @@ class WhatHappenedComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href:
-              edit_referral_allegation_details_path(
-                referral,
-                return_to: request.url
-              ),
+            href: [
+              :edit,
+              referral.routing_scope,
+              referral,
+              :allegation,
+              :details,
+              { return_to: }
+            ],
             visually_hidden_text: "how I want to report the allegation"
           }
         ],
@@ -33,11 +36,14 @@ class WhatHappenedComponent < ViewComponent::Base
         actions: [
           {
             text: "Change",
-            href:
-              edit_referral_allegation_dbs_path(
-                referral,
-                return_to: request.url
-              ),
+            href: [
+              :edit,
+              referral.routing_scope,
+              referral,
+              :allegation,
+              :dbs,
+              { return_to: }
+            ],
             visually_hidden_text: "DBS notified"
           }
         ],
@@ -65,5 +71,11 @@ class WhatHappenedComponent < ViewComponent::Base
     else
       "Incomplete"
     end
+  end
+
+  def return_to
+    polymorphic_path(
+      [:edit, referral.routing_scope, referral, :allegation, :check_answers]
+    )
   end
 end

--- a/app/controllers/public_referrals/allegation/check_answers_controller.rb
+++ b/app/controllers/public_referrals/allegation/check_answers_controller.rb
@@ -1,9 +1,6 @@
 module PublicReferrals
   module Allegation
     class CheckAnswersController < Referrals::Allegation::CheckAnswersController
-      def next_path
-        edit_public_referral_path(current_referral)
-      end
     end
   end
 end

--- a/app/controllers/public_referrals/allegation/details_controller.rb
+++ b/app/controllers/public_referrals/allegation/details_controller.rb
@@ -4,18 +4,14 @@ module PublicReferrals
   module Allegation
     class DetailsController < Referrals::Allegation::DetailsController
       def next_path
-        edit_public_referral_allegation_considerations_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :allegation,
+          :considerations
+        ]
       end
-
-      def update_path
-        public_referral_allegation_details_path(current_referral)
-      end
-      helper_method :update_path
-
-      def back_link
-        edit_public_referral_path(current_referral)
-      end
-      helper_method :back_link
     end
   end
 end

--- a/app/controllers/public_referrals/declaration_controller.rb
+++ b/app/controllers/public_referrals/declaration_controller.rb
@@ -1,17 +1,4 @@
 module PublicReferrals
   class DeclarationController < Referrals::DeclarationController
-    private
-
-    def update_path
-      public_referral_declaration_path(current_referral)
-    end
-
-    def back_link
-      public_referral_review_path(current_referral)
-    end
-
-    def next_path
-      public_referral_confirmation_path(current_referral)
-    end
   end
 end

--- a/app/controllers/public_referrals/personal_details/check_answers_controller.rb
+++ b/app/controllers/public_referrals/personal_details/check_answers_controller.rb
@@ -1,13 +1,6 @@
 module PublicReferrals
   module PersonalDetails
     class CheckAnswersController < Referrals::PersonalDetails::CheckAnswersController
-      def next_path
-        edit_public_referral_path(current_referral)
-      end
-
-      def update_path
-        public_referral_personal_details_check_answers_path(current_referral)
-      end
     end
   end
 end

--- a/app/controllers/public_referrals/personal_details/name_controller.rb
+++ b/app/controllers/public_referrals/personal_details/name_controller.rb
@@ -2,17 +2,13 @@ module PublicReferrals
   module PersonalDetails
     class NameController < Referrals::PersonalDetails::NameController
       def next_path
-        edit_public_referral_personal_details_check_answers_path(
-          current_referral
-        )
-      end
-
-      def update_path
-        public_referral_personal_details_name_path(current_referral)
-      end
-
-      def back_link
-        edit_public_referral_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :personal_details,
+          :check_answers
+        ]
       end
     end
   end

--- a/app/controllers/public_referrals/referrer_name_controller.rb
+++ b/app/controllers/public_referrals/referrer_name_controller.rb
@@ -3,11 +3,7 @@ module PublicReferrals
     private
 
     def next_path
-      edit_public_referral_referrer_phone_path(current_referral)
-    end
-
-    def update_path
-      public_referral_referrer_name_path(current_referral)
+      [:edit, current_referral.routing_scope, current_referral, :referrer_phone]
     end
   end
 end

--- a/app/controllers/public_referrals/referrer_phone_controller.rb
+++ b/app/controllers/public_referrals/referrer_phone_controller.rb
@@ -10,13 +10,5 @@ module PublicReferrals
         ]
       )
     end
-
-    def next_path
-      public_referral_referrer_path(current_referral)
-    end
-
-    def update_path
-      public_referral_referrer_phone_path(current_referral)
-    end
   end
 end

--- a/app/controllers/public_referrals/referrers_controller.rb
+++ b/app/controllers/public_referrals/referrers_controller.rb
@@ -1,11 +1,4 @@
 module PublicReferrals
   class ReferrersController < Referrals::ReferrersController
-    def next_path
-      edit_public_referral_path(current_referral)
-    end
-
-    def update_path
-      public_referral_referrer_path(current_referral)
-    end
   end
 end

--- a/app/controllers/public_referrals/teacher_role/check_answers_controller.rb
+++ b/app/controllers/public_referrals/teacher_role/check_answers_controller.rb
@@ -1,15 +1,6 @@
 module PublicReferrals
   module TeacherRole
     class CheckAnswersController < Referrals::TeacherRole::CheckAnswersController
-      private
-
-      def next_path
-        edit_public_referral_path(current_referral)
-      end
-
-      def update_path
-        public_referral_teacher_role_check_answers_path(current_referral)
-      end
     end
   end
 end

--- a/app/controllers/public_referrals/teacher_role/duties_controller.rb
+++ b/app/controllers/public_referrals/teacher_role/duties_controller.rb
@@ -1,20 +1,14 @@
 module PublicReferrals
   module TeacherRole
     class DutiesController < Referrals::TeacherRole::DutiesController
-      private
-
       def next_path
-        edit_public_referral_teacher_role_organisation_address_known_path(
-          current_referral
-        )
-      end
-
-      def update_path
-        public_referral_teacher_role_duties_path(current_referral)
-      end
-
-      def back_link
-        edit_public_referral_teacher_role_job_title_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :teacher_role,
+          :organisation_address_known
+        ]
       end
     end
   end

--- a/app/controllers/public_referrals/teacher_role/job_title_controller.rb
+++ b/app/controllers/public_referrals/teacher_role/job_title_controller.rb
@@ -1,19 +1,6 @@
 module PublicReferrals
   module TeacherRole
     class JobTitleController < Referrals::TeacherRole::JobTitleController
-      private
-
-      def next_path
-        edit_public_referral_teacher_role_duties_path(current_referral)
-      end
-
-      def update_path
-        public_referral_teacher_role_job_title_path(current_referral)
-      end
-
-      def back_link
-        edit_public_referral_path(current_referral)
-      end
     end
   end
 end

--- a/app/controllers/public_referrals/teacher_role/organisation_address_controller.rb
+++ b/app/controllers/public_referrals/teacher_role/organisation_address_controller.rb
@@ -1,20 +1,14 @@
 module PublicReferrals
   module TeacherRole
     class OrganisationAddressController < Referrals::TeacherRole::OrganisationAddressController
-      private
-
       def next_path
-        edit_public_referral_teacher_role_check_answers_path(current_referral)
-      end
-
-      def update_path
-        public_referral_teacher_role_organisation_address_path(current_referral)
-      end
-
-      def back_link
-        edit_public_referral_teacher_role_organisation_address_known_path(
-          current_referral
-        )
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :teacher_role,
+          :check_answers
+        ]
       end
     end
   end

--- a/app/controllers/public_referrals/teacher_role/organisation_address_known_controller.rb
+++ b/app/controllers/public_referrals/teacher_role/organisation_address_known_controller.rb
@@ -5,22 +5,34 @@ module PublicReferrals
 
       def next_path
         if current_referral.organisation_address_known?
-          edit_public_referral_teacher_role_organisation_address_path(
-            current_referral
-          )
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :organisation_address
+          ]
         else
-          edit_public_referral_teacher_role_check_answers_path(current_referral)
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :check_answers
+          ]
         end
       end
 
-      def update_path
-        public_referral_teacher_role_organisation_address_known_path(
-          current_referral
-        )
-      end
-
       def back_link
-        edit_public_referral_teacher_role_duties_path(current_referral)
+        polymorphic_path(
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :duties
+          ]
+        )
       end
     end
   end

--- a/app/controllers/public_referrals_controller.rb
+++ b/app/controllers/public_referrals_controller.rb
@@ -11,12 +11,4 @@ class PublicReferralsController < ReferralsController
   def referral
     @referral ||= current_user.referrals.member_of_public.find(params[:id])
   end
-
-  def review_path
-    public_referral_review_path(referral)
-  end
-
-  def update_path
-    public_referral_path(referral)
-  end
 end

--- a/app/controllers/referrals/allegation/check_answers_controller.rb
+++ b/app/controllers/referrals/allegation/check_answers_controller.rb
@@ -16,7 +16,7 @@ module Referrals
           )
 
         if @allegation_check_answers_form.save
-          redirect_to next_path
+          redirect_to [:edit, current_referral.routing_scope, current_referral]
         else
           render :edit
         end
@@ -28,10 +28,6 @@ module Referrals
         params.fetch(:referrals_allegation_check_answers_form, {}).permit(
           :allegation_details_complete
         )
-      end
-
-      def next_path
-        edit_referral_path(current_referral)
       end
     end
   end

--- a/app/controllers/referrals/allegation/dbs_controller.rb
+++ b/app/controllers/referrals/allegation/dbs_controller.rb
@@ -24,7 +24,13 @@ module Referrals
       end
 
       def next_path
-        edit_referral_allegation_check_answers_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :allegation,
+          :check_answers
+        ]
       end
     end
   end

--- a/app/controllers/referrals/allegation/details_controller.rb
+++ b/app/controllers/referrals/allegation/details_controller.rb
@@ -34,18 +34,14 @@ module Referrals
       end
 
       def next_path
-        edit_referral_allegation_dbs_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :allegation,
+          :dbs
+        ]
       end
-
-      def back_link
-        edit_referral_path(current_referral)
-      end
-      helper_method :back_link
-
-      def update_path
-        referral_allegation_details_path(current_referral)
-      end
-      helper_method :update_path
     end
   end
 end

--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -13,7 +13,7 @@ module Referrals
     private
 
     def current_referral
-      id = params[:referral_id] || params[:public_referral_id]
+      id = params[:id] || params[:referral_id] || params[:public_referral_id]
       @current_referral ||= current_user.referrals.find(id)
     end
     helper_method :current_referral

--- a/app/controllers/referrals/contact_details/address_controller.rb
+++ b/app/controllers/referrals/contact_details/address_controller.rb
@@ -41,7 +41,13 @@ module Referrals
       end
 
       def next_path
-        edit_referral_contact_details_check_answers_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :contact_details,
+          :check_answers
+        ]
       end
     end
   end

--- a/app/controllers/referrals/contact_details/check_answers_controller.rb
+++ b/app/controllers/referrals/contact_details/check_answers_controller.rb
@@ -16,7 +16,7 @@ module Referrals
             )
           )
         if @contact_details_check_answers_form.save
-          redirect_to edit_referral_path(current_referral)
+          redirect_to [:edit, current_referral.routing_scope, current_referral]
         else
           render :edit
         end

--- a/app/controllers/referrals/contact_details/email_controller.rb
+++ b/app/controllers/referrals/contact_details/email_controller.rb
@@ -31,7 +31,13 @@ module Referrals
       end
 
       def next_path
-        edit_referral_contact_details_telephone_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :contact_details,
+          :telephone
+        ]
       end
     end
   end

--- a/app/controllers/referrals/contact_details/telephone_controller.rb
+++ b/app/controllers/referrals/contact_details/telephone_controller.rb
@@ -33,7 +33,13 @@ module Referrals
       end
 
       def next_path
-        edit_referral_contact_details_address_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :contact_details,
+          :address
+        ]
       end
     end
   end

--- a/app/controllers/referrals/declaration_controller.rb
+++ b/app/controllers/referrals/declaration_controller.rb
@@ -10,7 +10,11 @@ module Referrals
           declaration_form_params.merge(referral: current_referral)
         )
       if @declaration_form.save
-        redirect_to next_path
+        redirect_to [
+                      current_referral.routing_scope,
+                      current_referral,
+                      :confirmation
+                    ]
       else
         render :show
       end
@@ -20,20 +24,6 @@ module Referrals
 
     def declaration_form_params
       params.require(:declaration_form).permit(:declaration_agreed)
-    end
-
-    def update_path
-      referral_declaration_path(current_referral)
-    end
-    helper_method :update_path
-
-    def back_link
-      referral_review_path(current_referral)
-    end
-    helper_method :back_link
-
-    def next_path
-      referral_confirmation_path(current_referral)
     end
   end
 end

--- a/app/controllers/referrals/organisation_controller.rb
+++ b/app/controllers/referrals/organisation_controller.rb
@@ -14,7 +14,7 @@ module Referrals
         )
 
       if @organisation_form.save
-        redirect_to edit_referral_path(current_referral)
+        redirect_to [:edit, current_referral.routing_scope, current_referral]
       else
         @organisation = current_referral.organisation
         render :show

--- a/app/controllers/referrals/organisation_name_controller.rb
+++ b/app/controllers/referrals/organisation_name_controller.rb
@@ -20,7 +20,12 @@ module Referrals
     private
 
     def next_path
-      edit_referral_organisation_address_path(current_referral)
+      [
+        :edit,
+        current_referral.routing_scope,
+        current_referral,
+        :organisation_address
+      ]
     end
 
     def organisation_name_form_params

--- a/app/controllers/referrals/personal_details/age_controller.rb
+++ b/app/controllers/referrals/personal_details/age_controller.rb
@@ -40,7 +40,13 @@ module Referrals
       end
 
       def next_path
-        edit_referral_personal_details_trn_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :personal_details,
+          :trn
+        ]
       end
     end
   end

--- a/app/controllers/referrals/personal_details/check_answers_controller.rb
+++ b/app/controllers/referrals/personal_details/check_answers_controller.rb
@@ -25,13 +25,8 @@ module Referrals
       private
 
       def next_path
-        edit_referral_path(current_referral)
+        [:edit, current_referral.routing_scope, current_referral]
       end
-
-      def update_path
-        referral_personal_details_check_answers_path(current_referral)
-      end
-      helper_method :update_path
 
       def check_answers_params
         params.fetch(:referrals_personal_details_check_answers_form, {}).permit(

--- a/app/controllers/referrals/personal_details/name_controller.rb
+++ b/app/controllers/referrals/personal_details/name_controller.rb
@@ -25,18 +25,14 @@ module Referrals
       private
 
       def next_path
-        edit_referral_personal_details_age_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :personal_details,
+          :age
+        ]
       end
-
-      def update_path
-        referral_personal_details_name_path(current_referral)
-      end
-      helper_method :update_path
-
-      def back_link
-        edit_referral_path(current_referral)
-      end
-      helper_method :back_link
 
       def name_params
         params.require(:referrals_personal_details_name_form).permit(

--- a/app/controllers/referrals/personal_details/qts_controller.rb
+++ b/app/controllers/referrals/personal_details/qts_controller.rb
@@ -24,7 +24,13 @@ module Referrals
       end
 
       def next_path
-        edit_referral_personal_details_check_answers_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :personal_details,
+          :check_answers
+        ]
       end
     end
   end

--- a/app/controllers/referrals/personal_details/trn_controller.rb
+++ b/app/controllers/referrals/personal_details/trn_controller.rb
@@ -30,7 +30,13 @@ module Referrals
       end
 
       def next_path
-        edit_referral_personal_details_qts_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :personal_details,
+          :qts
+        ]
       end
     end
   end

--- a/app/controllers/referrals/previous_misconduct_controller.rb
+++ b/app/controllers/referrals/previous_misconduct_controller.rb
@@ -12,7 +12,7 @@ class Referrals::PreviousMisconductController < Referrals::BaseController
       )
 
     if @previous_misconduct_form.save
-      redirect_to edit_referral_path(current_referral)
+      redirect_to [:edit, current_referral.routing_scope, current_referral]
     else
       render :show
     end

--- a/app/controllers/referrals/previous_misconduct_reported_controller.rb
+++ b/app/controllers/referrals/previous_misconduct_reported_controller.rb
@@ -32,7 +32,13 @@ module Referrals
     end
 
     def next_path
-      edit_referral_previous_misconduct_detailed_account_path(current_referral)
+      [
+        :edit,
+        current_referral.routing_scope,
+        current_referral,
+        :previous_misconduct,
+        :detailed_account
+      ]
     end
 
     def next_page

--- a/app/controllers/referrals/referrer_job_title_controller.rb
+++ b/app/controllers/referrals/referrer_job_title_controller.rb
@@ -24,7 +24,7 @@ module Referrals
     end
 
     def next_path
-      edit_referral_referrer_phone_path(current_referral)
+      [:edit, current_referral.routing_scope, current_referral, :referrer_phone]
     end
   end
 end

--- a/app/controllers/referrals/referrer_name_controller.rb
+++ b/app/controllers/referrals/referrer_name_controller.rb
@@ -24,12 +24,12 @@ module Referrals
     end
 
     def next_path
-      edit_referral_referrer_job_title_path(current_referral)
+      [
+        :edit,
+        current_referral.routing_scope,
+        current_referral,
+        :referrer_job_title
+      ]
     end
-
-    def update_path
-      referral_referrer_name_path(current_referral)
-    end
-    helper_method :update_path
   end
 end

--- a/app/controllers/referrals/referrer_phone_controller.rb
+++ b/app/controllers/referrals/referrer_phone_controller.rb
@@ -23,7 +23,7 @@ module Referrals
     end
 
     def next_path
-      referral_referrer_path(current_referral)
+      [current_referral.routing_scope, current_referral, :referrer]
     end
 
     def previous_path
@@ -37,10 +37,5 @@ module Referrals
       )
     end
     helper_method :previous_path
-
-    def update_path
-      referral_referrer_phone_path(current_referral)
-    end
-    helper_method :update_path
   end
 end

--- a/app/controllers/referrals/referrers_controller.rb
+++ b/app/controllers/referrals/referrers_controller.rb
@@ -27,12 +27,7 @@ module Referrals
     end
 
     def next_path
-      edit_referral_path(current_referral)
+      [:edit, current_referral.routing_scope, current_referral]
     end
-
-    def update_path
-      referral_referrer_path(current_referral)
-    end
-    helper_method :update_path
   end
 end

--- a/app/controllers/referrals/teacher_role/check_answers_controller.rb
+++ b/app/controllers/referrals/teacher_role/check_answers_controller.rb
@@ -31,13 +31,8 @@ module Referrals
       end
 
       def next_path
-        edit_referral_path(current_referral)
+        [:edit, current_referral.routing_scope, current_referral]
       end
-
-      def update_path
-        referral_teacher_role_check_answers_path(current_referral)
-      end
-      helper_method :update_path
     end
   end
 end

--- a/app/controllers/referrals/teacher_role/duties_controller.rb
+++ b/app/controllers/referrals/teacher_role/duties_controller.rb
@@ -32,18 +32,14 @@ module Referrals
       end
 
       def next_path
-        edit_referral_teacher_role_same_organisation_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :teacher_role,
+          :same_organisation
+        ]
       end
-
-      def update_path
-        referral_teacher_role_duties_path(current_referral)
-      end
-      helper_method :update_path
-
-      def back_link
-        edit_referral_teacher_role_job_title_path(current_referral)
-      end
-      helper_method :back_link
     end
   end
 end

--- a/app/controllers/referrals/teacher_role/employment_status_controller.rb
+++ b/app/controllers/referrals/teacher_role/employment_status_controller.rb
@@ -31,9 +31,21 @@ module Referrals
 
       def next_path
         if current_referral.left_role?
-          edit_referral_teacher_role_end_date_path(current_referral)
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :end_date
+          ]
         else
-          edit_referral_teacher_role_check_answers_path(current_referral)
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :check_answers
+          ]
         end
       end
 

--- a/app/controllers/referrals/teacher_role/end_date_controller.rb
+++ b/app/controllers/referrals/teacher_role/end_date_controller.rb
@@ -43,9 +43,21 @@ module Referrals
 
       def next_path
         if current_referral.left_role?
-          edit_referral_teacher_role_reason_leaving_role_path(current_referral)
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :reason_leaving_role
+          ]
         else
-          edit_referral_teacher_role_check_answers_path(current_referral)
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :check_answers
+          ]
         end
       end
     end

--- a/app/controllers/referrals/teacher_role/job_title_controller.rb
+++ b/app/controllers/referrals/teacher_role/job_title_controller.rb
@@ -26,18 +26,14 @@ module Referrals
       end
 
       def next_path
-        edit_referral_teacher_role_duties_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :teacher_role,
+          :duties
+        ]
       end
-
-      def update_path
-        referral_teacher_role_job_title_path(current_referral)
-      end
-      helper_method :update_path
-
-      def back_link
-        edit_referral_path(current_referral)
-      end
-      helper_method :back_link
     end
   end
 end

--- a/app/controllers/referrals/teacher_role/organisation_address_controller.rb
+++ b/app/controllers/referrals/teacher_role/organisation_address_controller.rb
@@ -43,20 +43,14 @@ module Referrals
       end
 
       def next_path
-        edit_referral_teacher_role_start_date_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :teacher_role,
+          :start_date
+        ]
       end
-
-      def update_path
-        referral_teacher_role_organisation_address_path(current_referral)
-      end
-      helper_method :update_path
-
-      def back_link
-        edit_referral_teacher_role_organisation_address_known_path(
-          current_referral
-        )
-      end
-      helper_method :back_link
     end
   end
 end

--- a/app/controllers/referrals/teacher_role/organisation_address_known_controller.rb
+++ b/app/controllers/referrals/teacher_role/organisation_address_known_controller.rb
@@ -32,9 +32,21 @@ module Referrals
 
       def next_path
         if current_referral.organisation_address_known?
-          edit_referral_teacher_role_organisation_address_path(current_referral)
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :organisation_address
+          ]
         else
-          edit_referral_teacher_role_start_date_path(current_referral)
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :start_date
+          ]
         end
       end
 
@@ -47,13 +59,16 @@ module Referrals
         super
       end
 
-      def update_path
-        referral_teacher_role_organisation_address_known_path(current_referral)
-      end
-      helper_method :update_path
-
       def back_link
-        edit_referral_teacher_role_same_organisation_path(current_referral)
+        polymorphic_path(
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :same_organisation
+          ]
+        )
       end
       helper_method :back_link
     end

--- a/app/controllers/referrals/teacher_role/reason_leaving_role_controller.rb
+++ b/app/controllers/referrals/teacher_role/reason_leaving_role_controller.rb
@@ -30,7 +30,13 @@ module Referrals
       end
 
       def next_path
-        edit_referral_teacher_role_working_somewhere_else_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :teacher_role,
+          :working_somewhere_else
+        ]
       end
     end
   end

--- a/app/controllers/referrals/teacher_role/same_organisation_controller.rb
+++ b/app/controllers/referrals/teacher_role/same_organisation_controller.rb
@@ -31,11 +31,21 @@ module Referrals
 
       def next_path
         if current_referral.same_organisation?
-          edit_referral_teacher_role_start_date_path(current_referral)
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :start_date
+          ]
         else
-          edit_referral_teacher_role_organisation_address_known_path(
-            current_referral
-          )
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :organisation_address_known
+          ]
         end
       end
 

--- a/app/controllers/referrals/teacher_role/start_date_controller.rb
+++ b/app/controllers/referrals/teacher_role/start_date_controller.rb
@@ -42,16 +42,25 @@ module Referrals
       end
 
       def next_path
-        edit_referral_teacher_role_employment_status_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :teacher_role,
+          :employment_status
+        ]
       end
-
-      def update_path
-        referral_teacher_role_start_date_path(current_referral)
-      end
-      helper_method :update_path
 
       def back_link
-        edit_referral_teacher_role_same_organisation_path(current_referral)
+        polymorphic_path(
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :same_organisation
+          ]
+        )
       end
       helper_method :back_link
     end

--- a/app/controllers/referrals/teacher_role/work_location_controller.rb
+++ b/app/controllers/referrals/teacher_role/work_location_controller.rb
@@ -38,7 +38,13 @@ module Referrals
       end
 
       def next_path
-        edit_referral_teacher_role_check_answers_path(current_referral)
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :teacher_role,
+          :check_answers
+        ]
       end
     end
   end

--- a/app/controllers/referrals/teacher_role/work_location_known_controller.rb
+++ b/app/controllers/referrals/teacher_role/work_location_known_controller.rb
@@ -31,9 +31,21 @@ module Referrals
 
       def next_path
         if current_referral.work_location_known?
-          edit_referral_teacher_role_work_location_path(current_referral)
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :work_location
+          ]
         else
-          edit_referral_teacher_role_check_answers_path(current_referral)
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :check_answers
+          ]
         end
       end
 

--- a/app/controllers/referrals/teacher_role/working_somewhere_else_controller.rb
+++ b/app/controllers/referrals/teacher_role/working_somewhere_else_controller.rb
@@ -31,9 +31,21 @@ module Referrals
 
       def next_path
         if current_referral.working_somewhere_else?
-          edit_referral_teacher_role_work_location_known_path(current_referral)
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :work_location_known
+          ]
         else
-          edit_referral_teacher_role_check_answers_path(current_referral)
+          [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :teacher_role,
+            :check_answers
+          ]
         end
       end
 

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -66,11 +66,6 @@ class ReferralsController < Referrals::BaseController
   end
 
   def review_path
-    referral_review_path(referral)
+    [referral.routing_scope, referral, :review]
   end
-
-  def update_path
-    referral_path(referral)
-  end
-  helper_method :update_path
 end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -77,7 +77,14 @@ class ReferralForm
           section.items.append(
             ReferralSectionItem.new(
               I18n.t("referral_form.contact_details"),
-              edit_referral_contact_details_email_path(referral),
+              polymorphic_path(
+                [
+                  :edit,
+                  referral.routing_scope,
+                  referral,
+                  :contact_details_email
+                ]
+              ),
               section_status(:contact_details_complete)
             )
           )
@@ -86,7 +93,15 @@ class ReferralForm
         section.items.append(
           ReferralSectionItem.new(
             I18n.t("referral_form.about_their_role"),
-            path_for_teacher_role,
+            polymorphic_path(
+              [
+                :edit,
+                referral.routing_scope,
+                referral,
+                :teacher_role,
+                :job_title
+              ]
+            ),
             section_status(:teacher_role_complete)
           )
         )
@@ -158,13 +173,5 @@ class ReferralForm
     return start_path if status == :not_started_yet
 
     check_answers_path
-  end
-
-  def path_for_teacher_role
-    if referral.from_employer?
-      edit_referral_teacher_role_job_title_path(referral)
-    else
-      edit_public_referral_teacher_role_job_title_path(referral)
-    end
   end
 end

--- a/app/views/referrals/allegation/check_answers/edit.html.erb
+++ b/app/views/referrals/allegation/check_answers/edit.html.erb
@@ -10,7 +10,7 @@
 
     <%= render WhatHappenedComponent.new(referral: current_referral) %>
 
-    <%= form_with model: @allegation_check_answers_form, url: referral_allegation_check_answers_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @allegation_check_answers_form, url: [current_referral.routing_scope, current_referral, :allegation, :check_answers], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset(

--- a/app/views/referrals/allegation/dbs/edit.html.erb
+++ b/app/views/referrals/allegation/dbs/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_dbs_form.errors.any?}Telling DBS about this case" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_allegation_details_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :allegation_details])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @allegation_dbs_form, url: referral_allegation_dbs_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @allegation_dbs_form, url: [current_referral.routing_scope, current_referral, :allegation_dbs], method: :put do |f| %>
       <span class="govuk-caption-l">The allegation</span>
       <h1 class="govuk-heading-l">Telling DBS about this case</h1>
       <p>DBS (Disclosure and Barring Service) need to know about any allegations that involve harm to a child, or the risk of harm to a child.</p>

--- a/app/views/referrals/allegation/details/edit.html.erb
+++ b/app/views/referrals/allegation/details/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_details_form.errors.any?}How do you want to tell us about your allegation?" %>
-<% content_for :back_link_url, return_to_session_or(back_link) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @allegation_details_form, url: update_path, method: :put do |f| %>
+    <%= form_with model: @allegation_details_form, url: [current_referral.routing_scope, current_referral, :allegation_details], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">The allegation</span>

--- a/app/views/referrals/contact_details/address/edit.html.erb
+++ b/app/views/referrals/contact_details/address/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{"Error: " if @contact_details_address_form.errors.any?}Do you know their home address?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_contact_details_telephone_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :contact_details_telephone])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_address_form, url: referral_contact_details_address_path, method: :put do |f| %>
+    <%= form_with model: @contact_details_address_form, url: [current_referral.routing_scope, current_referral, :contact_details_address], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Contact details</span>

--- a/app/views/referrals/contact_details/check_answers/edit.html.erb
+++ b/app/views/referrals/contact_details/check_answers/edit.html.erb
@@ -10,7 +10,7 @@
 
     <%= render ContactDetailsComponent.new(referral: current_referral) %>
 
-    <%= form_with model: @contact_details_check_answers_form, url: referral_contact_details_check_answers_path, method: :put do |f| %>
+    <%= form_with model: @contact_details_check_answers_form, url: [current_referral.routing_scope, current_referral, :contact_details, :check_answers], method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset :contact_details_complete,
         legend: { size: "m", text: "Have you completed this section?" },

--- a/app/views/referrals/contact_details/email/edit.html.erb
+++ b/app/views/referrals/contact_details/email/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @contact_details_email_form.errors.any?}Do you know the personal email address of the person you are referring?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/contact_details/telephone/edit.html.erb
+++ b/app/views/referrals/contact_details/telephone/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{"Error: " if @contact_details_telephone_form.errors.any?}Do you know their main contact number?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_contact_details_email_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :contact_details_email])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_telephone_form, url: referral_contact_details_telephone_path, method: :put do |f| %>
+    <%= form_with model: @contact_details_telephone_form, url: [current_referral.routing_scope, current_referral, :contact_details_telephone], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Contact details</span>

--- a/app/views/referrals/declaration/show.html.erb
+++ b/app/views/referrals/declaration/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @declaration_form.errors.any?}Before you send your referral" %>
-<% content_for :back_link_url, return_to_session_or(back_link) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([current_referral.routing_scope, current_referral, :review])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @declaration_form, url: update_path, method: :post do |f| %>
+    <%= form_with model: @declaration_form, url: [current_referral.routing_scope, current_referral, :declaration], method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">Before you send your referral</h1>
       <p>You must confirm that:</p>

--- a/app/views/referrals/delete.html.erb
+++ b/app/views/referrals/delete.html.erb
@@ -2,9 +2,9 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Are you sure you want to delete your draft?</h1>
     <% if @referral %>
-      <%= govuk_button_to "Yes I’m sure – delete it", referral_path(@referral), method: :delete, class: "govuk-button--warning" %>
+      <%= govuk_button_to "Yes I’m sure – delete it", [@referral.routing_scope, @referral], method: :delete, class: "govuk-button--warning" %>
       <p>
-        <%= govuk_link_to "Cancel", edit_referral_path(@referral) %>
+        <%= govuk_link_to "Cancel", [:edit, @referral.routing_scope, @referral] %>
       </p>
     <% else %>
       <%= govuk_link_to "Yes I’m sure – delete it", deleted_referral_path, class: "govuk-button govuk-button--warning" %>

--- a/app/views/referrals/edit.html.erb
+++ b/app/views/referrals/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @referral_form, url: update_path, method: :put do |f| %>
+    <%= form_with model: @referral_form, url: [current_referral.routing_scope, current_referral], method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl"><%= t("referral_form.heading") %></h1>
       <%= render TaskListComponent.new(sections: @referral_form.sections) %>

--- a/app/views/referrals/evidence/check_answers/edit.html.erb
+++ b/app/views/referrals/evidence/check_answers/edit.html.erb
@@ -10,14 +10,14 @@
 
     <%= govuk_button_to(
       "Add more evidence",
-      edit_referral_evidence_upload_path(current_referral),
+      [:edit, current_referral.routing_scope, current_referral, :evidence_upload],
       method: "get",
       class: "govuk-button--secondary govuk-!-margin-bottom-8"
     ) if current_referral.has_evidence %>
 
     <%= render EvidenceComponent.new(referral: current_referral) %>
 
-    <%= form_with model: @evidence_check_answers_form, url: referral_evidence_check_answers_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @evidence_check_answers_form, url: [current_referral.routing_scope, current_referral, :evidence, :check_answers], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset(

--- a/app/views/referrals/evidence/start/edit.html.erb
+++ b/app/views/referrals/evidence/start/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_start_form.errors.any?}Evidence and supporting information" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/evidence/upload/edit.html.erb
+++ b/app/views/referrals/evidence/upload/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_upload_form.errors.any?}Upload evidence and supporting information" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_evidence_start_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :evidence_start])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/evidence/uploaded/edit.html.erb
+++ b/app/views/referrals/evidence/uploaded/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Uploaded evidence" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_evidence_upload_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :evidence_upload])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/organisation_address/edit.html.erb
+++ b/app/views/referrals/organisation_address/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @organisation_address_form.errors.any?}What is your organisation’s address?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_organisation_name_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :organisation_name])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @organisation_address_form, url: referral_organisation_address_url(current_referral), method: :patch do |f| %>
+    <%= form_with model: @organisation_address_form, url: [current_referral.routing_scope, current_referral, :organisation_address], method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">
         What is your organisation’s address?

--- a/app/views/referrals/organisation_name/edit.html.erb
+++ b/app/views/referrals/organisation_name/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @organisation_name_form.errors.any?}What’s the name of your organisation?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @organisation_name_form, url: referral_organisation_name_url(current_referral), method: :patch do |f| %>
+    <%= form_with model: @organisation_name_form, url: [current_referral.routing_scope, current_referral, :organisation_name], method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field :name, label: { size: 'xl', text: "What’s the name of your organisation?" } %>

--- a/app/views/referrals/personal_details/age/edit.html.erb
+++ b/app/views/referrals/personal_details/age/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_age_form.errors.any?}Do you know their date of birth?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_personal_details_name_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details_name])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @personal_details_age_form, url: referral_personal_details_age_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @personal_details_age_form, url: [current_referral.routing_scope, current_referral, :personal_details_age], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Personal details</span>

--- a/app/views/referrals/personal_details/check_answers/edit.html.erb
+++ b/app/views/referrals/personal_details/check_answers/edit.html.erb
@@ -10,7 +10,7 @@
 
     <%= render PersonalDetailsComponent.new(referral: current_referral) %>
 
-    <%= form_with model: @personal_details_check_answers_form, url: update_path, method: :put do |f| %>
+    <%= form_with model: @personal_details_check_answers_form, url: [current_referral.routing_scope, current_referral, :personal_details, :check_answers], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset(

--- a/app/views/referrals/personal_details/name/edit.html.erb
+++ b/app/views/referrals/personal_details/name/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_name_form.errors.any?}What is the name of the person you’re referring?" %>
-<% content_for :back_link_url, return_to_session_or(back_link) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @personal_details_name_form, url: update_path, method: :put do |f| %>
+    <%= form_with model: @personal_details_name_form, url: [current_referral.routing_scope, current_referral, :personal_details, :name], method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <span class="govuk-caption-l">Personal details</span>
       <h1 class="govuk-heading-l">Their name</h1>

--- a/app/views/referrals/personal_details/qts/edit.html.erb
+++ b/app/views/referrals/personal_details/qts/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_qts_form.errors.any?}Do they have qualified teacher status (QTS)?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_personal_details_trn_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details_trn])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @personal_details_qts_form, url: referral_personal_details_qts_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @personal_details_qts_form, url: [current_referral.routing_scope, current_referral, :personal_details_qts], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Personal details</span>

--- a/app/views/referrals/personal_details/trn/edit.html.erb
+++ b/app/views/referrals/personal_details/trn/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_trn_form.errors.any?}Do you know their teacher reference number (TRN)?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_personal_details_age_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details_age])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @personal_details_trn_form, url: referral_personal_details_trn_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @personal_details_trn_form, url: [current_referral.routing_scope, current_referral, :personal_details_trn], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Personal details</span>

--- a/app/views/referrals/previous_misconduct_detailed_account/edit.html.erb
+++ b/app/views/referrals/previous_misconduct_detailed_account/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @detailed_account_form.errors.any?}Give a detailed account of previous allegations" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_previous_misconduct_reported_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :previous_misconduct_reported])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -12,7 +12,7 @@
       <li>what action was taken</li>
       <li>reference numbers from previous referrals</li>
     </ul>
-    <%= form_with model: @detailed_account_form, url: referral_previous_misconduct_detailed_account_url(current_referral), method: :patch do |f| %>
+    <%= form_with model: @detailed_account_form, url: [current_referral.routing_scope, current_referral, :previous_misconduct, :detailed_account], method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset(:format, legend: { size: "m", text: "How do you want to give details about previous allegations?" }) do %>

--- a/app/views/referrals/previous_misconduct_reported/edit.html.erb
+++ b/app/views/referrals/previous_misconduct_reported/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @previous_misconduct_reported_form.errors.any?}Has there been any previous misconduct, disciplinary action or complaints?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @previous_misconduct_reported_form, url: referral_previous_misconduct_reported_url(current_referral), method: :patch do |f| %>
+    <%= form_with model: @previous_misconduct_reported_form, url: [current_referral.routing_scope, current_referral, :previous_misconduct_reported], method: :patch do |f| %>
       <h1 class="govuk-heading-l">Previous allegations</h1>
       <p class="govuk-body">This includes:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">

--- a/app/views/referrals/referrer_job_title/edit.html.erb
+++ b/app/views/referrals/referrer_job_title/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @referrer_job_title_form.errors.any?}Your job title" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_referrer_name_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :referrer_name])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @referrer_job_title_form, url: referral_referrer_job_title_path(current_referral), method: :patch do |f| %>
+    <%= form_with model: @referrer_job_title_form, url: [current_referral.routing_scope, current_referral, :referrer_job_title], method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Your details</span>

--- a/app/views/referrals/referrer_name/edit.html.erb
+++ b/app/views/referrals/referrer_name/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @referrer_name_form, url: update_path, method: :patch do |f| %>
+    <%= form_with model: @referrer_name_form, url: [current_referral.routing_scope, current_referral, :referrer_name], method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Your details</span>

--- a/app/views/referrals/referrer_phone/edit.html.erb
+++ b/app/views/referrals/referrer_phone/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @referrer_phone_form, url: update_path, method: :patch do |f| %>
+    <%= form_with model: @referrer_phone_form, url: [current_referral.routing_scope, current_referral, :referrer_phone], method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Your details</span>

--- a/app/views/referrals/referrers/show.html.erb
+++ b/app/views/referrals/referrers/show.html.erb
@@ -10,7 +10,7 @@
 
      <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
 
-    <%= form_with model: @referrer_form, url: update_path, method: :patch do |f| %>
+    <%= form_with model: @referrer_form, url: [current_referral.routing_scope, current_referral, :referrer], method: :patch do |f| %>
       <%= f.govuk_radio_buttons_fieldset :complete, hint: { text: 'You can still make changes to a completed section' }, legend: { size: 'm', text: 'Have you completed this section?' } do %>
         <%= f.hidden_field :complete %>
         <%= f.govuk_radio_button :complete, 'true', label: { text: "Yes, I’ve completed this section" }, link_errors: true %>

--- a/app/views/referrals/teacher_role/check_answers/edit.html.erb
+++ b/app/views/referrals/teacher_role/check_answers/edit.html.erb
@@ -10,7 +10,7 @@
 
     <%= render TheirRoleComponent.new(referral: current_referral) %>
 
-    <%= form_with model: @teacher_role_check_answers_form, url: update_path, method: :put do |f| %>
+    <%= form_with model: @teacher_role_check_answers_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :check_answers], method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset :teacher_role_complete,
         legend: { size: "m", text: "Have you completed this section?" },

--- a/app/views/referrals/teacher_role/duties/edit.html.erb
+++ b/app/views/referrals/teacher_role/duties/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @duties_form.errors.any?}How do you want to give details about their main duties?" %>
-<% content_for :back_link_url, return_to_session_or(back_link) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :job_title])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @duties_form, url: update_path, method: :put do |f| %>
+    <%= form_with model: @duties_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :duties], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/employment_status/edit.html.erb
+++ b/app/views/referrals/teacher_role/employment_status/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @employment_status_form.errors.any?}Are they still employed in the job where the alleged misconduct took place?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_start_date_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :start_date])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @employment_status_form, url: referral_teacher_role_employment_status_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @employment_status_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :employment_status], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/end_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/end_date/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @role_end_date_form.errors.any?}Do you know when they left the job?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_employment_status_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :employment_status])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @role_end_date_form, url: referral_teacher_role_end_date_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @role_end_date_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :end_date], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/job_title/edit.html.erb
+++ b/app/views/referrals/teacher_role/job_title/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @job_title_form.errors.any?}Their job title" %>
-<% content_for :back_link_url, return_to_session_or(back_link) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @job_title_form, url: update_path, method: :put do |f| %>
+    <%= form_with model: @job_title_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :job_title], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/organisation_address/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @organisation_address_form.errors.any?}Name and address of the organisation where the alleged misconduct took place" %>
-<% content_for :back_link_url, return_to_session_or(back_link) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :organisation_address_known])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @organisation_address_form, url: update_path, method: :put do |f| %>
+    <%= form_with model: @organisation_address_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :organisation_address], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @organisation_address_known_form, url: update_path, method: :put do |f| %>
+    <%= form_with model: @organisation_address_known_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :organisation_address_known], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/reason_leaving_role/edit.html.erb
+++ b/app/views/referrals/teacher_role/reason_leaving_role/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @reason_leaving_role_form.errors.any?}Reason they left the job" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_end_date_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :end_date])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @reason_leaving_role_form, url: referral_teacher_role_reason_leaving_role_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @reason_leaving_role_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :reason_leaving_role], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/same_organisation/edit.html.erb
+++ b/app/views/referrals/teacher_role/same_organisation/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @same_organisation_form.errors.any?}Did they work at the same organisation as you at the time of the alleged misconduct?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_duties_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :duties])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @same_organisation_form, url: referral_teacher_role_same_organisation_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @same_organisation_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :same_organisation], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/start_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/start_date/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @role_start_date_form.errors.any?}Do you know when they started their job?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_same_organisation_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(back_link) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @role_start_date_form, url: referral_teacher_role_start_date_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @role_start_date_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :start_date], method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <span class="govuk-caption-l">About their role</span>
       <%= f.govuk_radio_buttons_fieldset :role_start_date_known,

--- a/app/views/referrals/teacher_role/work_location/edit.html.erb
+++ b/app/views/referrals/teacher_role/work_location/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{"Error: " if @work_location_form.errors.any?}Where they currently work" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_work_location_known_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :work_location_known])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_location_form, url: referral_teacher_role_work_location_path, method: :put do |f| %>
+    <%= form_with model: @work_location_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :work_location], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/work_location_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/work_location_known/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @work_location_known_form.errors.any?}Do you know the name and address of the organisation where they’re currently working?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_working_somewhere_else_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :working_somewhere_else])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @work_location_known_form, url: referral_teacher_role_work_location_known_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @work_location_known_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :work_location_known], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/app/views/referrals/teacher_role/working_somewhere_else/edit.html.erb
+++ b/app/views/referrals/teacher_role/working_somewhere_else/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title, "#{'Error: ' if @working_somewhere_else_form.errors.any?}Are they employed somewhere else?" %>
-<% content_for :back_link_url, return_to_session_or(edit_referral_teacher_role_reason_leaving_role_path(current_referral)) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :reason_leaving_role])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @working_somewhere_else_form, url: referral_teacher_role_working_somewhere_else_path(current_referral), method: :put do |f| %>
+    <%= form_with model: @working_somewhere_else_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :working_somewhere_else], method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">About their role</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,7 +240,7 @@ Rails.application.routes.draw do
         end
 
         resources :evidence, only: [] do
-          get "/delete", to: "evidence/check_answers#delete"
+          get "/delete", to: "evidence/check_answers#delete", as: :delete
           delete "/", to: "evidence/check_answers#destroy", as: :destroy
         end
         namespace :evidence do

--- a/spec/system/referrals/user_adds_an_allegation_spec.rb
+++ b/spec/system/referrals/user_adds_an_allegation_spec.rb
@@ -95,14 +95,17 @@ RSpec.feature "Allegation", type: :system do
       key: "Summary",
       value: "Something something something",
       change_link:
-        edit_referral_allegation_details_path(@referral, return_to: current_url)
+        edit_referral_allegation_details_path(
+          @referral,
+          return_to: current_path
+        )
     )
 
     expect_summary_row(
       key: "Have you told DBS?",
       value: "Yes",
       change_link:
-        edit_referral_allegation_dbs_path(@referral, return_to: current_url)
+        edit_referral_allegation_dbs_path(@referral, return_to: current_path)
     )
   end
 

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -249,7 +249,7 @@ RSpec.feature "Contact details", type: :system do
       change_link:
         edit_referral_contact_details_email_path(
           @referral,
-          return_to: current_url
+          return_to: current_path
         )
     )
 
@@ -259,7 +259,7 @@ RSpec.feature "Contact details", type: :system do
       change_link:
         edit_referral_contact_details_telephone_path(
           @referral,
-          return_to: current_url
+          return_to: current_path
         )
     )
 
@@ -269,7 +269,7 @@ RSpec.feature "Contact details", type: :system do
       change_link:
         edit_referral_contact_details_address_path(
           @referral,
-          return_to: current_url
+          return_to: current_path
         )
     )
   end


### PR DESCRIPTION
Now that the referrals are scoped by type, we need to ensure links
take the scope into account.

The easiest way to do this is to use the Rails link helpers and pass the
routing scope. If it is `nil` then the default scope is used, eg.
`referrals`, alternatively we use `public_referrals`.

There are some views and controllers that are only used for the employer
flow, so I left some of those links as they are.

I attempted to change the uploaded evidence views but ran into an issue
with the routes not matching the model they refer to, eg.
`ReferralEvidence` is rendered at the `referrals/1/evidences/1` route.

The custom route means we need to override more things and I was trying
to limit the scope of this change to simply replacing the helper methods
with the array style.
