### PR TITLE
Update change answer links

### DIFF
--- a/app/components/about_you_component.rb
+++ b/app/components/about_you_component.rb
@@ -17,7 +17,7 @@ class AboutYouComponent < ViewComponent::Base
                 [:edit, referral.routing_scope, referral, :referrer_name],
                 return_to: request.path
               ),
-            visually_hidden_text: "name"
+            visually_hidden_text: "your name"
           }
         ],
         key: {
@@ -54,7 +54,7 @@ class AboutYouComponent < ViewComponent::Base
                   ],
                   return_to: request.path
                 ),
-              visually_hidden_text: "job title"
+              visually_hidden_text: "your job title"
             }
           ],
           key: {
@@ -77,7 +77,7 @@ class AboutYouComponent < ViewComponent::Base
                 [:edit, referral.routing_scope, referral, :referrer_phone],
                 return_to: request.path
               ),
-            visually_hidden_text: "phone"
+            visually_hidden_text: "your phone number"
           }
         ],
         key: {

--- a/app/components/contact_details_component.rb
+++ b/app/components/contact_details_component.rb
@@ -26,7 +26,7 @@ class ContactDetailsComponent < ViewComponent::Base
           {
             text: "Change",
             href: path_for(:telephone),
-            visually_hidden_text: "telephone"
+            visually_hidden_text: "phone number"
           }
         ],
         key: {

--- a/app/components/evidence_component.rb
+++ b/app/components/evidence_component.rb
@@ -19,7 +19,8 @@ class EvidenceComponent < ViewComponent::Base
             polymorphic_path(
               [:edit, referral.routing_scope, referral, :evidence_start],
               return_to: request.path
-            )
+            ),
+          visually_hidden_text: "if you have anything to upload"
         }
       ],
       key: {
@@ -42,7 +43,8 @@ class EvidenceComponent < ViewComponent::Base
             polymorphic_path(
               [:edit, referral.routing_scope, referral, :evidence_uploaded],
               return_to: request.path
-            )
+            ),
+          visually_hidden_text: "uploaded evidence"
         }
       ],
       key: {

--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -71,7 +71,7 @@ class PersonalDetailsComponent < ViewComponent::Base
                 ],
                 return_to: request.path
               ),
-            visually_hidden_text: "do they have QTS?"
+            visually_hidden_text: "if they have QTS?"
           }
         ],
         key: {

--- a/app/components/previous_misconduct_component.rb
+++ b/app/components/previous_misconduct_component.rb
@@ -18,7 +18,7 @@ class PreviousMisconductComponent < ViewComponent::Base
               :reported,
               { return_to: }
             ],
-            visually_hidden_text: "reported"
+            visually_hidden_text: "if there has been any previous misconduct"
           }
         ],
         key: {

--- a/app/components/public_allegation_component.rb
+++ b/app/components/public_allegation_component.rb
@@ -54,7 +54,7 @@ class PublicAllegationComponent < ViewComponent::Base
                 return_to: request.path
               ),
             visually_hidden_text:
-              "How do you want to give details about the allegation?"
+              "how you want to give details about the allegation?"
           }
         ],
         key: {
@@ -73,7 +73,7 @@ class PublicAllegationComponent < ViewComponent::Base
                 referral,
                 return_to: request.path
               ),
-            visually_hidden_text: "Description of the allegation"
+            visually_hidden_text: "description of the allegation"
           }
         ],
         key: {
@@ -93,7 +93,7 @@ class PublicAllegationComponent < ViewComponent::Base
                 return_to: request.path
               ),
             visually_hidden_text:
-              "Details about how this complaint has been considered"
+              "details about how this complaint has been considered"
           }
         ],
         key: {

--- a/app/components/their_role_component.rb
+++ b/app/components/their_role_component.rb
@@ -62,7 +62,7 @@ class TheirRoleComponent < ViewComponent::Base
           text: "Change",
           href: path_for(:duties),
           visually_hidden_text:
-            "how do you want to give details about their main duties"
+            "how you want to give details about their main duties"
         }
       ],
       key: {

--- a/spec/system/public_referrals/user_adds_their_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_their_details_spec.rb
@@ -146,7 +146,7 @@ RSpec.feature "Public Referral: About You", type: :system do
   end
 
   def when_i_click_on_change_name
-    click_on "Change name"
+    click_on "Change your name"
   end
 
   def when_i_click_on_your_details

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -209,6 +209,6 @@ RSpec.feature "Personal details", type: :system do
   end
 
   def when_i_click_change_qts
-    click_on "Change do they have QTS"
+    click_on "Change if they have QTS"
   end
 end

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -162,7 +162,7 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
   end
 
   def when_i_click_change_previous_misconduct_reported
-    click_on "Change reported"
+    click_on "Change if there has been any previous misconduct"
   end
 
   def when_i_click_on_previous_misconduct

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -159,7 +159,7 @@ RSpec.feature "Employer Referral: About You", type: :system do
   end
 
   def when_i_click_on_change_name
-    click_on "Change name"
+    click_on "Change your name"
   end
 
   def when_i_click_on_your_details


### PR DESCRIPTION
We want to ensure all 'Change' links have a `visually_hidden_text`
value.

There are also instances that need updating to read better.

### Link to Trello card

https://trello.com/c/zkogJ9PS/1137-change-links-have-visually-hidden-text

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
