### PR TITLE
Add contact email length validator

### DIFF
--- a/app/forms/referrals/contact_details/email_form.rb
+++ b/app/forms/referrals/contact_details/email_form.rb
@@ -8,7 +8,12 @@ module Referrals
 
       validates :referral, presence: true
       validates :email_known, inclusion: { in: [true, false] }
-      validates :email_address, presence: true, if: -> { email_known }
+      validates :email_address,
+                presence: true,
+                length: {
+                  maximum: 256
+                },
+                if: -> { email_known }
       validates :email_address,
                 valid_for_notify: true,
                 if: -> { email_known && email_address.present? }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,7 @@ en:
               inclusion: Select yes if you know their email address
             email_address:
               blank: Enter their email address
+              too_long: "The email address must have no more than %{count} characters."
               invalid: Enter an email address in the correct format, like name@example.com
         "referrals/contact_details/telephone_form":
           attributes:

--- a/spec/forms/referrals/contact_details/email_form_spec.rb
+++ b/spec/forms/referrals/contact_details/email_form_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe Referrals::ContactDetails::EmailForm, type: :model do
       end
     end
 
+    context "when email_address is longer than 256 characters" do
+      let(:email_address) { "#{"x" * 250}@example.com" }
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        expect(form.errors[:email_address]).to eq(
+          ["The email address must have no more than 256 characters."]
+        )
+      end
+    end
+
     context "when email_address is invalid" do
       let(:email_address) { "name" }
 


### PR DESCRIPTION
Match the database limit of 256 characters

### Context

The contact email had a limit in the database but do not a length validator. This could cause a potential postgres error: `PG::StringDataRightTruncation: ERROR: value too long for type character varying(256)`

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
