### PR TITLE
Add allegation format to the employer referral

### DIFF
--- a/app/components/what_happened_component.rb
+++ b/app/components/what_happened_component.rb
@@ -15,6 +15,28 @@ class WhatHappenedComponent < ViewComponent::Base
               referral.routing_scope,
               referral,
               :allegation,
+              :details
+            ],
+            visually_hidden_text:
+              "how you want to give details about the allegation"
+          }
+        ],
+        key: {
+          text: "How do you want to give details about the allegation?"
+        },
+        value: {
+          text: allegation_details_type
+        }
+      },
+      {
+        actions: [
+          {
+            text: "Change",
+            href: [
+              :edit,
+              referral.routing_scope,
+              referral,
+              :allegation,
               :details,
               { return_to: }
             ],
@@ -57,5 +79,14 @@ class WhatHappenedComponent < ViewComponent::Base
     polymorphic_path(
       [:edit, referral.routing_scope, referral, :allegation, :check_answers]
     )
+  end
+
+  private
+
+  def allegation_details_type
+    return "Upload file" if referral.allegation_upload.attached?
+    return "Describe the allegation" if referral.allegation_details.present?
+
+    "Incomplete"
   end
 end

--- a/spec/system/referrals/user_adds_an_allegation_spec.rb
+++ b/spec/system/referrals/user_adds_an_allegation_spec.rb
@@ -92,6 +92,11 @@ RSpec.feature "Allegation", type: :system do
     expect(page).to have_content("Check and confirm your answers")
 
     expect_summary_row(
+      key: "How do you want to give details about the allegation?",
+      value: "Describe the allegation"
+    )
+
+    expect_summary_row(
       key: "Summary",
       value: "Something something something",
       change_link:


### PR DESCRIPTION
The employer referral flow is missing the allegation format on the check
answers page.

Although the view component is similar to the public one, there is a
question that is different. For this reason, I didn't attempt to
refactor them both to have a single view component.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1029" alt="Screenshot 2023-01-26 at 1 36 25 pm" src="https://user-images.githubusercontent.com/3126/214849107-5c932878-fb13-46f3-9f69-7d446f56e2ec.png">

