### PR TITLE
1083 - Filling in the allegation details can no longer be skipped

### DIFF
--- a/app/forms/referrals/allegation/details_form.rb
+++ b/app/forms/referrals/allegation/details_form.rb
@@ -4,10 +4,7 @@ module Referrals
     class DetailsForm
       include ActiveModel::Model
 
-      validates :allegation_format,
-                inclusion: {
-                  in: %w[details incomplete upload]
-                }
+      validates :allegation_format, inclusion: { in: %w[details upload] }
       validates :allegation_details,
                 presence: true,
                 if: -> { allegation_format == "details" }
@@ -25,6 +22,7 @@ module Referrals
         return false if invalid?
 
         attrs = { allegation_format: }
+
         case allegation_format
         when "details"
           referral.allegation_upload.purge

--- a/app/views/referrals/allegation/details/edit.html.erb
+++ b/app/views/referrals/allegation/details/edit.html.erb
@@ -18,7 +18,6 @@
                                   hint: { text: "Include dates and locations" },
                                   rows: 20 %>
           <% end %>
-          <%= f.govuk_radio_button :allegation_format, "incomplete", label: { text: "I’ll do this later" } %>
         <% end %>
       </div>
       <%= f.govuk_submit "Save and continue" %>

--- a/spec/forms/referrals/allegation/details_form_spec.rb
+++ b/spec/forms/referrals/allegation/details_form_spec.rb
@@ -117,11 +117,5 @@ RSpec.describe Referrals::Allegation::DetailsForm, type: :model do
         expect(referral.allegation_upload).not_to be_attached
       end
     end
-
-    context "when format is incomplete" do
-      let(:allegation_format) { "incomplete" }
-
-      it { is_expected.to be_truthy }
-    end
   end
 end


### PR DESCRIPTION
### Context

Filling in the allegation details can no longer be skipped

### Changes proposed in this pull request

- Remove the `I'll do this later` option when filling the allegation details page
- Skipping this page is no longer possible

Before

![Screenshot 2023-01-27 at 14 13 14](https://user-images.githubusercontent.com/1955084/215109178-b64ee83b-6b1d-4f49-888c-02cf7e26e755.png)

After

![Screenshot 2023-01-27 at 14 13 37](https://user-images.githubusercontent.com/1955084/215109223-e460701b-603d-4752-b8da-dd29c1d92209.png)
![Screenshot 2023-01-27 at 14 13 44](https://user-images.githubusercontent.com/1955084/215109226-d9c2b9a0-7477-41b3-b3f3-e55674978bc4.png)

Both employer/public referral routes have been tested. 


### Link to Trello card

https://trello.com/c/quaVqrWj

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
