### PR TITLE
Add an extra item to check answers

### DIFF
--- a/app/components/previous_misconduct_component.rb
+++ b/app/components/previous_misconduct_component.rb
@@ -42,6 +42,29 @@ class PreviousMisconductComponent < ViewComponent::Base
               :detailed_account,
               { return_to: }
             ],
+            visually_hidden_text:
+              "how you want to give details about previous allegations"
+          }
+        ],
+        key: {
+          text: "How do you want to give details about previous allegations?"
+        },
+        value: {
+          text: detail_type
+        }
+      }
+      @rows << {
+        actions: [
+          {
+            text: "Change",
+            href: [
+              :edit,
+              referral.routing_scope,
+              referral,
+              :previous_misconduct,
+              :detailed_account,
+              { return_to: }
+            ],
             visually_hidden_text: "details"
           }
         ],
@@ -59,7 +82,15 @@ class PreviousMisconductComponent < ViewComponent::Base
 
   def report
     if referral.previous_misconduct_upload.attached?
-      return referral.previous_misconduct_upload.filename
+      return(
+        govuk_link_to(
+          referral.previous_misconduct_upload.filename,
+          rails_blob_path(
+            referral.previous_misconduct_upload,
+            disposition: "attachment"
+          )
+        )
+      )
     end
 
     if referral.previous_misconduct_details.present?
@@ -71,5 +102,11 @@ class PreviousMisconductComponent < ViewComponent::Base
 
   def return_to
     polymorphic_path([referral.routing_scope, referral, :previous_misconduct])
+  end
+
+  def detail_type
+    return "Upload file" if referral.previous_misconduct_upload.attached?
+
+    "Describe the allegation"
   end
 end

--- a/app/views/referrals/previous_misconduct/show.html.erb
+++ b/app/views/referrals/previous_misconduct/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "Check and confirm your answers" %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l">Previous allegations</span>
       Check and confirm your answers


### PR DESCRIPTION
The previous misconduct check answers screen is missing a summary item
referencing the way it is being reported.

This change ensures that this 'type' value is present and provides a way
to edit it.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1010" alt="Screenshot 2023-01-30 at 9 27 50 am" src="https://user-images.githubusercontent.com/3126/215438577-b403e222-3d66-491b-a844-1e6f024df6f3.png">

