### PR TITLE
Remove TRA references

### DIFF
--- a/app/views/pages/no_complaint.html.erb
+++ b/app/views/pages/no_complaint.html.erb
@@ -1,19 +1,18 @@
-<% content_for :page_title, 'You should complain to the school, school governors or your local council first' %>
+<% content_for :page_title, 'Make a complaint to the school, school governors or your local council first' %>
 <% content_for :back_link_url, have_you_complained_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You should complain to the school, school governors or your local council first</h1>
+    <h1 class="govuk-heading-xl">Make a complaint to the school, school governors or your local council first</h1>
     <p class="govuk-body">
-      Visit GOV.UK for <%= link_to "guidance on how to make an informal complaint", "https://www.gov.uk/report-teacher-misconduct" %></a>.
+      View guidance about <%= link_to "how to make an informal complaint", "https://www.gov.uk/report-teacher-misconduct" %></a>.
     </p>
 
     <p class="govuk-body">You’ll need to provide proof to support your complaint.</p>
 
-    <h2 class="govuk-heading-m">Making a referral without an informal complaint</h2>
     <p class="govuk-body">
-      You can still refer serious misconduct without making an informal complaint. Depending on the case, TRA might not investigate unless you have tried to deal with the matter informally.
+      You can still refer serious misconduct without making an informal complaint. Depending on the allegation, it may not be investigated unless you have tried to deal with the matter informally.
     </p>
-    <%= govuk_button_link_to "Continue without an informal complaint", is_a_teacher_path, secondary: true %>
+    <%= govuk_button_link_to "Continue without an informal complaint", is_a_teacher_path %>
   </div>
 </div>

--- a/app/views/pages/no_jurisdiction_unsupervised.html.erb
+++ b/app/views/pages/no_jurisdiction_unsupervised.html.erb
@@ -6,7 +6,7 @@
     <h1 class="govuk-heading-xl">You need to report this misconduct somewhere else</h1>
     <h2 class="govuk-heading-m">Why you can’t refer them using this service</h2>
     <p class="govuk_body">
-      The Teaching Regulation Agency (TRA) will only consider cases of serious misconduct by teachers who are, or have been, employed or engaged at:
+      Cases of serious misconduct must be related to teachers who are (or have been) employed or engaged at:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
@@ -18,7 +18,7 @@
     </ul>
 
     <p class="govuk_body">
-      TRA will not usually consider cases relating to teaching assistants, higher level teaching assistants or other support staff.
+      This does not include cases relating to teaching assistants, higher level teaching assistants or other support staff.
     </p>
     <h2 class="govuk-heading-m">Reporting someone who is not a teacher</h2>
     <p class="govuk_body">

--- a/app/views/pages/not_serious_misconduct.html.erb
+++ b/app/views/pages/not_serious_misconduct.html.erb
@@ -6,9 +6,9 @@
     <h1 class="govuk-heading-xl">You need to report this misconduct somewhere else</h1>
 
     <p class="govuk_body">
-      The Teaching Regulation Agency (TRA) will not deal with cases relating to minor misconduct, or a teacher’s performance or competence.
+      Cases relating to minor misconduct or a teacher’s performance or competence will not be investigated.
     </p>
-    <p class="govuk_body">You should:</p>
+    <p class="govuk_body">You need to:</p>
     <ol class="govuk-list govuk-list--number">
       <li>talk to the school or sixth-form college first to try to solve the problem.</li>
       <li>contact the school’s board of governors or contact the council if you’re not happy with the response.</li>

--- a/app/views/pages/you_should_know.html.erb
+++ b/app/views/pages/you_should_know.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-xl">What completing this referral means for you</h1>
     <p class="govuk_body">
-      If TRA decide to investigate this allegation, it could result in the person you’re referring being banned from teaching.
+      If your allegation of serious misconduct is investigated, it could result in the person you’re referring being banned from teaching.
     </p>
 
     <p class="govuk_body">

--- a/app/views/public_referrals/referrers/personal_details.html.erb
+++ b/app/views/public_referrals/referrers/personal_details.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <span class="govuk-caption-l">Your details</span>
     <h1 class="govuk-heading-l">How your personal details will be&nbsp;used</h1>
-    <p>If the TRA decides to investigate this case, your name will be shared with the teacher you’re referring and their employer. The teacher has a right to know who referred them.</p>
-    <p>Your contact details will not be shared. The TRA will only use these to contact you about this case.</p>
+    <p>If your case is investigated, your name will be shared with the teacher you’re referring and their employer. The teacher has a right to know who referred them.</p>
+    <p>Your contact details will not be shared. These will only be used to contact you about this case.</p>
     <%= govuk_button_link_to "Continue", polymorphic_path([:edit, current_referral.routing_scope, current_referral, :referrer_name]) %>
 </div>

--- a/app/views/referrals/confirmation/show.html.erb
+++ b/app/views/referrals/confirmation/show.html.erb
@@ -1,44 +1,31 @@
-<% content_for :page_title, 'We have received your referral' %>
+<% content_for :page_title, 'Referral sent' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= govuk_panel(
-      title_text: 'We have received your referral',
+      title_text: 'Referral sent',
       classes: %w[govuk-!-margin-bottom-6]
     ) %>
     <p class="govuk_body">
-      We’ve sent you a confirmation by email. Your confirmation includes a link to view your referral.
+      You’ll be sent a confirmation email. This email will include a link to <%= link_to "view your referral", [current_referral.routing_scope, current_referral, :review] %></a>.
     </p>
 
     <h2 class="govuk-heading-m">What happens next</h2>
     <p class="govuk_body">
-      We’ll review your referral within 3 working days.
+      Your referral will be reviewed within 3 working days.
     </p>
     <p class="govuk_body">
-      It can take up to 20 weeks from the date of your referral for us to investigate and make a decision whether there is a case to answer.
+      If a decision is not made about your case within 14 days, you’ll be sent an email letting you know.
     </p>
 
     <p class="govuk_body">
-      If we’ve not made a decision whether to investigate your referral within 14 days of receiving it, we’ll send you an email to let you know.
+      It could be decided that:
     </p>
-    <p class="govuk_body">We could tell you that we:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>need more information to decide whether to investigate the case</li>
-      <li>will not investigate the case because it’s outside their remit</li>
-      <li>will not investigate the case because it does not have the potential to result in a prohibition order</li>
-      <li>will launch a formal investigation</li>
+      <li>more information is needed</li>
+      <li>the case will not be investigated, for example because it’s unlikely the teacher will be stopped from teaching</li>
+      <li>a formal investigation will be launched</li>
     </ul>
-
-    <h2 class="govuk-heading-m">Contacting TRA about this referral</h2>
-    <p class="govuk_body">If you need more information about making a referral, you can contact TRA.</p>
-    <p class="govuk_body">
-      Email: <%= mail_to t('service.email') %><br />
-      We aim to respond within 3 working days.
-    </p>
-    <p class="govuk_body">
-      Phone: <%= t('service.phone') %><br />
-      Monday to Friday, 9am to 5pm (except Mondays and Fridays)
-    </p>
-    <p class="govuk_body"><a href="https://www.gov.uk/call-charges">Find out about call charges.</a></p>
+    <p class="govuk_body">You’ll be sent an email with the decision within 20 weeks.</p>
   </div>
 </div>

--- a/app/views/referrals/declaration/show.html.erb
+++ b/app/views/referrals/declaration/show.html.erb
@@ -6,15 +6,15 @@
     <%= form_with model: @declaration_form, url: [current_referral.routing_scope, current_referral, :declaration], method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">Before you send your referral</h1>
-      <p>You must confirm that:</p>
+      <p>By sending this referral, you agree that:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>you want TRA to investigate this allegation, which could result in the person you’re referring being stopped from teaching</li>
-        <li>all your answers are true to the best of your knowledge and belief</li>
-        <li>you give consent for this referral and any supporting documents to be shared with the person you’re referring and any employer (only your name will be shared with them)</li>
-        <li>you have permission from the relevant third parties for any supporting documents to be shared, for example the police or DBS</li>
-        <li>you understand that you might need to attend a hearing of a professional conduct panel to give evidence should this allegation reach that stage</li>
+        <li>your allegation will be investigated, which could result in the person you’re referring being stopped from teaching</li>
+        <li>your answers are true to the best of your knowledge and belief</li>
+        <li>your referral, any evidence and supporting information will be shared with the person you’re referring and any employer</li>
+        <li>you have permission from the relevant third parties for any evidence and supporting information to be shared, for example the police or DBS</li>
+        <li>you may need to attend a hearing and give evidence if your allegation reaches that stage</li>
+        <li>your referral will be kept on file for 50 years</li>
       </ul>
-      <p>This declaration is required by law and won’t affect any existing GDPR or other workplace regulations.</p>
       <%= f.govuk_check_boxes_fieldset :declaration_agreed, multiple: false, legend: { text: 'Do you agree to this declaration?', size: 'm' } do %>
         <%= f.govuk_check_box :declaration_agreed, 1, 0, multiple: false, link_errors: true, label: { text: "Yes, I agree" } %>
       <% end %>

--- a/app/views/referrals/referrer_phone/edit.html.erb
+++ b/app/views/referrals/referrer_phone/edit.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Your details</span>
-      <%= f.govuk_text_field :phone, label: { size: 'l', text: "Your phone number" }, hint: { text: 'The TRA will only use this number to contact you about your referral' }, class: 'govuk-input--width-20' %>
+      <%= f.govuk_text_field :phone, label: { size: 'l', text: "Your phone number" }, hint: { text: 'It’ll only be used to contact you about your referral' }, class: 'govuk-input--width-20' %>
       <%= f.govuk_submit 'Save and continue' %>
     <% end %>
   </div>

--- a/spec/system/public_referrals/user_submits_referral_spec.rb
+++ b/spec/system/public_referrals/user_submits_referral_spec.rb
@@ -45,8 +45,8 @@ RSpec.feature "A member of the public submits a referral", type: :system do
     expect(page).to have_current_path(
       "/public-referrals/#{@referral.id}/confirmation"
     )
-    expect(page).to have_title("We have received your referral")
-    expect(page).to have_content("We have received your referral")
+    expect(page).to have_title("Referral sent")
+    expect(page).to have_content("Referral sent")
   end
 
   def then_i_see_the_declaration_page

--- a/spec/system/referrals/user_submits_referral_spec.rb
+++ b/spec/system/referrals/user_submits_referral_spec.rb
@@ -45,8 +45,8 @@ RSpec.feature "User submits a referral", type: :system do
 
   def then_i_see_the_confirmation_page
     expect(page).to have_current_path("/referrals/#{@referral.id}/confirmation")
-    expect(page).to have_title("We have received your referral")
-    expect(page).to have_content("We have received your referral")
+    expect(page).to have_title("Referral sent")
+    expect(page).to have_content("Referral sent")
   end
 
   def then_i_see_the_declaration_page

--- a/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
@@ -182,12 +182,12 @@ RSpec.feature "Eligibility screener", type: :system do
     expect(page).to have_current_path("/no-complaint")
     expect(page).to have_title(
       [
-        "You should complain to the school, school governors or your local council first",
+        "Make a complaint to the school, school governors or your local council first",
         "Refer serious misconduct by a teacher in England"
       ].join(" - ")
     )
     expect(page).to have_content(
-      "You should complain to the school, school governors or your local council first"
+      "Make a complaint to the school, school governors or your local council first"
     )
   end
 


### PR DESCRIPTION
### Context

We’re removing all references to ‘the Teacher Regulation Agency’ / ‘the tra’ / ‘we’ for accessibility reasons

### Changes proposed in this pull request

A number of changes across the forms

### Guidance to review

### Link to Trello card

https://trello.com/c/a37zsLNY/1156-remove-references-to-the-tra

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
