### PR TITLE
Add case worker referral index page

### DIFF
--- a/app/assets/stylesheets/_task-list.scss
+++ b/app/assets/stylesheets/_task-list.scss
@@ -5,6 +5,7 @@
   padding-left: 0;
   margin-top: 0;
   margin-bottom: 0;
+
   @include govuk-media-query($from: tablet) {
     min-width: 550px;
   }
@@ -26,6 +27,7 @@
   @include govuk-responsive-margin(9, "bottom");
   list-style: none;
   padding-left: 0;
+
   @include govuk-media-query($from: tablet) {
     padding-left: govuk-spacing(6);
   }
@@ -45,6 +47,7 @@
 
 .app-task-list__task-name {
   display: block;
+
   @include govuk-media-query($from: 450px) {
     float: left;
   }
@@ -62,5 +65,41 @@
     float: right;
     margin-top: 0;
     margin-bottom: 0;
+  }
+}
+
+.app-list {
+  margin-bottom: govuk-spacing(4);
+}
+
+.app-list__item {
+  border-bottom: 1px solid $govuk-border-colour;
+  padding-top: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
+
+  &:first-of-type {
+    padding-top: 0;
+  }
+
+  h2 {
+    margin-bottom: govuk-spacing(1);
+  }
+
+  .govuk-summary-list {
+    @include govuk-font(16);
+    margin-bottom: 0;
+  }
+
+  .govuk-summary-list__key,
+  .govuk-summary-list__value {
+    padding-bottom: govuk-spacing(0);
+  }
+
+  .govuk-summary-list__row:last-child {
+    margin-bottom: 0;
+
+    .govuk-summary-list__value {
+      margin-bottom: 0;
+    }
   }
 }

--- a/app/controllers/manage_interface/manage_interface_controller.rb
+++ b/app/controllers/manage_interface/manage_interface_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module ManageInterface
+  class ManageInterfaceController < ApplicationController
+    layout "support_layout"
+
+    before_action :authenticate_staff!
+  end
+end

--- a/app/controllers/manage_interface/referrals_controller.rb
+++ b/app/controllers/manage_interface/referrals_controller.rb
@@ -1,0 +1,11 @@
+module ManageInterface
+  class ReferralsController < ManageInterfaceController
+    def index
+      @referrals_count = Referral.count
+      @pagy, @referrals = pagy(Referral.all)
+    end
+
+    def show
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,7 +28,12 @@ module ApplicationHelper
   def navigation
     govuk_header(service_name: t("service.name")) do |header|
       case current_namespace
-      when "support"
+      when "manage", "support"
+        header.navigation_item(
+          active: current_page?(main_app.manage_interface_referrals_path),
+          href: main_app.manage_interface_referrals_path,
+          text: "Referrals"
+        )
         header.navigation_item(
           active:
             current_page?(main_app.support_interface_eligibility_checks_path),

--- a/app/views/manage_interface/referrals/index.html.erb
+++ b/app/views/manage_interface/referrals/index.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title, "Manage teacher misconduct referrals" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">Referrals (<%= @referrals_count %>)</h1>
+    <div class="app-list">
+      <% @referrals.each do |referral| %>
+        <div class="app-list__item">
+          <h1 class="govuk-heading-m">
+            <%= govuk_link_to "#{referral.first_name} #{referral.last_name}", manage_interface_referral_path(referral.id) %>
+          </h1>
+
+          <%= govuk_summary_list(
+            classes: ["govuk-summary-list--no-border"],
+            rows: [
+              { key: { text: "Referral date" }, value: { text: referral.created_at.to_fs(:day_month_year_time)} },
+              { key: { text: "Referrer" }, value: { text: referral.referrer.name } }
+            ])
+          %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<%= govuk_pagination(pagy: @pagy) %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -6,3 +6,5 @@ Date::DATE_FORMATS[:weekday_day_and_month] = "%A %-d %B"
 
 Time::DATE_FORMATS[:month_and_year] = "%B %Y"
 Date::DATE_FORMATS[:month_and_year] = "%B %Y"
+
+Time::DATE_FORMATS[:day_month_year_time] = "%d %B %Y at %l:%M %P"

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -12,7 +12,7 @@
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
 # Pagy::DEFAULT[:page]   = 1                                  # default
-Pagy::DEFAULT[:items] = 10 # default
+Pagy::DEFAULT[:items] = 20 # default
 # Pagy::DEFAULT[:outset] = 0                                  # default
 
 # Other Variables

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,6 +278,10 @@ Rails.application.routes.draw do
     get "/eligibility-checks", to: "eligibility_checks#index"
   end
 
+  namespace :manage_interface, path: "/manage" do
+    resources :referrals, only: %i[index show]
+  end
+
   get "/accessibility", to: "static#accessibility"
   get "/cookies", to: "static#cookies"
   get "/privacy", to: "static#privacy"


### PR DESCRIPTION
### Context

Adds a case worker referral index page that displays a list of paginated referrals. The page will be accessible via the `manage/referrals` path and requires staff authentication.

<img width="502" alt="Screenshot 2023-01-18 at 10 30 10" src="https://user-images.githubusercontent.com/1636476/213150227-a63de74c-885d-4bd4-a5ea-ff3a86c0cf14.png">

Pagination:
<img width="547" alt="Screenshot 2023-01-18 at 10 29 43" src="https://user-images.githubusercontent.com/1636476/213150271-735e5e70-7906-4ff0-bb46-f3fb5ce476ab.png">

### Link to Trello card

https://trello.com/c/wQAm7Z2e/1108-case-worker-referral-index-page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
