### PR TITLE
Add all sections to case worker referral view

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -36,3 +36,8 @@ $govuk-assets-path: "/";
     }
   }
 }
+
+.app-panel {
+  padding-bottom: govuk-spacing(6);
+  padding-top: govuk-spacing(5);
+}

--- a/app/components/what_happened_component.rb
+++ b/app/components/what_happened_component.rb
@@ -1,12 +1,8 @@
 class WhatHappenedComponent < ViewComponent::Base
   include ActiveModel::Model
+  include ReferralHelper
 
   attr_accessor :referral
-
-  def allegation_check_answers_form
-    @allegation_check_answers_form ||=
-      Referrals::Allegation::CheckAnswersForm.new(referral:)
-  end
 
   def rows
     [
@@ -29,7 +25,7 @@ class WhatHappenedComponent < ViewComponent::Base
           text: "Summary"
         },
         value: {
-          text: allegation_details
+          text: allegation_details(referral)
         }
       },
       {
@@ -55,22 +51,6 @@ class WhatHappenedComponent < ViewComponent::Base
         }
       }
     ]
-  end
-
-  def allegation_details
-    if referral.allegation_upload.attached?
-      [
-        "File:",
-        govuk_link_to(
-          referral.allegation_upload.filename,
-          rails_blob_path(referral.allegation_upload, disposition: "attachment")
-        )
-      ].join(" ").html_safe
-    elsif referral.allegation_details.present?
-      referral.allegation_details.truncate(150)
-    else
-      "Incomplete"
-    end
   end
 
   def return_to

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -30,4 +30,39 @@ module ReferralHelper
       "Incomplete"
     end
   end
+
+  def allegation_details(referral)
+    if referral.allegation_upload.attached?
+      [
+        "File:",
+        govuk_link_to(
+          referral.allegation_upload.filename,
+          rails_blob_path(referral.allegation_upload, disposition: "attachment")
+        )
+      ].join(" ").html_safe
+    elsif referral.allegation_details.present?
+      referral.allegation_details.truncate(150)
+    else
+      "Incomplete"
+    end
+  end
+
+  def previous_allegation_details(referral)
+    if referral.previous_misconduct_upload.attached?
+      [
+        "File:",
+        govuk_link_to(
+          referral.previous_misconduct_upload.filename,
+          rails_blob_path(
+            referral.previous_misconduct_upload,
+            disposition: "attachment"
+          )
+        )
+      ].join(" ").html_safe
+    elsif referral.previous_misconduct_details.present?
+      simple_format(referral.previous_misconduct_details)
+    else
+      "Incomplete"
+    end
+  end
 end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -80,4 +80,8 @@ class Referral < ApplicationRecord
   def left_role?
     employment_status == "left_role"
   end
+
+  def name
+    [first_name, last_name].join(" ")
+  end
 end

--- a/app/models/referrer.rb
+++ b/app/models/referrer.rb
@@ -1,6 +1,14 @@
 class Referrer < ApplicationRecord
   belongs_to :referral
 
+  def first_name
+    name.split(" ").first
+  end
+
+  def last_name
+    name.split(" ")[1]
+  end
+
   def completed?
     completed_at.present?
   end

--- a/app/views/manage_interface/referrals/show.html.erb
+++ b/app/views/manage_interface/referrals/show.html.erb
@@ -3,14 +3,14 @@
 <% content_for :breadcrumbs do %>
   <%= govuk_breadcrumbs(breadcrumbs: {
     "Referrals" => manage_interface_referrals_path,
-    @referral.referrer_name => nil
+    @referral.name => nil
   }) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <span class="govuk-caption-l"><%= @referral.id %></span>
-    <h1 class="govuk-heading-l"><%= @referral.referrer_name %></h1>
+    <h1 class="govuk-heading-l"><%= @referral.name %></h1>
 
     <div class="app-panel">
       <h2 class="govuk-heading-m">Summary</h2>
@@ -19,6 +19,75 @@
         { key: { text: "Referral date" }, value: { text: @referral.created_at.to_fs(:day_month_year_time) } }
       ]) 
       %>
+    </div>
+
+    <div class="app-panel">
+      <h2 class="govuk-heading-m">Personal details</h2>
+      <%= govuk_summary_list(rows: [
+        { key: { text: "First name" }, value: { text: @referral.first_name } },
+        { key: { text: "Last name" }, value: { text: @referral.last_name } },
+        { key: { text: "Do they have qualified teacher status?" }, value: { text: @referral.has_qts&.humanize } },
+      ])
+      %>
+    </div>
+
+    <div class="app-panel">
+      <h2 class="govuk-heading-m">Employment details</h2>
+      <%= govuk_summary_list(rows: [
+        { key: { text: "Job title" }, value: { text: @referral.job_title || "Not known" } },
+        { key: { text: "Main duties" }, value: { text: duties_details(@referral) } },
+        { key: { text: "Organisation" }, value: { text: referral_organisation_address(@referral) } },
+        { key: { text: "Job start date" }, value: { text: @referral.role_start_date&.to_fs(:long_ordinal_uk) }},
+        { key: { text: "Job end date" }, value: { text: @referral.role_end_date&.to_fs(:long_ordinal_uk) }},
+        { key: { text: "Reason they left the job" }, value: { text: @referral.reason_leaving_role&.humanize }},
+      ]) %>
+    </div>
+
+    <div class="app-panel">
+      <h2 class="govuk-heading-m">Other employment details</h2>
+      <%= govuk_summary_list(rows: [
+        { key: { text: "Organisation" }, value: { text: teaching_address(@referral) } }
+      ]) %>
+    </div>
+
+    <div class="app-panel">
+      <h2 class="govuk-heading-m">Allegation details</h2>
+      <%= govuk_summary_list(rows: [
+        { key: { text: "Allegation details" }, value: { text: allegation_details(@referral) } },
+        { key: { text: "Have you told the Disclosure and Barring Service (DBS)?" }, value: { text: @referral.dbs_notified ? "Yes" : "No" } },
+      ]) %>
+    </div>
+
+    <div class="app-panel">
+      <h2 class="govuk-heading-m">Evidence and supporting information</h2>
+      <% if @referral.evidences.any? %>
+        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+          <% @referral.evidences.map do |evidence| %>
+            <li class="govuk-!-margin-bottom-0">
+              <%= govuk_link_to(evidence.filename, rails_blob_path(evidence.document, disposition: "attachment")) %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    </div>
+
+    <div class="app-panel">
+      <h2 class="govuk-heading-m">Previous allegation details</h2>
+      <%= govuk_summary_list(rows: [
+        { key: { text: "Has there been any previous misconduct?" }, value: { text: humanize_three_way_choice(@referral.previous_misconduct_reported) } },
+        { key: { text: "Previous allegation details" }, value: { text: previous_allegation_details(@referral) } },
+      ]) %>
+    </div>
+
+    <div class="app-panel">
+      <h2 class="govuk-heading-m">Referrer details</h2>
+      <%= govuk_summary_list(rows: [
+        { key: { text: "First name" }, value: { text: @referral.referrer.first_name } },
+        { key: { text: "Last name" }, value: { text: @referral.referrer.last_name } },
+        { key: { text: "Job title" }, value: { text: @referral.referrer.job_title } },
+        { key: { text: "Email address" }, value: { text: @referral.user.email } },
+        { key: { text: "Phone number" }, value: { text: @referral.referrer.phone } },
+      ]) %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This adds all the sections to the case worker referral view that are
detailed in the current designs.

There are some parts to this that aren't implemented yet.

The referrer name is stored as a single field. For now I opted to split
this value into first and last name methods so we can render the
proposed UI.

When the change to the way we collect this value happens, then these
methods will continue to work and we won't need to change the referral
view.

Secondly, we don't collect the referrer's current employer address.

Rather than guess at how we might do that, I left it unimplemented.

### Link to Trello card

https://trello.com/c/HEb0DEie/1109-case-worker-referral-show-page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
