### PR TITLE
Remove leading padding for date format

### DIFF
--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -7,4 +7,4 @@ Date::DATE_FORMATS[:weekday_day_and_month] = "%A %-d %B"
 Time::DATE_FORMATS[:month_and_year] = "%B %Y"
 Date::DATE_FORMATS[:month_and_year] = "%B %Y"
 
-Time::DATE_FORMATS[:day_month_year_time] = "%d %B %Y at %l:%M %P"
+Time::DATE_FORMATS[:day_month_year_time] = "%d %B %Y at %-l:%M %P"


### PR DESCRIPTION
### Context

The `day_month_year_time` was using 12 hours time format with an extra padding for single digit hours. This was causing an issue with our tests.