### PR TITLE
Make error messages for date validations more accessible

### DIFF
--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -61,8 +61,13 @@ class DateValidator < ActiveModel::EachValidator
       return false
     end
 
-    if year < 1000
+    if year.zero?
       record.errors.add(attribute, :missing_year)
+      return false
+    end
+
+    if year < 1000
+      record.errors.add(attribute, :incomplete_year)
       return false
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,9 +94,10 @@ en:
               inclusion: You must be 16 or over to use this service
               in_the_future: Their date of birth must be in the past
               invalid: Enter their date of birth in the correct format
-              missing_day: Enter a day for their date of birth, formatted as a number
-              missing_month: Enter a month for their date of birth, formatted as a number
-              missing_year: Enter a year with 4 digits
+              missing_day: Date of birth must include a day
+              missing_month: Date of birth must include a month
+              missing_year: Date of birth must include a year
+              incomplete_year: Year must include 4 numbers
             age_known:
               inclusion: Select yes if you know their date of birth
         "referrals/personal_details/name_form":
@@ -165,6 +166,7 @@ en:
               missing_day: Job start date must include a day
               missing_month: Job start date must include a month
               missing_year: Job start date must include a year
+              incomplete_year: Year must include 4 numbers
         "referrals/teacher_role/employment_status_form":
           attributes:
             employment_status:
@@ -233,6 +235,7 @@ en:
               missing_day: Job end date must include a day
               missing_month: Job end date must include a month
               missing_year: Job end date must include a year
+              incomplete_year: Year must include 4 numbers
         "referrals/teacher_role/reason_leaving_role_form":
           attributes:
             reason_leaving_role:


### PR DESCRIPTION
### Context

To improve the accessibility of the referral form error messages for the IAC audit

### Changes proposed in this pull request

* Changes to the locale.yml
* Tweak to the date validator
Before

After
<img width="660" alt="image" src="https://user-images.githubusercontent.com/29513/214817172-af726f5f-b21b-43ff-8da9-69d4e2dff189.png">
<img width="645" alt="image" src="https://user-images.githubusercontent.com/29513/214817247-9e99120b-ced6-41c7-94c2-6c274d87dd77.png">
<img width="652" alt="image" src="https://user-images.githubusercontent.com/29513/214817290-7126b84e-89a2-462c-a8bd-b4ff73cf1c7e.png">


### Guidance to review

Go through the referral form and interact with the date fields attempting to save them in an incomplete state

### Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/3ZLNfEl2/1126-update-error-messages-for-date-validations)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
