### PR TITLE
Change feature flag gem to use tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 gem "govuk_feature_flags",
     git: "https://github.com/DFE-Digital/govuk_feature_flags.git",
-    branch: "main"
+    tag: "v1.0.0"
 gem "govuk_markdown", "~> 1.0"
 gem "jsbundling-rails"
 gem "mail-notify"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DFE-Digital/govuk_feature_flags.git
-  revision: ac67ee4400f5b5316068fd5957a62a07d8749a75
-  branch: main
+  revision: 5211071bd5aa1139e3839cd9b6bc9092b1fad7a6
+  tag: v1.0.0
   specs:
     govuk_feature_flags (0.1.0)
       rails (>= 7.0.4)


### PR DESCRIPTION
Because it was using the main branch, every time a dependabot merge was happening on the gem's repo, it was triggering a dependabot PR on the refer repo.

I created an initial release for `govuk_feature_flags` here: https://github.com/DFE-Digital/govuk_feature_flags/releases/tag/v1.0.0