### PR TITLE
Add case worker zip file download

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "propshaft"
 gem "puma", "~> 6.0"
 gem "rails", "~> 7.0.4"
 gem "rotp"
+gem "rubyzip"
 gem "sentry-rails"
 gem "sidekiq", "< 7"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,6 +350,7 @@ GEM
       rubocop (~> 1.33)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
     sentry-rails (5.7.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.7.0)
@@ -452,6 +453,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   rubocop-govuk
+  rubyzip
   sentry-rails
   shoulda-matchers
   sidekiq (< 7)

--- a/app/controllers/manage_interface/referrals_controller.rb
+++ b/app/controllers/manage_interface/referrals_controller.rb
@@ -1,12 +1,30 @@
 module ManageInterface
   class ReferralsController < ManageInterfaceController
+    before_action :referral, only: %i[show download]
+
     def index
       @referrals_count = Referral.submitted.count
       @pagy, @referrals = pagy(Referral.submitted)
     end
 
     def show
-      @referral = Referral.find(params[:id])
+    end
+
+    def download
+      filepath = @referral.zip_file_path
+      file = File.open(filepath)
+      contents = file.read
+      file.close
+
+      File.delete(filepath) if File.exist?(filepath)
+
+      send_data(contents, filename: @referral.zip_file_name)
+    end
+
+    private
+
+    def referral
+      @referral ||= Referral.find(params[:id])
     end
   end
 end

--- a/app/models/concerns/zippable.rb
+++ b/app/models/concerns/zippable.rb
@@ -1,0 +1,65 @@
+require "zip"
+
+module Zippable
+  extend ActiveSupport::Concern
+
+  included do
+    def zip_file_path
+      @zip_file_path ||= zip_file.path
+    end
+
+    def zip_file_name
+      "#{Time.zone.now.to_fs(:number)}-#{self.class.name.downcase}-#{id}.zip"
+    end
+
+    def has_attachments?
+      has_own_attachments? || has_evidence_attachments?
+    end
+
+    private
+
+    def zip_file
+      temp_file = Tempfile.new("temp.zip")
+
+      Zip::File.open(temp_file.path, create: true) do |zip_file|
+        attachments.each do |attachment|
+          next unless attachment.attached?
+
+          file = ActiveStorage::Blob.service.path_for(attachment.key)
+          zip_file.add(
+            "#{attachment.name}/#{attachment.record.id}-#{attachment.filename}",
+            File.join(file)
+          )
+        end
+      end
+
+      temp_file
+    end
+
+    def attachments
+      files = []
+
+      self.class.zippable_attachments.each do |zippable_attachment|
+        files << send(zippable_attachment)
+      end
+
+      files + evidences.map(&:document)
+    end
+
+    def has_own_attachments?
+      self.class.zippable_attachments.any? do |attachment|
+        send(attachment).attached?
+      end
+    end
+
+    def has_evidence_attachments?
+      evidences.any? { |evidence| evidence.document.attached? }
+    end
+  end
+
+  class_methods do
+    def zippable_attachments
+      reflect_on_all_attachments.map(&:name)
+    end
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -1,4 +1,6 @@
 class Referral < ApplicationRecord
+  include Zippable
+
   belongs_to :eligibility_check, dependent: :destroy
   belongs_to :user
 

--- a/app/views/manage_interface/referrals/show.html.erb
+++ b/app/views/manage_interface/referrals/show.html.erb
@@ -13,11 +13,18 @@
     <h1 class="govuk-heading-l"><%= @referral.name %></h1>
 
     <div class="app-panel">
+      <% if @referral.has_attachments? %>
+        <p class="govuk-body">
+          <%= govuk_link_to "Download referral (ZIP)", download_manage_interface_referral_path %>
+        </p>
+      <% end %>
+
       <h2 class="govuk-heading-m">Summary</h2>
+
       <%= govuk_summary_list(rows: [
         { key: { text: "Referral ID" }, value: { text: @referral.id } },
         { key: { text: "Referral date" }, value: { text: @referral.created_at.to_fs(:day_month_year_time) } }
-      ]) 
+      ])
       %>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -279,7 +279,9 @@ Rails.application.routes.draw do
   end
 
   namespace :manage_interface, path: "/manage" do
-    resources :referrals, only: %i[index show]
+    resources :referrals, only: %i[index show] do
+      get 'download', on: :member, to: "referrals#download"
+    end
   end
 
   get "/accessibility", to: "static#accessibility"

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -21,5 +21,14 @@ FactoryBot.define do
       complete
       submitted_at { Time.current }
     end
+
+    trait :with_attachments do
+      allegation_upload do
+        Rack::Test::UploadedFile.new("spec/fixtures/files/upload1.pdf")
+      end
+      duties_upload do
+        Rack::Test::UploadedFile.new("spec/fixtures/files/upload2.pdf")
+      end
+    end
   end
 end

--- a/spec/models/concerns/zippable_spec.rb
+++ b/spec/models/concerns/zippable_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe Zippable do
+  before { travel_to Time.zone.local(2022, 11, 22, 12, 0, 0) }
+
+  describe "#zip_file_path" do
+    let(:referral) { create(:referral, :with_attachments) }
+
+    it "returns the generated file path" do
+      expect(Pathname.new(referral.zip_file_path)).to be_file
+    end
+  end
+
+  describe "#zip_file_name" do
+    let(:referral) { create(:referral) }
+
+    it "returns the file name" do
+      expect(referral.zip_file_name).to eq(
+        "20221122120000-referral-#{referral.id}.zip"
+      )
+    end
+  end
+
+  describe "#has_attachments?" do
+    context "without attachments" do
+      let(:referral) { create(:referral) }
+
+      it "returns false" do
+        expect(referral.has_attachments?).to be false
+      end
+    end
+
+    context "with attachments" do
+      let(:referral) { create(:referral, :with_attachments) }
+
+      it "returns true" do
+        expect(referral.has_attachments?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

This is the first iteration of the download functionality for the case worker manage referrals page.

It adds a link to download the exported zip file:
<img width="489" alt="Screenshot 2023-01-20 at 11 55 09" src="https://user-images.githubusercontent.com/1636476/213689393-5975224a-8bd1-4776-ab27-0278de4be038.png">

### Changes proposed in this pull request

- select all the file attachments for the referral: `duties_upload`, `allegation_upload`, and all the documents attached via the submitted evidences.
- group the files into folders
- the downloaded file will have the following format for its name: `<timestamp>-referral-<referral_id>.zip`
- make sure the temp file gets deleted afterwards.

The way we handle this might change in the future as for larger files an asynchronous approach would be better (scheduled exports or exports triggered on click followed by an email with the download link.)

### Link to Trello card

https://trello.com/c/HontnuhK/1111-case-worker-zip-file-download

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
