### PR TITLE
1108-case-worker-referral-index-page

### DIFF
--- a/app/controllers/manage_interface/referrals_controller.rb
+++ b/app/controllers/manage_interface/referrals_controller.rb
@@ -1,7 +1,7 @@
 module ManageInterface
   class ReferralsController < ManageInterfaceController
     def index
-      @referrals_count = Referral.count
+      @referrals_count = Referral.submitted.count
       @pagy, @referrals = pagy(Referral.submitted)
     end
 

--- a/spec/system/manage/case_worker_views_referrals_spec.rb
+++ b/spec/system/manage/case_worker_views_referrals_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Manage referrals" do
   before do
     travel_to Time.zone.local(2022, 11, 22, 12, 0, 0)
     create_list(:referral, 30, :submitted)
+    create_list(:referral, 20)
   end
 
   scenario "Case worker views referrals" do
@@ -16,6 +17,7 @@ RSpec.feature "Manage referrals" do
 
     and_i_visit_the_referrals_page
     then_i_can_see_the_referrals_page
+    and_i_can_see_pagination_for_submitted_claims
   end
 
   private
@@ -36,7 +38,9 @@ RSpec.feature "Manage referrals" do
     expect(page).to have_content "Referrals (30)"
     expect(page).to have_content "MyString"
     expect(page).to have_content "22 November 2022 at 12:00 pm"
+  end
 
+  def and_i_can_see_pagination_for_submitted_claims
     within(".govuk-pagination") do
       expect(page).to have_content "1"
       expect(page).to have_content "2"


### PR DESCRIPTION
The count was not scoping by submitted. The system spec checks if the pagination doesn't count the submitted claims as well.

### Link to Trello card

https://trello.com/c/wQAm7Z2e/1108-case-worker-referral-index-page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
