### PR TITLE
Display a simple referral page for case workers

### DIFF
--- a/app/controllers/manage_interface/referrals_controller.rb
+++ b/app/controllers/manage_interface/referrals_controller.rb
@@ -6,6 +6,7 @@ module ManageInterface
     end
 
     def show
+      @referral = Referral.find(params[:id])
     end
   end
 end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -30,6 +30,8 @@ class Referral < ApplicationRecord
           )
         }
 
+  delegate :name, to: :referrer, prefix: true, allow_nil: true
+
   def routing_scope
     return :public if from_member_of_public?
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -34,6 +34,7 @@
         This is a new service – <a class="govuk-link" href="https://forms.gle/mroZH7aVYGPrB37G6">your feedback will help us to improve it</a>.
       <% end %>
       <%= govuk_back_link(href: yield(:back_link_url)) if content_for?(:back_link_url) %>
+      <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= render(FlashMessageComponent.new(flash: flash)) %>
         <%= yield :content %>

--- a/app/views/manage_interface/referrals/index.html.erb
+++ b/app/views/manage_interface/referrals/index.html.erb
@@ -14,7 +14,7 @@
             classes: ["govuk-summary-list--no-border"],
             rows: [
               { key: { text: "Referral date" }, value: { text: referral.created_at.to_fs(:day_month_year_time)} },
-              { key: { text: "Referrer" }, value: { text: referral.referrer.name } }
+              { key: { text: "Referrer" }, value: { text: referral.referrer_name } }
             ])
           %>
         </div>

--- a/app/views/manage_interface/referrals/show.html.erb
+++ b/app/views/manage_interface/referrals/show.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, "Manage teacher misconduct referrals" %>
+
+<% content_for :breadcrumbs do %>
+  <%= govuk_breadcrumbs(breadcrumbs: {
+    "Referrals" => manage_interface_referrals_path,
+    @referral.referrer_name => nil
+  }) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <span class="govuk-caption-l"><%= @referral.id %></span>
+    <h1 class="govuk-heading-l"><%= @referral.referrer_name %></h1>
+
+    <div class="app-panel">
+      <h2 class="govuk-heading-m">Summary</h2>
+      <%= govuk_summary_list(rows: [
+        { key: { text: "Referral ID" }, value: { text: @referral.id } },
+        { key: { text: "Referral date" }, value: { text: @referral.created_at.to_fs(:day_month_year_time) } }
+      ]) 
+      %>
+    </div>
+  </div>
+</div>

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -3,6 +3,10 @@ module CommonSteps
     FeatureFlags::FeatureFlag.activate(:service_open)
   end
 
+  def and_staff_http_basic_is_active
+    FeatureFlags::FeatureFlag.activate(:staff_http_basic_auth)
+  end
+
   def and_i_am_signed_in
     @user = create(:user)
     sign_in(@user)

--- a/spec/system/manage/case_worker_views_a_referral_spec.rb
+++ b/spec/system/manage/case_worker_views_a_referral_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Manage referrals" do
+  include CommonSteps
+
+  scenario "Case worker views a referral" do
+    given_the_service_is_open
+    and_the_referral_form_feature_is_active
+    and_the_eligibility_screener_feature_is_active
+    and_staff_http_basic_is_active
+    and_i_am_authorized_as_a_case_worker
+    and_there_is_an_existing_referral
+
+    when_i_visit_the_referral
+    then_i_see_the_referral
+  end
+
+  private
+
+  def and_i_am_authorized_as_a_case_worker
+    page.driver.basic_authorize(
+      ENV.fetch("SUPPORT_USERNAME", "test"),
+      ENV.fetch("SUPPORT_PASSWORD", "test")
+    )
+  end
+
+  def and_there_is_an_existing_referral
+    create(:referral, :complete)
+  end
+
+  def then_i_see_the_referral
+    expect(page).to have_content(Referral.last.id)
+    expect(page).to have_content(Referral.last.referrer_name)
+  end
+
+  def when_i_visit_the_referral
+    visit manage_interface_referral_path(Referral.last)
+  end
+end

--- a/spec/system/support/staff_user_signs_in_as_user_spec.rb
+++ b/spec/system/support/staff_user_signs_in_as_user_spec.rb
@@ -21,10 +21,6 @@ RSpec.feature "Test users" do
 
   private
 
-  def and_staff_http_basic_is_active
-    FeatureFlags::FeatureFlag.activate(:staff_http_basic_auth)
-  end
-
   def when_i_am_authorized_as_a_staff_user
     page.driver.basic_authorize(
       ENV.fetch("SUPPORT_USERNAME", "test"),


### PR DESCRIPTION
As part of building the case worker management interface, we need a page
that displays the details of a specific referral.

To make it easier for us to work on this page concurrently, I'm shipping
a very basic version that we can iterate on.

### Link to Trello card

https://trello.com/c/HEb0DEie/1109-case-worker-referral-show-page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1017" alt="Screenshot 2023-01-18 at 1 01 40 pm" src="https://user-images.githubusercontent.com/3126/213178382-f8ff519f-ea39-47d1-9c55-b9c5293cdb45.png">

