### PR TITLE
Fix position and message of validation for previous allegation upload

### DIFF
--- a/app/views/referrals/previous_misconduct_detailed_account/edit.html.erb
+++ b/app/views/referrals/previous_misconduct_detailed_account/edit.html.erb
@@ -3,17 +3,17 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">Previous allegations</span>
-    <h1 class="govuk-heading-l">Detailed account of previous allegations</h1>
-    <p class="govuk-body">Provide details of:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>dates and locations</li>
-      <li>what happened</li>
-      <li>what action was taken</li>
-      <li>reference numbers from previous referrals</li>
-    </ul>
     <%= form_with model: @detailed_account_form, url: [current_referral.routing_scope, current_referral, :previous_misconduct, :detailed_account], method: :patch do |f| %>
       <%= f.govuk_error_summary %>
+      <span class="govuk-caption-l">Previous allegations</span>
+      <h1 class="govuk-heading-l">Detailed account of previous allegations</h1>
+      <p class="govuk-body">Provide details of:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>dates and locations</li>
+        <li>what happened</li>
+        <li>what action was taken</li>
+        <li>reference numbers from previous referrals</li>
+      </ul>
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset(:format, legend: { size: "m", text: "How do you want to give details about previous allegations?" }) do %>
           <%= f.govuk_radio_button :format, "upload", label: { text: "Upload file" }, link_errors: true do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,6 +284,11 @@ en:
               blank: Enter a description of previous allegations
             format:
               inclusion: Select how you want to give details about previous allegations
+            upload:
+              blank: Select a file containing details of previous allegations
+              invalid_content_type: The selected file must be of type (%{valid_types})
+              mismatch_content_type: The selected file does not match its contents
+              file_size_too_big: The selected file must be smaller than %{max_file_size}
         previous_misconduct_reported_form:
           attributes:
             previous_misconduct_reported:


### PR DESCRIPTION
### Context

Upload validation field file validation messages wasnt complete and was in the wrong place

### Changes proposed in this pull request
Before:
<img width="755" alt="image" src="https://user-images.githubusercontent.com/29513/214612609-be4c40aa-cc92-4b31-b054-cd5c5263cf17.png">

After:
<img width="752" alt="image" src="https://user-images.githubusercontent.com/29513/214611971-9a57b970-bf72-48a1-81c6-78751b8f2824.png">

### Guidance to review

### Link to Trello card

None yet

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
