### PR TITLE
Add "How your data will be used page"

### DIFF
--- a/app/controllers/public_referrals/referrer_name_controller.rb
+++ b/app/controllers/public_referrals/referrer_name_controller.rb
@@ -5,5 +5,9 @@ module PublicReferrals
     def next_path
       [:edit, current_referral.routing_scope, current_referral, :referrer_phone]
     end
+
+    def previous_path
+      public_referral_personal_details_path(current_referral)
+    end
   end
 end

--- a/app/controllers/public_referrals/referrers_controller.rb
+++ b/app/controllers/public_referrals/referrers_controller.rb
@@ -1,4 +1,6 @@
 module PublicReferrals
   class ReferrersController < Referrals::ReferrersController
+    def personal_details
+    end
   end
 end

--- a/app/controllers/referrals/referrer_name_controller.rb
+++ b/app/controllers/referrals/referrer_name_controller.rb
@@ -31,5 +31,12 @@ module Referrals
         :referrer_job_title
       ]
     end
+
+    def previous_path
+      polymorphic_path(
+        [:edit, current_referral.routing_scope, current_referral]
+      )
+    end
+    helper_method :previous_path
   end
 end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -38,9 +38,7 @@ class ReferralForm
         section.items = [
           ReferralSectionItem.new(
             I18n.t("referral_form.your_details"),
-            polymorphic_path(
-              [:edit, referral.routing_scope, referral, :referrer_name]
-            ),
+            about_you_section_path,
             referral.referrer_status
           )
         ]
@@ -57,6 +55,16 @@ class ReferralForm
           )
         end
       end
+  end
+
+  def about_you_section_path
+    if referral.from_employer?
+      polymorphic_path(
+        [:edit, referral.routing_scope, referral, :referrer_name]
+      )
+    else
+      public_referral_personal_details_path(referral)
+    end
   end
 
   def about_the_person_you_are_referring_section

--- a/app/views/public_referrals/referrers/personal_details.html.erb
+++ b/app/views/public_referrals/referrers/personal_details.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, "How your personal details will be used" %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <span class="govuk-caption-l">Your details</span>
+    <h1 class="govuk-heading-l">How your personal details will be&nbsp;used</h1>
+    <p>If the TRA decides to investigate this case, your name will be shared with the teacher you’re referring and their employer. The teacher has a right to know who referred them.</p>
+    <p>Your contact details will not be shared. The TRA will only use these to contact you about this case.</p>
+    <%= govuk_button_link_to "Continue", polymorphic_path([:edit, current_referral.routing_scope, current_referral, :referrer_name]) %>
+</div>

--- a/app/views/referrals/referrer_name/edit.html.erb
+++ b/app/views/referrals/referrer_name/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @referrer_name_form.errors.any?}Your name" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, return_to_session_or(previous_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,7 @@ Rails.application.routes.draw do
       end
 
       resource :referrer, only: %i[show update]
+      get "/personal-details", to: "referrers#personal_details"
 
       resource :referrer_name,
                only: %i[edit update],

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -70,6 +70,11 @@ module CommonSteps
   end
   alias_method :and_i_click_save_and_continue, :when_i_click_save_and_continue
 
+  def when_i_click_continue
+    click_on "Continue"
+  end
+  alias_method :and_i_click_continue, :when_i_click_continue
+
   def when_i_click_back
     click_on "Back"
   end

--- a/spec/system/public_referrals/user_adds_their_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_their_details_spec.rb
@@ -10,7 +10,10 @@ RSpec.feature "Public Referral: About You", type: :system do
     and_i_am_a_member_of_the_public_with_an_existing_referral
     when_i_visit_the_public_referral
     and_i_click_on_your_details
-    then_i_am_on_the_your_details_page
+    then_i_am_on_the_personal_details_page
+
+    when_i_click_continue
+    then_i_am_on_the_your_name_page
 
     when_i_click_save_and_continue
     then_i_see_the_name_error_message
@@ -28,7 +31,7 @@ RSpec.feature "Public Referral: About You", type: :system do
     and_i_see_my_answers_on_the_referrer_check_your_answers_page
 
     when_i_click_on_change_name
-    then_i_am_on_the_your_details_page
+    then_i_am_on_the_your_name_page
     and_i_see_my_name_in_the_form_field
 
     when_i_click_save_and_continue
@@ -38,6 +41,7 @@ RSpec.feature "Public Referral: About You", type: :system do
     and_i_see_your_details_flagged_as_incomplete
 
     when_i_click_on_your_details
+    and_i_click_continue
     then_i_see_the_name_prefilled
 
     when_i_click_save_and_continue
@@ -75,7 +79,16 @@ RSpec.feature "Public Referral: About You", type: :system do
     end
   end
 
-  def then_i_am_on_the_your_details_page
+  def then_i_am_on_the_personal_details_page
+    expect(page).to have_current_path(
+      "/public-referrals/#{@referral.id}/personal-details",
+      ignore_query: true
+    )
+    expect(page).to have_title("How your personal details will be used")
+    expect(page).to have_content("Your details")
+  end
+
+  def then_i_am_on_the_your_name_page
     expect(page).to have_current_path(
       "/public-referrals/#{@referral.id}/referrer-name/edit",
       ignore_query: true

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
     and_i_have_an_existing_referral
     and_i_visit_the_referral
     when_i_click_on_your_details
-    then_i_am_on_the_your_details_page
+    then_i_am_on_the_your_name_page
 
     when_i_click_save_and_continue
     then_i_see_the_name_error_message
@@ -35,7 +35,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
     and_i_see_my_answers_on_the_referrer_check_your_answers_page
 
     when_i_click_on_change_name
-    then_i_am_on_the_your_details_page
+    then_i_am_on_the_your_name_page
     and_i_see_my_name_in_the_form_field
 
     when_i_click_save_and_continue
@@ -85,7 +85,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
     end
   end
 
-  def then_i_am_on_the_your_details_page
+  def then_i_am_on_the_your_name_page
     expect(page).to have_current_path(
       "/referrals/#{@referral.id}/referrer-name/edit",
       ignore_query: true


### PR DESCRIPTION
### Context

Adds a page accessible from clicking on the "Your details" link from the referral hub for the public referrals.

<img width="678" alt="Screenshot 2023-01-24 at 10 45 54" src="https://user-images.githubusercontent.com/1636476/214272947-0319b26b-49e0-49bc-8c11-eee6418f362d.png">

### Link to Trello card

https://trello.com/c/Czxw5QKc/1039-how-your-data-will-be-used-page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
