### PR TITLE
1157 - Add postcode format validation for organisation address form

### DIFF
--- a/app/forms/organisation_address_form.rb
+++ b/app/forms/organisation_address_form.rb
@@ -9,6 +9,8 @@ class OrganisationAddressForm
   validates :postcode, presence: true
   validates :referral, presence: true
 
+  validate :postcode_is_valid, if: -> { postcode.present? }
+
   def city
     @city ||= organisation&.city
   end
@@ -31,5 +33,13 @@ class OrganisationAddressForm
     return false unless valid?
 
     organisation.update(city:, postcode:, street_1:, street_2:)
+  end
+
+  private
+
+  def postcode_is_valid
+    unless UKPostcode.parse(postcode).full_valid?
+      errors.add(:postcode, :invalid)
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,6 +272,7 @@ en:
               blank: Enter the town or city
             postcode:
               blank: Enter the postcode
+              invalid: Enter a real postcode
 
         organisation_name_form:
           attributes:

--- a/spec/forms/organisation_address_form_spec.rb
+++ b/spec/forms/organisation_address_form_spec.rb
@@ -2,24 +2,41 @@ require "rails_helper"
 
 RSpec.describe OrganisationAddressForm, type: :model do
   describe "validations" do
-    subject { described_class.new(referral:) }
+    subject(:form) { described_class.new(referral:) }
 
     let(:referral) { build(:referral) }
 
     it { is_expected.to validate_presence_of(:referral) }
-    it { is_expected.to validate_presence_of(:city) }
-    it { is_expected.to validate_presence_of(:postcode) }
-    it { is_expected.to validate_presence_of(:street_1) }
+
+    it do
+      expect(form).to validate_presence_of(:city).with_message(
+        "Enter the town or city"
+      )
+    end
+
+    it do
+      expect(form).to validate_presence_of(:postcode).with_message(
+        "Enter the postcode"
+      )
+    end
+
+    it do
+      expect(form).to validate_presence_of(:street_1).with_message(
+        "Enter the first line of your organisation’s address"
+      )
+    end
   end
 
   describe "#valid?" do
     subject(:valid) { form.valid? }
 
+    before { valid }
+
     let(:form) { described_class.new(params) }
     let(:params) do
       {
         city: "London",
-        postcode: "W1 1CW",
+        postcode: "NW1 4NP",
         referral:,
         street_1: "1 Street",
         street_2: ""
@@ -30,10 +47,12 @@ RSpec.describe OrganisationAddressForm, type: :model do
 
     it { is_expected.to be_truthy }
 
-    context "when one of the validations is failing" do
-      let(:params) { super().merge(street_1: "") }
+    context "when postcode is invalid" do
+      let(:params) { super().merge(postcode: "Invalid") }
 
       it { is_expected.to be_falsy }
+
+      it { expect(form.errors[:postcode]).to eq(["Enter a real postcode"]) }
     end
   end
 
@@ -44,7 +63,7 @@ RSpec.describe OrganisationAddressForm, type: :model do
     let(:params) do
       {
         city: "London",
-        postcode: "W1 1CW",
+        postcode: "NW1 4NP",
         referral:,
         street_1: "1 Street",
         street_2: "Extra"
@@ -56,7 +75,7 @@ RSpec.describe OrganisationAddressForm, type: :model do
     before { save }
 
     it { expect(organisation.city).to eq("London") }
-    it { expect(organisation.postcode).to eq("W1 1CW") }
+    it { expect(organisation.postcode).to eq("NW1 4NP") }
     it { expect(organisation.street_1).to eq("1 Street") }
     it { expect(organisation.street_2).to eq("Extra") }
   end


### PR DESCRIPTION
### Context

Add postcode format validation for organisation address form.

### Changes proposed in this pull request

The change is done to ensure form validation consistency across the service.

<img width="658" alt="Screenshot 2023-01-26 at 12 19 10" src="https://user-images.githubusercontent.com/1955084/214838971-e49782ea-5969-462b-ae20-bd0da85e9c43.png">

### Link to Trello card

https://trello.com/c/sj7ZihnG

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
