### PR TITLE
Display only submitted referrals on the manage referrals index page 

### DIFF
--- a/app/controllers/manage_interface/referrals_controller.rb
+++ b/app/controllers/manage_interface/referrals_controller.rb
@@ -2,7 +2,7 @@ module ManageInterface
   class ReferralsController < ManageInterfaceController
     def index
       @referrals_count = Referral.count
-      @pagy, @referrals = pagy(Referral.all)
+      @pagy, @referrals = pagy(Referral.submitted)
     end
 
     def show

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -30,6 +30,8 @@ class Referral < ApplicationRecord
           )
         }
 
+  scope :submitted, -> { where.not(submitted_at: nil) }
+
   delegate :name, to: :referrer, prefix: true, allow_nil: true
 
   def routing_scope

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -16,5 +16,10 @@ FactoryBot.define do
         create(:referrer, :complete, referral:)
       end
     end
+
+    trait :submitted do
+      complete
+      submitted_at { Time.current }
+    end
   end
 end

--- a/spec/system/manage/case_worker_views_referrals_spec.rb
+++ b/spec/system/manage/case_worker_views_referrals_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Manage referrals" do
 
   before do
     travel_to Time.zone.local(2022, 11, 22, 12, 0, 0)
-    create_list(:referral, 30, :complete)
+    create_list(:referral, 30, :submitted)
   end
 
   scenario "Case worker views referrals" do


### PR DESCRIPTION
The manage referrals index page was showing all draft referrals. It should only display submitted referrals. This also ensures we have all the necessary details for the referral.

### Link to Trello card

https://trello.com/c/wQAm7Z2e/1108-case-worker-referral-index-page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
