### PR TITLE
Redirect to referral from start if it exists

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,14 @@ class ApplicationController < ActionController::Base
     password: ENV.fetch("SUPPORT_PASSWORD", nil),
     unless: -> { FeatureFlags::FeatureFlag.active?("service_open") }
   )
+
+  private
+
+  def redirect_to_referral_if_exists
+    latest_referral = current_user&.latest_referral
+
+    if latest_referral
+      redirect_to [:edit, latest_referral.routing_scope, latest_referral]
+    end
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,7 @@
 class PagesController < ApplicationController
   def start
+    redirect_to_referral_if_exists
+
     @start_now_path =
       if FeatureFlags::FeatureFlag.active?(:referral_form)
         current_user ? referral_type_path : new_user_session_path

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -31,14 +31,6 @@ class ReferralsController < Referrals::BaseController
 
   private
 
-  def redirect_to_referral_if_exists
-    latest_referral = current_user.latest_referral
-
-    if latest_referral
-      redirect_to [:edit, latest_referral.routing_scope, latest_referral]
-    end
-  end
-
   def referral
     @referral ||= current_user.referrals.employer.find(params[:id])
   end

--- a/spec/system/referrals/user_revisits_spec.rb
+++ b/spec/system/referrals/user_revisits_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.feature "User revisits", type: :system do
+  include CommonSteps
+
+  scenario "New user visits" do
+    given_the_service_is_open
+    and_the_referral_form_feature_is_active
+    and_the_eligibility_screener_feature_is_active
+    when_i_visit_the_service
+    then_i_see_the_start_page
+  end
+
+  scenario "User with existing referral visits" do
+    given_the_service_is_open
+    and_the_referral_form_feature_is_active
+    and_the_eligibility_screener_feature_is_active
+    and_i_am_signed_in
+    and_i_am_a_member_of_the_public_with_an_existing_referral
+    when_i_visit_the_service
+    then_i_see_the_public_referral_summary
+  end
+
+  private
+
+  def then_i_see_the_start_page
+    expect(page).to have_link("Start now")
+  end
+end


### PR DESCRIPTION
### Context

Improve UX for users who partially complete the form then revisit the site.

### Changes proposed in this pull request

If the current user is logged in and has a referral in progress they are redirected from the start page. Otherwise the site behaves as normal

### Guidance to review

### Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/r2EX5IGG/1080-rootpath-should-redirect-to-task-list-for-logged-in-users)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
