### PR TITLE
1138 - Remove the autofocus on input fields

### DIFF
--- a/app/views/staff/confirmations/new.html.erb
+++ b/app/views/staff/confirmations/new.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), label: { text: "Email" } %>
+      <%= f.govuk_email_field :email, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), label: { text: "Email" } %>
       <%= f.govuk_submit "Resend confirmation instructions" %>
     <% end %>
 

--- a/app/views/staff/passwords/new.html.erb
+++ b/app/views/staff/passwords/new.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+      <%= f.govuk_email_field :email, autocomplete: "email", label: { text: "Email" } %>
       <%= f.govuk_submit "Send me reset password instructions" %>
     <% end %>
 

--- a/app/views/staff/sessions/new.html.erb
+++ b/app/views/staff/sessions/new.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+      <%= f.govuk_email_field :email, autocomplete: "email", label: { text: "Email" } %>
       <%= f.govuk_password_field :password, autocomplete: "current-password", label: { text: "Password" } %>
 
       <% if devise_mapping.rememberable? %>

--- a/app/views/staff/unlocks/new.html.erb
+++ b/app/views/staff/unlocks/new.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+      <%= f.govuk_email_field :email, autocomplete: "email", label: { text: "Email" } %>
       <%= f.govuk_submit "Resend unlock instructions" %>
     <% end %>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -8,7 +8,7 @@
     <%= form_for(resource, as: resource_name, url: user_session_path, method: :post) do |f| %>
       <p>Use your email address to return at any time.</p>
 
-      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: nil %>
+      <%= f.govuk_email_field :email, autocomplete: "email", label: nil %>
 
       <%= f.govuk_submit "Continue" %>
     <% end %>


### PR DESCRIPTION
### Context

Remove the autofocus on input fields.

### Changes proposed in this pull request

Remove the autofocus attribute on any input fields.

### Link to Trello card

https://trello.com/c/GZiD6xzh

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
