### PR TITLE
1139 - Validation errors order matches input field order on the forms

### DIFF
--- a/app/forms/organisation_address_form.rb
+++ b/app/forms/organisation_address_form.rb
@@ -4,10 +4,10 @@ class OrganisationAddressForm
   attr_accessor :referral
   attr_writer :street_1, :street_2, :city, :postcode
 
+  validates :street_1, presence: true
   validates :city, presence: true
   validates :postcode, presence: true
   validates :referral, presence: true
-  validates :street_1, presence: true
 
   def city
     @city ||= organisation&.city

--- a/spec/system/referrals/user_adds_organisation_details_spec.rb
+++ b/spec/system/referrals/user_adds_organisation_details_spec.rb
@@ -126,11 +126,18 @@ RSpec.feature "Employer Referral: Organisation", type: :system do
   end
 
   def then_i_see_the_missing_address_errors
-    expect(page).to have_content(
-      "Enter the first line of your organisation’s address"
-    )
-    expect(page).to have_content("Enter the town or city")
-    expect(page).to have_content("Enter the postcode")
+    expected_messages = [
+      "Enter the first line of your organisation’s address",
+      "Enter the town or city",
+      "Enter the postcode"
+    ]
+
+    page
+      .all(".govuk-error-summary ul li")
+      .collect(&:text)
+      .each_with_index do |error_message, position|
+        expect(error_message).to eq(expected_messages[position])
+      end
   end
 
   def then_i_see_the_missing_name_error


### PR DESCRIPTION
### Context

Some forms with multiple input fields display the wrong validation error message order.

### Changes proposed in this pull request

The forms that have been scanned for this problem are:

![Screenshot 2023-01-25 at 14 41 44](https://user-images.githubusercontent.com/1955084/214592871-72a3fce9-41e3-44ea-8423-f8e69e546809.png)

The form identified with the issue is the Organization Address form.

Both employer/public user journeys checked.

#### Before

![Screenshot 2023-01-25 at 13 59 06](https://user-images.githubusercontent.com/1955084/214592464-6a5e91bd-9de2-4593-9e30-9fa0180cbf6d.png)

#### After

![Screenshot 2023-01-25 at 13 59 22](https://user-images.githubusercontent.com/1955084/214592521-82b95534-7e67-413d-b4ea-65cc49a3fa10.png)

### Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/P74BbNi6)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
