### PR TITLE
Split referrer name field

### DIFF
--- a/app/components/about_you_component.rb
+++ b/app/components/about_you_component.rb
@@ -24,7 +24,7 @@ class AboutYouComponent < ViewComponent::Base
           text: "Your name"
         },
         value: {
-          text: referrer.name
+          text: "#{referrer.first_name} #{referrer.last_name}"
         }
       },
       {

--- a/app/controllers/referrals/referrer_name_controller.rb
+++ b/app/controllers/referrals/referrer_name_controller.rb
@@ -20,7 +20,10 @@ module Referrals
     private
 
     def name_params
-      params.require(:referrals_referrer_name_form).permit(:name)
+      params.require(:referrals_referrer_name_form).permit(
+        :first_name,
+        :last_name
+      )
     end
 
     def next_path

--- a/app/forms/referrals/referrer_name_form.rb
+++ b/app/forms/referrals/referrer_name_form.rb
@@ -3,19 +3,24 @@ module Referrals
     include ActiveModel::Model
 
     attr_accessor :referral
-    attr_writer :name
+    attr_writer :first_name, :last_name
 
-    validates :name, presence: true
+    validates :first_name, presence: true
+    validates :last_name, presence: true
     validates :referral, presence: true
 
-    def name
-      @name ||= referrer&.name
+    def first_name
+      @first_name ||= referrer&.first_name
+    end
+
+    def last_name
+      @last_name ||= referrer&.last_name
     end
 
     def save
       return false unless valid?
 
-      referrer.update(name:)
+      referrer.update(first_name:, last_name:)
     end
 
     private

--- a/app/models/referrer.rb
+++ b/app/models/referrer.rb
@@ -1,16 +1,12 @@
 class Referrer < ApplicationRecord
   belongs_to :referral
 
-  def first_name
-    name.split(" ").first
-  end
-
-  def last_name
-    name.split(" ")[1]
-  end
-
   def completed?
     completed_at.present?
+  end
+
+  def name
+    [first_name, last_name].join(" ")
   end
 
   def status

--- a/app/views/referrals/referrer_name/edit.html.erb
+++ b/app/views/referrals/referrer_name/edit.html.erb
@@ -7,7 +7,10 @@
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Your details</span>
-      <%= f.govuk_text_field :name, label: { size: 'l', text: "Your name" } %>
+      <h1 class="govuk-heading-l">Your name</h1>
+
+      <%= f.govuk_text_field :first_name, label: { size: 'm', text: "First name" }, hint: { text: "Or given name" } %>
+      <%= f.govuk_text_field :last_name, label: { size: 'm', text: "Last name" }, hint: { text: "Or family name" } %>
       <%= f.govuk_submit 'Save and continue' %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -253,8 +253,10 @@ en:
               invalid: Enter your phone number in the correct format
         "referrals/referrer_name_form":
           attributes:
-            name:
-              blank: Enter your name
+            first_name:
+              blank: Enter your first name
+            last_name:
+              blank: Enter your last name
         organisation_form:
           attributes:
             complete:

--- a/db/migrate/20230124125525_split_referrer_name.rb
+++ b/db/migrate/20230124125525_split_referrer_name.rb
@@ -1,0 +1,6 @@
+class SplitReferrerName < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :referrers, :name, :first_name
+    add_column :referrers, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_12_202954) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_24_125525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -153,12 +153,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_12_202954) do
 
   create_table "referrers", force: :cascade do |t|
     t.bigint "referral_id", null: false
-    t.string "name"
+    t.string "first_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "phone"
     t.string "job_title"
     t.datetime "completed_at", precision: nil
+    t.string "last_name"
     t.index ["referral_id"], name: "index_referrers_on_referral_id"
   end
 

--- a/spec/factories/referrers.rb
+++ b/spec/factories/referrers.rb
@@ -3,13 +3,15 @@ FactoryBot.define do
     referral { nil }
 
     trait :incomplete do
-      name { nil }
+      first_name { nil }
+      last_name { nil }
     end
 
     trait :complete do
       completed_at { Time.current }
       job_title { "Headteacher" }
-      name { "Jane Smith" }
+      first_name { "Jane" }
+      last_name { "Smith" }
       phone { "01234567890" }
     end
   end

--- a/spec/forms/referrals/referrer_name_form_spec.rb
+++ b/spec/forms/referrals/referrer_name_form_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Referrals::ReferrerNameForm, type: :model do
 
     let(:referral) { build(:referral) }
 
-    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
   end
 
   it { is_expected.to validate_presence_of(:referral) }
@@ -14,25 +15,28 @@ RSpec.describe Referrals::ReferrerNameForm, type: :model do
   describe "#save" do
     subject { form.save }
 
-    let(:form) { described_class.new(name:, referral:) }
+    let(:form) { described_class.new(first_name:, last_name:, referral:) }
 
     context "when the form is invalid" do
-      let(:name) { "" }
+      let(:first_name) { "" }
+      let(:last_name) { "" }
       let(:referral) { nil }
 
       it { is_expected.to be_falsey }
     end
 
     context "when the form is valid" do
-      let(:name) { "Test" }
+      let(:first_name) { "John" }
+      let(:last_name) { "Doe" }
       let(:referral) { build(:referral) }
 
       it { is_expected.to be_truthy }
     end
   end
 
-  describe "#name" do
-    subject { form.name }
+  describe "form attributes" do
+    let(:first_name) { form.first_name }
+    let(:last_name) { form.first_name }
 
     let(:form) { described_class.new(referral:) }
 
@@ -41,13 +45,25 @@ RSpec.describe Referrals::ReferrerNameForm, type: :model do
 
       before { build(:referrer, referral:) }
 
-      it { is_expected.to eq(referral.referrer.name) }
+      it "has the correct first_name value" do
+        expect(first_name).to eq(referral.referrer.first_name)
+      end
+
+      it "has the correct last_name value" do
+        expect(last_name).to eq(referral.referrer.last_name)
+      end
     end
 
     context "when the referrer is not present" do
       let(:referral) { build(:referral) }
 
-      it { is_expected.to be_nil }
+      it "has a nil first_name value" do
+        expect(first_name).to be_nil
+      end
+
+      it "has a nil last_name value" do
+        expect(last_name).to be_nil
+      end
     end
   end
 end

--- a/spec/system/public_referrals/user_adds_their_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_their_details_spec.rb
@@ -64,11 +64,12 @@ RSpec.feature "Public Referral: About You", type: :system do
   end
 
   def and_i_see_my_name_in_the_form_field
-    expect(page).to have_field("Your name", with: "Test Name")
+    expect(page).to have_field("First name", with: "John")
+    expect(page).to have_field("Last name", with: "Doe")
   end
 
   def and_i_see_my_answers_on_the_referrer_check_your_answers_page
-    expect(page).to have_content("Your name\tTest Name")
+    expect(page).to have_content("Your name\tJohn Doe")
     expect(page).to have_content("Your phone number\t01234567890")
   end
 
@@ -104,11 +105,13 @@ RSpec.feature "Public Referral: About You", type: :system do
   end
 
   def then_i_see_the_name_error_message
-    expect(page).to have_content("Enter your name")
+    expect(page).to have_content("Enter your first name")
+    expect(page).to have_content("Enter your last name")
   end
 
   def then_i_see_the_name_prefilled
-    expect(page).to have_field("Your name", with: "Test Name")
+    expect(page).to have_field("First name", with: "John")
+    expect(page).to have_field("Last name", with: "Doe")
   end
 
   def then_i_see_the_referrer_check_your_answers_page
@@ -152,7 +155,8 @@ RSpec.feature "Public Referral: About You", type: :system do
   alias_method :and_i_click_on_your_details, :when_i_click_on_your_details
 
   def when_i_enter_my_name
-    fill_in "Your name", with: "Test Name"
+    fill_in "First name", with: "John"
+    fill_in "Last name", with: "Doe"
   end
 
   def when_i_enter_my_phone_number

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -70,11 +70,12 @@ RSpec.feature "Employer Referral: About You", type: :system do
   end
 
   def and_i_see_my_name_in_the_form_field
-    expect(page).to have_field("Your name", with: "Test Name")
+    expect(page).to have_field("First name", with: "John")
+    expect(page).to have_field("Last name", with: "Doe")
   end
 
   def and_i_see_my_answers_on_the_referrer_check_your_answers_page
-    expect(page).to have_content("Your name\tTest Name")
+    expect(page).to have_content("Your name\tJohn Doe")
     expect(page).to have_content("Your phone number\t01234567890")
   end
 
@@ -119,11 +120,13 @@ RSpec.feature "Employer Referral: About You", type: :system do
   end
 
   def then_i_see_the_name_error_message
-    expect(page).to have_content("Enter your name")
+    expect(page).to have_content("Enter your first name")
+    expect(page).to have_content("Enter your last name")
   end
 
   def then_i_see_the_name_prefilled
-    expect(page).to have_field("Your name", with: "Test Name")
+    expect(page).to have_field("First name", with: "John")
+    expect(page).to have_field("Last name", with: "Doe")
   end
 
   def then_i_see_the_referrer_check_your_answers_page
@@ -168,7 +171,8 @@ RSpec.feature "Employer Referral: About You", type: :system do
   end
 
   def when_i_enter_my_name
-    fill_in "Your name", with: "Test Name"
+    fill_in "First name", with: "John"
+    fill_in "Last name", with: "Doe"
   end
 
   def when_i_enter_my_phone_number


### PR DESCRIPTION
### Context

Splits the `name` field into `first_name` and `last_name` for the employer and public form. The check answers pages remain identical as they display the name merged.

<img width="692" alt="Screenshot 2023-01-25 at 15 07 03" src="https://user-images.githubusercontent.com/1636476/214599306-dfb468c3-547d-47e8-90ca-394751095913.png">
<img width="725" alt="Screenshot 2023-01-25 at 15 07 12" src="https://user-images.githubusercontent.com/1636476/214599329-b420366d-19ed-40ac-ad45-62f42cf71084.png">
<img width="983" alt="Screenshot 2023-01-25 at 15 07 21" src="https://user-images.githubusercontent.com/1636476/214599345-2405ddc8-a339-4f2e-badc-901de2b84abe.png">


### Link to Trello card

https://trello.com/c/4G5vcyR6/1131-split-referrer-name-field-into-firstname-and-lastname

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
