### PR TITLE
Move case worker views into components

### DIFF
--- a/app/components/app_panel_component.html.erb
+++ b/app/components/app_panel_component.html.erb
@@ -1,0 +1,5 @@
+<div class="app-panel" id="<%= dom_id %>">
+  <h2 class="govuk-heading-m"><%= title %></h2>
+
+  <%= govuk_summary_list(rows:) %>
+</div>

--- a/app/components/app_panel_component.rb
+++ b/app/components/app_panel_component.rb
@@ -1,0 +1,9 @@
+class AppPanelComponent < ViewComponent::Base
+  include ActiveModel::Model
+
+  attr_accessor :referral, :rows, :title
+
+  def dom_id
+    title.parameterize(separator: "_")
+  end
+end

--- a/app/components/manage_interface/allegation_details_component.html.erb
+++ b/app/components/manage_interface/allegation_details_component.html.erb
@@ -1,0 +1,1 @@
+<%= render AppPanelComponent.new(referral:, rows:, title:) %>

--- a/app/components/manage_interface/allegation_details_component.rb
+++ b/app/components/manage_interface/allegation_details_component.rb
@@ -1,0 +1,33 @@
+module ManageInterface
+  class AllegationDetailsComponent < ViewComponent::Base
+    include ActiveModel::Model
+    include ReferralHelper
+
+    attr_accessor :referral
+
+    def rows
+      [
+        {
+          key: {
+            text: "Allegation details"
+          },
+          value: {
+            text: allegation_details(referral)
+          }
+        },
+        {
+          key: {
+            text: "Have you told the Disclosure and Barring Service (DBS)?"
+          },
+          value: {
+            text: referral.dbs_notified ? "Yes" : "No"
+          }
+        }
+      ]
+    end
+
+    def title
+      "Allegation details"
+    end
+  end
+end

--- a/app/components/manage_interface/employment_details_component.html.erb
+++ b/app/components/manage_interface/employment_details_component.html.erb
@@ -1,0 +1,1 @@
+<%= render AppPanelComponent.new(referral:, rows:, title:) %>

--- a/app/components/manage_interface/employment_details_component.rb
+++ b/app/components/manage_interface/employment_details_component.rb
@@ -1,0 +1,94 @@
+module ManageInterface
+  class EmploymentDetailsComponent < ViewComponent::Base
+    include ActiveModel::Model
+    include ReferralHelper
+    include AddressHelper
+
+    attr_accessor :referral
+
+    def rows
+      rows = [
+        {
+          key: {
+            text: "Job title"
+          },
+          value: {
+            text: referral.job_title || "Not known"
+          }
+        },
+        {
+          key: {
+            text: "Main duties"
+          },
+          value: {
+            text: duties_details(referral)
+          }
+        }
+      ]
+
+      return rows unless referral.from_employer?
+
+      rows.push(organisation_row)
+      if referral.role_start_date_known
+        rows.push(
+          {
+            key: {
+              text: "Job start date"
+            },
+            value: {
+              text: referral.role_start_date&.to_fs(:long_ordinal_uk)
+            }
+          }
+        )
+      end
+      if referral.role_end_date_known
+        rows.push(
+          {
+            key: {
+              text: "Job end date"
+            },
+            value: {
+              text: referral.role_end_date&.to_fs(:long_ordinal_uk)
+            }
+          }
+        )
+      end
+      rows.push(
+        {
+          key: {
+            text: "Reason they left the job"
+          },
+          value: {
+            text: referral.reason_leaving_role&.humanize
+          }
+        }
+      )
+
+      rows
+    end
+
+    def title
+      "Employment details"
+    end
+
+    private
+
+    def organisation_row
+      {
+        key: {
+          text: "Organisation"
+        },
+        value: {
+          text:
+            (
+              if referral.same_organisation?
+                organisation_address(referral.organisation)
+              else
+                referral_organisation_address(referral)
+              end
+            )
+        }
+      }
+    end
+  end
+end

--- a/app/components/manage_interface/evidence_component.html.erb
+++ b/app/components/manage_interface/evidence_component.html.erb
@@ -1,0 +1,12 @@
+<div class="app-panel" id="evidence">
+  <h2 class="govuk-heading-m">Evidence and supporting information</h2>
+  <% if referral.evidences.any? %>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+      <% referral.evidences.map do |evidence| %>
+        <li class="govuk-!-margin-bottom-0">
+          <%= govuk_link_to(evidence.filename, rails_blob_path(evidence.document, disposition: "attachment")) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/components/manage_interface/evidence_component.rb
+++ b/app/components/manage_interface/evidence_component.rb
@@ -1,0 +1,7 @@
+module ManageInterface
+  class EvidenceComponent < ViewComponent::Base
+    include ActiveModel::Model
+
+    attr_accessor :referral
+  end
+end

--- a/app/components/manage_interface/other_employment_details_component.html.erb
+++ b/app/components/manage_interface/other_employment_details_component.html.erb
@@ -1,0 +1,1 @@
+<%= render AppPanelComponent.new(referral:, rows:, title:) %>

--- a/app/components/manage_interface/other_employment_details_component.rb
+++ b/app/components/manage_interface/other_employment_details_component.rb
@@ -1,0 +1,25 @@
+module ManageInterface
+  class OtherEmploymentDetailsComponent < ViewComponent::Base
+    include ActiveModel::Model
+    include AddressHelper
+
+    attr_accessor :referral
+
+    def rows
+      [
+        {
+          key: {
+            text: "Organisation"
+          },
+          value: {
+            text: teaching_address(referral)
+          }
+        }
+      ]
+    end
+
+    def title
+      "Other employment details"
+    end
+  end
+end

--- a/app/components/manage_interface/personal_details_component.html.erb
+++ b/app/components/manage_interface/personal_details_component.html.erb
@@ -1,0 +1,1 @@
+<%= render AppPanelComponent.new(referral:, rows:, title:) %>

--- a/app/components/manage_interface/personal_details_component.rb
+++ b/app/components/manage_interface/personal_details_component.rb
@@ -1,0 +1,31 @@
+module ManageInterface
+  class PersonalDetailsComponent < ViewComponent::Base
+    include ActiveModel::Model
+
+    attr_accessor :referral
+
+    def rows
+      rows = [
+        { key: { text: "First name" }, value: { text: referral.first_name } },
+        { key: { text: "Last name" }, value: { text: referral.last_name } }
+      ]
+      return rows unless referral.from_employer?
+
+      rows.push(
+        {
+          key: {
+            text: "Do they have qualified teacher status?"
+          },
+          value: {
+            text: referral.has_qts&.humanize
+          }
+        }
+      )
+      rows
+    end
+
+    def title
+      "Personal details"
+    end
+  end
+end

--- a/app/components/manage_interface/previous_allegation_details_component.html.erb
+++ b/app/components/manage_interface/previous_allegation_details_component.html.erb
@@ -1,0 +1,1 @@
+<%= render AppPanelComponent.new(referral:, rows:, title:) %>

--- a/app/components/manage_interface/previous_allegation_details_component.rb
+++ b/app/components/manage_interface/previous_allegation_details_component.rb
@@ -1,0 +1,35 @@
+module ManageInterface
+  class PreviousAllegationDetailsComponent < ViewComponent::Base
+    include ActiveModel::Model
+    include ReferralHelper
+    include ApplicationHelper
+
+    attr_accessor :referral
+
+    def rows
+      [
+        {
+          key: {
+            text: "Has there been any previous misconduct?"
+          },
+          value: {
+            text:
+              humanize_three_way_choice(referral.previous_misconduct_reported)
+          }
+        },
+        {
+          key: {
+            text: "Previous allegation details"
+          },
+          value: {
+            text: previous_allegation_details(referral)
+          }
+        }
+      ]
+    end
+
+    def title
+      "Previous allegation details"
+    end
+  end
+end

--- a/app/components/manage_interface/referral_summary_component.html.erb
+++ b/app/components/manage_interface/referral_summary_component.html.erb
@@ -1,0 +1,1 @@
+<%= render AppPanelComponent.new(referral:, rows:, title:) %>

--- a/app/components/manage_interface/referral_summary_component.rb
+++ b/app/components/manage_interface/referral_summary_component.rb
@@ -1,0 +1,25 @@
+module ManageInterface
+  class ReferralSummaryComponent < ViewComponent::Base
+    include ActiveModel::Model
+
+    attr_accessor :referral
+
+    def rows
+      [
+        { key: { text: "Referral ID" }, value: { text: referral.id } },
+        {
+          key: {
+            text: "Referral date"
+          },
+          value: {
+            text: referral.created_at.to_fs(:day_month_year_time)
+          }
+        }
+      ]
+    end
+
+    def title
+      "Summary"
+    end
+  end
+end

--- a/app/components/manage_interface/referrer_details_component.html.erb
+++ b/app/components/manage_interface/referrer_details_component.html.erb
@@ -1,0 +1,1 @@
+<%= render AppPanelComponent.new(referral:, rows:, title:) %>

--- a/app/components/manage_interface/referrer_details_component.rb
+++ b/app/components/manage_interface/referrer_details_component.rb
@@ -1,0 +1,44 @@
+module ManageInterface
+  class ReferrerDetailsComponent < ViewComponent::Base
+    include ActiveModel::Model
+    include AddressHelper
+
+    attr_accessor :referral
+
+    def rows
+      rows = [
+        { key: { text: "First name" }, value: { text: referrer.first_name } },
+        { key: { text: "Last name" }, value: { text: referrer.last_name } }
+      ]
+      if referral.from_employer?
+        rows.push(
+          { key: { text: "Job title" }, value: { text: referrer.job_title } }
+        )
+      end
+      rows.push({ key: { text: "Email address" }, value: { text: user.email } })
+      rows.push(
+        { key: { text: "Phone number" }, value: { text: referrer.phone } }
+      )
+      if referral.from_employer?
+        rows.push(
+          {
+            key: {
+              text: "Employer"
+            },
+            value: {
+              text: organisation_address(referral.organisation)
+            }
+          }
+        )
+      end
+
+      rows
+    end
+
+    def title
+      "Referrer details"
+    end
+
+    delegate :referrer, :user, to: :referral
+  end
+end

--- a/app/views/manage_interface/referrals/show.html.erb
+++ b/app/views/manage_interface/referrals/show.html.erb
@@ -20,97 +20,21 @@
       <% end %>
     </div>
 
-    <div class="app-panel" id="summary">
-      <h2 class="govuk-heading-m">Summary</h2>
-
-      <%= govuk_summary_list(rows: [
-        { key: { text: "Referral ID" }, value: { text: @referral.id } },
-        { key: { text: "Referral date" }, value: { text: @referral.created_at.to_fs(:day_month_year_time) } }
-      ])
-      %>
-    </div>
-
-    <div class="app-panel" id="personal_details">
-      <h2 class="govuk-heading-m">Personal details</h2>
-      <% personal_rows = [
-        { key: { text: "First name" }, value: { text: @referral.first_name } },
-        { key: { text: "Last name" }, value: { text: @referral.last_name } },
-      ]
-        personal_rows << { key: { text: "Do they have qualified teacher status?" }, value: { text: @referral.has_qts&.humanize } } if @referral.from_employer?
-      %>
-      <%= govuk_summary_list(rows: personal_rows) %>
-    </div>
-
-    <div class="app-panel" id="employment_details">
-      <h2 class="govuk-heading-m">Employment details</h2>
-      <% 
-        employment_rows = [
-          { key: { text: "Job title" }, value: { text: @referral.job_title || "Not known" } },
-          { key: { text: "Main duties" }, value: { text: duties_details(@referral) } },
-        ] 
-        if @referral.from_employer?
-          employment_rows.push({ key: { text: "Organisation" }, value: { text: @referral.same_organisation? ? organisation_address(@referral.organisation) : referral_organisation_address(@referral) } })
-          employment_rows.push({ key: { text: "Job start date" }, value: { text: @referral.role_start_date&.to_fs(:long_ordinal_uk) }}) if @referral.role_start_date_known
-          employment_rows.push({ key: { text: "Job end date" }, value: { text: @referral.role_end_date&.to_fs(:long_ordinal_uk) }}) if @referral.role_end_date_known
-          employment_rows.push({ key: { text: "Reason they left the job" }, value: { text: @referral.reason_leaving_role&.humanize }})
-        end
-      %>
-      <%= govuk_summary_list(rows: employment_rows) %>
-    </div>
+    <%= render ManageInterface::ReferralSummaryComponent.new(referral: @referral) %>
+    <%= render ManageInterface::PersonalDetailsComponent.new(referral: @referral) %>
+    <%= render ManageInterface::EmploymentDetailsComponent.new(referral: @referral) %>
 
     <% if @referral.from_employer? %>
-      <div class="app-panel" id="other_employment_details">
-        <h2 class="govuk-heading-m">Other employment details</h2>
-        <%= govuk_summary_list(rows: [
-          { key: { text: "Organisation" }, value: { text: teaching_address(@referral) } }
-        ]) %>
-      </div>
+      <%= render ManageInterface::OtherEmploymentDetailsComponent.new(referral: @referral) %>
     <% end %>
 
-    <div class="app-panel" id="allegation_details">
-      <h2 class="govuk-heading-m">Allegation details</h2>
-      <%= govuk_summary_list(rows: [
-        { key: { text: "Allegation details" }, value: { text: allegation_details(@referral) } },
-        { key: { text: "Have you told the Disclosure and Barring Service (DBS)?" }, value: { text: @referral.dbs_notified ? "Yes" : "No" } },
-      ]) %>
-    </div>
-
-    <div class="app-panel" id="evidence">
-      <h2 class="govuk-heading-m">Evidence and supporting information</h2>
-      <% if @referral.evidences.any? %>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
-          <% @referral.evidences.map do |evidence| %>
-            <li class="govuk-!-margin-bottom-0">
-              <%= govuk_link_to(evidence.filename, rails_blob_path(evidence.document, disposition: "attachment")) %>
-            </li>
-          <% end %>
-        </ul>
-      <% end %>
-    </div>
+    <%= render ManageInterface::AllegationDetailsComponent.new(referral: @referral) %>
+    <%= render ManageInterface::EvidenceComponent.new(referral: @referral) %>
 
     <% if @referral.from_employer? %>
-      <div class="app-panel" id="previous_allegation_details">
-        <h2 class="govuk-heading-m">Previous allegation details</h2>
-        <%= govuk_summary_list(rows: [
-          { key: { text: "Has there been any previous misconduct?" }, value: { text: humanize_three_way_choice(@referral.previous_misconduct_reported) } },
-          { key: { text: "Previous allegation details" }, value: { text: previous_allegation_details(@referral) } },
-        ]) %>
-      </div>
+      <%= render ManageInterface::PreviousAllegationDetailsComponent.new(referral: @referral) %>
     <% end %>
 
-    <div class="app-panel" id="referrer_details">
-      <h2 class="govuk-heading-m">Referrer details</h2>
-      <% 
-        referrer_rows = [
-          { key: { text: "First name" }, value: { text: @referral.referrer.first_name } },
-          { key: { text: "Last name" }, value: { text: @referral.referrer.last_name } },
-        ] 
-        referrer_rows.push({ key: { text: "Job title" }, value: { text: @referral.referrer.job_title } }) if @referral.from_employer?
-        referrer_rows.push({ key: { text: "Email address" }, value: { text: @referral.user.email } })
-        referrer_rows.push({ key: { text: "Phone number" }, value: { text: @referral.referrer.phone } })
-        referrer_rows.push({ key: { text: "Employer" }, value: { text: organisation_address(@referral.organisation) } }) if @referral.from_employer?
-      %>
-      <%= govuk_summary_list(rows: referrer_rows) %>
-    </div>
+    <%= render ManageInterface::ReferrerDetailsComponent.new(referral: @referral) %>
   </div>
 </div>


### PR DESCRIPTION
The case worker referral view currently contains all the UI in a single
template. 

There is an opportunity to migrate this to using view
components to make the logic clearer to follow, provide the opportunity
for easier re-use and maintain a UI pattern used throughout the DfE
projects.

A next step for this work is to look for ways to share these view components 
with the public and employer check answers pages.

They display similar information but in a different context.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
