### PR TITLE
Update the check answers style

### DIFF
--- a/app/assets/stylesheets/_app-govuk-summary-card.scss
+++ b/app/assets/stylesheets/_app-govuk-summary-card.scss
@@ -1,19 +1,4 @@
 .app-govuk-summary-card {
-  border: 1px solid $govuk-border-colour;
-
-  // Card header
-  &__header {
-    align-items: center;
-    background-color: govuk-colour("light-grey");
-    padding: govuk-spacing(3);
-
-    @include govuk-media-query($from: desktop) {
-      display: flex;
-      justify-content: space-between;
-      align-items: start;
-    }
-  }
-
   &__title {
     @include govuk-font($size: 19);
     margin: 0;
@@ -53,16 +38,10 @@
   // Card body
   &__body {
     @include govuk-font($size: 19);
-    padding: govuk-spacing(3);
   }
 
   .govuk-summary-list {
     margin-bottom: 0;
-  }
-
-  .govuk-summary-list__row:last-child,
-  .govuk-summary-list__row:last-child > * {
-    border-bottom: 0;
   }
 }
 

--- a/app/components/about_you_component.html.erb
+++ b/app/components/about_you_component.html.erb
@@ -1,3 +1,1 @@
-<%= render(SummaryCardComponent.new(rows:)) do %>
-  <%= render SummaryCardHeaderComponent.new(title: 'Your details') %>
-<% end %>
+<%= render(SummaryCardComponent.new(rows:)) %>

--- a/app/components/contact_details_component.html.erb
+++ b/app/components/contact_details_component.html.erb
@@ -1,3 +1,1 @@
-<%= render(SummaryCardComponent.new(rows:)) do %>
-  <%= render SummaryCardHeaderComponent.new(title: 'Contact details') %>
-<% end %>
+<%= render(SummaryCardComponent.new(rows:)) %>

--- a/app/components/evidence_component.html.erb
+++ b/app/components/evidence_component.html.erb
@@ -1,3 +1,1 @@
-<%= render(SummaryCardComponent.new(rows:)) do %>
-  <%= render SummaryCardHeaderComponent.new(title: "Evidence") %>
-<% end %>
+<%= render(SummaryCardComponent.new(rows:)) %>

--- a/app/components/organisation_component.html.erb
+++ b/app/components/organisation_component.html.erb
@@ -1,3 +1,1 @@
-<%= render(SummaryCardComponent.new(rows:)) do %>
-  <%= render SummaryCardHeaderComponent.new(title: 'Your organisation') %>
-<% end %>
+<%= render(SummaryCardComponent.new(rows:)) %>

--- a/app/components/personal_details_component.html.erb
+++ b/app/components/personal_details_component.html.erb
@@ -1,3 +1,1 @@
-<%= render(SummaryCardComponent.new(rows:)) do %>
-  <%= render SummaryCardHeaderComponent.new(title: "Personal details") %>
-<% end %>
+<%= render(SummaryCardComponent.new(rows:)) %>

--- a/app/components/previous_misconduct_component.html.erb
+++ b/app/components/previous_misconduct_component.html.erb
@@ -1,3 +1,1 @@
-<%= render(SummaryCardComponent.new(rows:)) do %>
-  <%= render SummaryCardHeaderComponent.new(title: 'Previous allegations') %>
-<% end %>
+<%= render(SummaryCardComponent.new(rows:)) %>

--- a/app/components/public_allegation_component.html.erb
+++ b/app/components/public_allegation_component.html.erb
@@ -1,3 +1,1 @@
-<%= render(SummaryCardComponent.new(rows:)) do %>
-  <%= render SummaryCardHeaderComponent.new(title: "What happened") %>
-<% end %>
+<%= render(SummaryCardComponent.new(rows:)) %>

--- a/app/components/summary_card_component.html.erb
+++ b/app/components/summary_card_component.html.erb
@@ -1,4 +1,4 @@
-<section class="app-govuk-summary-card govuk-!-margin-bottom-9 <%= border_css_class %>">
+<section class="app-govuk-summary-card govuk-!-margin-bottom-9">
   <%= content %>
   <div class="app-govuk-summary-card__body">
     <%= govuk_summary_list(rows:) %>

--- a/app/components/summary_card_component.rb
+++ b/app/components/summary_card_component.rb
@@ -1,13 +1,8 @@
 class SummaryCardComponent < ViewComponent::Base
-  def initialize(rows:, border: true, editable: true, ignore_editable: [])
+  def initialize(rows:, editable: true, ignore_editable: [])
     super
     rows = transform_hash(rows) if rows.is_a?(Hash)
     @rows = rows_including_actions_if_editable(rows, editable, ignore_editable)
-    @border = border
-  end
-
-  def border_css_class
-    @border ? "" : "no-border"
   end
 
   private

--- a/app/components/summary_card_header_component.html.erb
+++ b/app/components/summary_card_header_component.html.erb
@@ -1,6 +1,0 @@
-<header class="app-govuk-summary-card__header" <%= @anchor ? "id=#{@anchor}" : nil %>>
-  <h<%= @heading_level %> class="app-govuk-summary-card__title">
-    <%= @title %>
-  </h<%= @heading_level %>>
-  <%= content %>
-</header>

--- a/app/components/summary_card_header_component.rb
+++ b/app/components/summary_card_header_component.rb
@@ -1,8 +1,0 @@
-class SummaryCardHeaderComponent < ViewComponent::Base
-  def initialize(title:, heading_level: 2, anchor: nil)
-    super
-    @title = title
-    @heading_level = heading_level
-    @anchor = anchor
-  end
-end

--- a/app/components/their_role_component.html.erb
+++ b/app/components/their_role_component.html.erb
@@ -1,3 +1,1 @@
-<%= render(SummaryCardComponent.new(rows:)) do %>
-  <%= render SummaryCardHeaderComponent.new(title: 'About their role') %>
-<% end %>
+<%= render(SummaryCardComponent.new(rows:)) %>

--- a/app/components/what_happened_component.html.erb
+++ b/app/components/what_happened_component.html.erb
@@ -1,3 +1,1 @@
-<%= render(SummaryCardComponent.new(rows:)) do %>
-  <%= render SummaryCardHeaderComponent.new(title: "What happened") %>
-<% end %>
+<%= render(SummaryCardComponent.new(rows:)) %>

--- a/app/views/public_referrals/allegation/check_answers/edit.html.erb
+++ b/app/views/public_referrals/allegation/check_answers/edit.html.erb
@@ -2,15 +2,13 @@
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l">The allegation</span>
-      Check and confirm your answers
-    </h1>
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">The allegation</span>
+    <h1 class="govuk-heading-l">Check and confirm your answers</h1>
+    <%= render PublicAllegationComponent.new(referral: current_referral) %>
+
     <%= form_with model: @allegation_check_answers_form, url: public_referral_allegation_check_answers_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
-
-      <%= render PublicAllegationComponent.new(referral: current_referral) %>
 
       <%= f.govuk_radio_buttons_fieldset(
         :allegation_details_complete,

--- a/app/views/referrals/allegation/check_answers/edit.html.erb
+++ b/app/views/referrals/allegation/check_answers/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l">The allegation</span>
       Check and confirm your answers

--- a/app/views/referrals/contact_details/check_answers/edit.html.erb
+++ b/app/views/referrals/contact_details/check_answers/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l">Contact details</span>
       Check and confirm your answers

--- a/app/views/referrals/organisation/show.html.erb
+++ b/app/views/referrals/organisation/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "Your organisation" %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l">Your organisation</span>
       Check and confirm your answers

--- a/app/views/referrals/personal_details/check_answers/edit.html.erb
+++ b/app/views/referrals/personal_details/check_answers/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l">Personal details</span>
       Check and confirm your answers

--- a/app/views/referrals/referrers/show.html.erb
+++ b/app/views/referrals/referrers/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l">Your details</span>
       Check and confirm your answers

--- a/app/views/referrals/teacher_role/check_answers/edit.html.erb
+++ b/app/views/referrals/teacher_role/check_answers/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l">About their role</span>
       Check and confirm your answers


### PR DESCRIPTION
The style of the summary list for all the check answers has changed in
the latest designs.

This change updates all the relevant pages.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally

<img width="1015" alt="Screenshot 2023-01-27 at 10 15 13 am" src="https://user-images.githubusercontent.com/3126/215063161-e6113830-2fe8-4a38-b804-4737d97c44e0.png">
