### PR TITLE
Update the name for linked files

### DIFF
--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -33,15 +33,12 @@ module ReferralHelper
 
   def allegation_details(referral)
     if referral.allegation_upload.attached?
-      [
-        "File:",
-        govuk_link_to(
-          referral.allegation_upload.filename,
-          rails_blob_path(referral.allegation_upload, disposition: "attachment")
-        )
-      ].join(" ").html_safe
+      govuk_link_to(
+        referral.allegation_upload.filename,
+        rails_blob_path(referral.allegation_upload, disposition: "attachment")
+      )
     elsif referral.allegation_details.present?
-      referral.allegation_details.truncate(150)
+      simple_format(referral.allegation_details)
     else
       "Incomplete"
     end
@@ -49,16 +46,13 @@ module ReferralHelper
 
   def previous_allegation_details(referral)
     if referral.previous_misconduct_upload.attached?
-      [
-        "File:",
-        govuk_link_to(
-          referral.previous_misconduct_upload.filename,
-          rails_blob_path(
-            referral.previous_misconduct_upload,
-            disposition: "attachment"
-          )
+      govuk_link_to(
+        referral.previous_misconduct_upload.filename,
+        rails_blob_path(
+          referral.previous_misconduct_upload,
+          disposition: "attachment"
         )
-      ].join(" ").html_safe
+      )
     elsif referral.previous_misconduct_details.present?
       simple_format(referral.previous_misconduct_details)
     else


### PR DESCRIPTION
The format of the linked files contains a 'File:' prefix.

Since we implemented this, the designs have changed and no longer
require this prefix. We can safely remove it.

While I was making a change there, I took the opportunity to standardise
how the allegation description is formatted.

Both the current allegation description and the previous allegation
description should be displayed in the same way.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
