### PR TITLE
Update the referral sign in flow to match the prototype

### DIFF
--- a/app/controllers/eligibility_screener_controller.rb
+++ b/app/controllers/eligibility_screener_controller.rb
@@ -1,6 +1,4 @@
 class EligibilityScreenerController < ApplicationController
-  include StoreUserLocation
-  include AuthenticateUser
   include EnforceQuestionOrder
   include RedirectIfFeatureFlagInactive
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,16 +4,18 @@ class PagesController < ApplicationController
 
     @start_now_path =
       if FeatureFlags::FeatureFlag.active?(:referral_form)
-        current_user ? referral_type_path : new_user_session_path
+        current_user ? referral_type_path : users_registrations_exists_path
       else
-        referral_type_path
+        users_registrations_exists_path
       end
   end
 
   def you_should_know
     @continue_path =
       if FeatureFlags::FeatureFlag.active?(:referral_form)
-        if eligibility_check.reporting_as_public?
+        if !current_user
+          new_user_session_path(new_referral: true)
+        elsif eligibility_check.reporting_as_public?
           new_public_referral_path
         else
           new_referral_path

--- a/app/controllers/referral_type_controller.rb
+++ b/app/controllers/referral_type_controller.rb
@@ -1,6 +1,4 @@
 class ReferralTypeController < EligibilityScreenerController
-  skip_before_action :authenticate_user!
-
   def new
     @reporting_as_form = ReportingAsForm.new(eligibility_check:)
   end

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -4,7 +4,11 @@ class ReferralsController < Referrals::BaseController
   before_action :redirect_to_screener_if_no_id_in_session, only: %i[new create]
 
   def new
-    @create_path = referrals_path
+    new_referral =
+      current_user.find_or_create_referral!(
+        eligibility_check_id: session.delete(:eligibility_check_id)
+      )
+    redirect_to [:edit, new_referral.routing_scope, new_referral]
   end
 
   def create

--- a/app/controllers/users/existing_registration_controller.rb
+++ b/app/controllers/users/existing_registration_controller.rb
@@ -1,0 +1,26 @@
+class Users::ExistingRegistrationController < ApplicationController
+  def new
+    @registration_exists_form = RegistrationExistsForm.new
+  end
+
+  def create
+    @registration_exists_form =
+      RegistrationExistsForm.new(registration_exists_form_params)
+
+    if @registration_exists_form.valid?
+      if @registration_exists_form.registration_exists?
+        redirect_to new_user_session_path
+      else
+        redirect_to referral_type_path
+      end
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def registration_exists_form_params
+    params.require(:registration_exists_form).permit(:registration_exists)
+  end
+end

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -36,7 +36,7 @@ class Users::OtpController < DeviseController
 
   def fail_and_retry(reason:)
     @otp_form.user.after_failed_otp_authentication
-    redirect_to retry_user_sign_in_path(error: reason)
+    redirect_to retry_user_sign_in_path(error: reason, new_referral:)
   end
 
   def auth_options
@@ -64,11 +64,17 @@ class Users::OtpController < DeviseController
         [:edit, latest_referral.routing_scope, latest_referral]
       end
     else
-      referral_type_path
+      new_referral_path
     end
   end
 
   def user_params
     params.require(:user).permit(:uuid, :otp, :email)
   end
+
+  def new_referral
+    params[:new_referral] == "true"
+  end
+  alias_method :new_referral?, :new_referral
+  helper_method :new_referral, :new_referral?
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,7 +6,7 @@ class Users::SessionsController < Devise::SessionsController
       resource.create_otp
       UserMailer.send_otp(resource).deliver_later
 
-      redirect_to new_user_otp_path(uuid: resource.uuid)
+      redirect_to new_user_otp_path(uuid: resource.uuid, new_referral:)
     else
       render :new
     end
@@ -17,4 +17,10 @@ class Users::SessionsController < Devise::SessionsController
   def sign_in_params
     resource_params.permit(:email)
   end
+
+  def new_referral
+    params[:new_referral] == "true"
+  end
+  alias_method :new_referral?, :new_referral
+  helper_method :new_referral, :new_referral?
 end

--- a/app/forms/registration_exists_form.rb
+++ b/app/forms/registration_exists_form.rb
@@ -1,0 +1,15 @@
+class RegistrationExistsForm
+  include ActiveModel::Model
+
+  attr_accessor :registration_exists
+
+  validates :registration_exists, inclusion: { in: %w[yes no] }
+
+  def registration_exists?
+    registration_exists == "yes"
+  end
+
+  def save
+    valid?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,4 +36,12 @@ class User < ApplicationRecord
     eligibility_check = EligibilityCheck.find_by!(id: eligibility_check_id)
     referrals.create!(eligibility_check_id: eligibility_check.id)
   end
+
+  def find_or_create_referral!(eligibility_check_id:)
+    eligibility_check = EligibilityCheck.find_by!(id: eligibility_check_id)
+    Referral.find_or_create_by!(
+      user_id: id,
+      eligibility_check_id: eligibility_check.id
+    )
+  end
 end

--- a/app/views/users/existing_registration/new.html.erb
+++ b/app/views/users/existing_registration/new.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, "Do you have an account?" %>
+<% content_for :back_link_url, url_for(:back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @registration_exists_form, url: users_registrations_exists_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_collection_radio_buttons(:registration_exists,
+        [OpenStruct.new(label: "Yes, sign in and continue making a referral", value: 'yes'), OpenStruct.new(label: "No", value: 'no')],
+        :value,
+        :label,
+        legend: { tag: 'h1', size: 'xl', text: 'Do you have an account?' }
+      ) %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/otp/new.html.erb
+++ b/app/views/users/otp/new.html.erb
@@ -1,17 +1,21 @@
-<% content_for :page_title, "Confirm your email address" %>
+<% content_for :page_title, "Check your email" %>
 <% content_for :back_link_url, new_user_session_path %>
 
-<h1 class="govuk-heading-xl">Confirm your email address</h1>
+<h1 class="govuk-heading-xl">Check your email</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: @otp_form, scope: resource_name, url: user_otp_path, method: :post) do |f| %>
+      <%= hidden_field_tag :new_referral, new_referral %>
+
       <%= f.hidden_field :uuid, value: @otp_form.uuid %>
       <%= f.hidden_field :email, value: @otp_form.email %>
 
-      <p>We've emailed a confirmation code to <%= @otp_form.email %></p>
+      <p>A confirmation code has been sent to <%= @otp_form.email %></p>
+      <p>Check your spam and trash folder if you cannot find the email.</p>
+      <p>You can also <%= link_to "request another confirmation code", new_user_session_path(new_referral:) %>.</p>
 
-      <%= f.govuk_text_field :otp, size: "m", label: { text: "Enter your code", class: "govuk-label--s" }, class: "govuk-!-width-one-quarter" %>
+      <%= f.govuk_text_field :otp, size: "m", label: { text: "Confirmation code", class: "govuk-label--s" }, class: "govuk-!-width-one-quarter" %>
 
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/users/otp/retry.html.erb
+++ b/app/views/users/otp/retry.html.erb
@@ -13,6 +13,6 @@
       </p>
     <% end %>
 
-    <%= govuk_button_link_to('Continue', new_user_session_path, method: :get) %>
+    <%= govuk_button_link_to('Continue', new_user_session_path(new_referral:), method: :get) %>
   </div>
 </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,14 +1,18 @@
-<% content_for :page_title, "What is your email address?" %>
+<% content_for :page_title, new_referral? ? "Your email address" : "Sign in" %>
 <% content_for :back_link_url, root_path %>
-
-<h1 class="govuk-heading-xl">What is your email address?</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(resource, as: resource_name, url: user_session_path, method: :post) do |f| %>
-      <p>Use your email address to return at any time.</p>
+      <%= hidden_field_tag :new_referral, new_referral %>
 
-      <%= f.govuk_email_field :email, autocomplete: "email", label: nil %>
+      <% if new_referral? %>
+        <%= f.govuk_email_field :email, autocomplete: "email", label: { tag: 'h1', text: "Your email address", size: "l" } %>
+      <% else %>
+        <h1 class="govuk-heading-xl">Sign in</h1>
+        <p>Sign in to continue making your referral of serious misconduct.</p>
+        <%= f.govuk_email_field :email, autocomplete: "email", label: { tag: 'h1', text: "Your email address", class: "m" } %>
+      <% end %>
 
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,10 @@ en:
           attributes:
             is_teacher:
               inclusion: Select yes if the allegation is about a teacher
+        registration_exists_form:
+          attributes:
+            registration_exists:
+              inclusion: Select yes if you have an account
         reporting_as_form:
           attributes:
             reporting_as:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
     -> { FeatureFlags::FeatureFlag.active?(:eligibility_screener) }
   ) do
     get "/start", to: "pages#start"
+    get "/users/registrations/exists", to: "users/existing_registration#new"
+    post "/users/registrations/exists", to: "users/existing_registration#create"
     get "/referral-type", to: "referral_type#new"
     post "/referral-type", to: "referral_type#create"
     get "/have-you-complained", to: "have_complained#new"

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -7,6 +7,10 @@ module CommonSteps
     FeatureFlags::FeatureFlag.activate(:staff_http_basic_auth)
   end
 
+  def and_the_eligibility_screener_is_enabled
+    FeatureFlags::FeatureFlag.activate(:eligibility_screener)
+  end
+
   def and_i_am_signed_in
     @user = create(:user)
     sign_in(@user)

--- a/spec/system/screener/question_order_spec.rb
+++ b/spec/system/screener/question_order_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Question order", type: :system do
     given_the_service_is_open
     and_the_eligibility_screener_feature_is_active
     and_the_referral_form_feature_is_active
-    and_i_am_signed_in
+
     when_i_visit_the_service
     then_i_see_the_start_page
 
@@ -25,6 +25,9 @@ RSpec.feature "Question order", type: :system do
     then_i_see_the_start_page
 
     when_i_press_start
+    then_i_see_the_start_new_referral_page
+
+    when_i_start_new_referral
     when_i_choose_employer
     when_i_press_continue
     then_i_see_the_is_a_teacher_page
@@ -63,6 +66,15 @@ RSpec.feature "Question order", type: :system do
 
   def then_i_see_the_unsupervised_teaching_page
     expect(page).to have_current_path("/unsupervised-teaching")
+  end
+
+  def then_i_see_the_start_new_referral_page
+    expect(page).to have_current_path("/users/registrations/exists")
+  end
+
+  def when_i_start_new_referral
+    choose "No", visible: false
+    click_on "Continue"
   end
 
   def when_i_choose_employer

--- a/spec/system/screener/user_completes_eligibility_screener_as_employer_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_as_employer_spec.rb
@@ -33,8 +33,7 @@ RSpec.feature "Eligibility screener", type: :system do
 
     expect(page).to have_content "What completing this referral means for you"
     click_on "Continue"
-    expect(page).to have_content "Your progress is saved as you go"
-    click_on "Continue"
+    expect(page).to have_content "Your allegation of serious misconduct"
   end
 
   def and_i_have_started_an_employer_referral

--- a/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
@@ -83,8 +83,6 @@ RSpec.feature "Eligibility screener", type: :system do
     then_i_see_the_you_should_know_page
 
     when_i_press_continue
-    then_i_see_the_progress_is_saved_page
-    when_i_press_continue
     then_i_have_started_a_member_of_public_referral
   end
 
@@ -92,10 +90,6 @@ RSpec.feature "Eligibility screener", type: :system do
 
   def then_i_see_a_validation_error
     expect(page).to have_content("There is a problem")
-  end
-
-  def then_i_see_the_progress_is_saved_page
-    expect(page).to have_content "Your progress is saved as you go"
   end
 
   def then_i_see_the_employer_or_public_question

--- a/spec/system/screener/user_completes_eligibility_screener_with_inactive_employer_form_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_with_inactive_employer_form_spec.rb
@@ -29,6 +29,10 @@ RSpec.feature "Eligibility screener", type: :system do
 
   def when_i_complete_the_screener
     click_on "Start now"
+
+    choose "No", visible: false
+    click_on "Continue"
+
     choose "I’m referring as an employer", visible: false
     click_on "Continue"
 

--- a/spec/system/user_auth/user_reaches_max_otp_guesses_spec.rb
+++ b/spec/system/user_auth/user_reaches_max_otp_guesses_spec.rb
@@ -29,13 +29,15 @@ RSpec.feature "User accounts" do
   def when_i_start_the_signin_flow
     visit root_path
     click_on "Start now"
+    choose "Yes, sign in and continue making a referral", visible: false
+    click_on "Continue"
     fill_in "user-email-field", with: "test@example.com"
     click_on "Continue"
   end
 
   def and_max_out_my_otp_guesses
     Users::OtpForm::MAX_GUESSES.times do
-      fill_in "Enter your code", with: "123456"
+      fill_in "Confirmation code", with: "123456"
       within("main") { click_on "Continue" }
     end
   end
@@ -47,7 +49,7 @@ RSpec.feature "User accounts" do
 
   def and_can_return_to_the_email_screen
     click_link "Continue"
-    expect(page).to have_content "What is your email address?"
+    expect(page).to have_content "Sign in"
   end
 
   def and_my_otp_state_is_reset

--- a/spec/system/user_auth/user_signs_in_spec.rb
+++ b/spec/system/user_auth/user_signs_in_spec.rb
@@ -9,8 +9,11 @@ RSpec.feature "User accounts" do
 
     when_i_visit_the_root_page
     and_click_start_now
-    and_i_submit_my_email
-    when_i_provide_a_short_otp
+    and_choose_continue_referral
+    then_i_should_see_the_sign_in_page
+
+    when_i_submit_my_email
+    and_i_provide_a_short_otp
     then_i_see_an_error_about_otp_length
     when_i_provide_the_wrong_otp
     then_i_see_an_error_about_a_wrong_code
@@ -53,19 +56,24 @@ RSpec.feature "User accounts" do
     click_on "Start now"
   end
 
+  def and_choose_continue_referral
+    choose "Yes, sign in and continue making a referral", visible: false
+    click_on "Continue"
+  end
+
   def and_i_submit_my_email
     fill_in "user-email-field", with: "test@example.com"
     click_on "Continue"
   end
   alias_method :when_i_submit_my_email, :and_i_submit_my_email
 
-  def when_i_provide_a_short_otp
-    fill_in "Enter your code", with: "123"
+  def and_i_provide_a_short_otp
+    fill_in "Confirmation code", with: "123"
     within("main") { click_on "Continue" }
   end
 
   def when_i_provide_the_wrong_otp
-    fill_in "Enter your code", with: "123456"
+    fill_in "Confirmation code", with: "123456"
     within("main") { click_on "Continue" }
   end
 
@@ -90,7 +98,7 @@ RSpec.feature "User accounts" do
     email = ActionMailer::Base.deliveries.last
     expect(email.body).to include expected_otp
 
-    fill_in "Enter your code", with: expected_otp
+    fill_in "Confirmation code", with: expected_otp
     within("main") { click_on "Continue" }
   end
 
@@ -132,6 +140,10 @@ RSpec.feature "User accounts" do
     expect(page).to have_current_path(
       edit_referral_contact_details_email_path(@referral)
     )
+  end
+
+  def then_i_should_see_the_sign_in_page
+    expect(page).to have_current_path(new_user_session_path)
   end
 
   def and_my_otp_state_is_reset

--- a/spec/system/user_auth/user_tries_signing_in_with_expired_otp_spec.rb
+++ b/spec/system/user_auth/user_tries_signing_in_with_expired_otp_spec.rb
@@ -32,6 +32,8 @@ RSpec.feature "User accounts" do
   def when_i_start_the_signin_flow
     visit root_path
     click_on "Start now"
+    choose "Yes, sign in and continue making a referral", visible: false
+    click_on "Continue"
     fill_in "user-email-field", with: "test@example.com"
     click_on "Continue"
   end
@@ -43,7 +45,7 @@ RSpec.feature "User accounts" do
   def when_i_try_to_sign_in
     user = User.find_by(email: "test@example.com")
     expected_otp = Devise::Otp.derive_otp(user.secret_key)
-    fill_in "Enter your code", with: expected_otp
+    fill_in "Confirmation code", with: expected_otp
     within("main") { click_on "Continue" }
   end
 
@@ -54,7 +56,7 @@ RSpec.feature "User accounts" do
 
   def and_can_return_to_the_email_screen
     click_link "Continue"
-    expect(page).to have_content "What is your email address?"
+    expect(page).to have_content "Sign in"
   end
 
   def and_my_otp_state_is_reset

--- a/spec/system/user_auth/user_with_completed_referral_signs_in_spec.rb
+++ b/spec/system/user_auth/user_with_completed_referral_signs_in_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "User accounts" do
     when_i_visit_the_service
     and_i_have_a_completed_referral
     and_click_start_now
+    and_choose_continue_referral
     and_i_submit_my_email
 
     when_i_provide_the_expected_otp
@@ -30,6 +31,11 @@ RSpec.feature "User accounts" do
     click_on "Start now"
   end
 
+  def and_choose_continue_referral
+    choose "Yes, sign in and continue making a referral", visible: false
+    click_on "Continue"
+  end
+
   def and_i_submit_my_email
     fill_in "user-email-field", with: @user.email
     click_on "Continue"
@@ -44,7 +50,7 @@ RSpec.feature "User accounts" do
     email = ActionMailer::Base.deliveries.last
     expect(email.body).to include expected_otp
 
-    fill_in "Enter your code", with: expected_otp
+    fill_in "Confirmation code", with: expected_otp
     within("main") { click_on "Continue" }
   end
 

--- a/spec/system/user_registration/user_registers_spec.rb
+++ b/spec/system/user_registration/user_registers_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "User registration" do
+  include CommonSteps
+
+  scenario "User registers while requesting another confirmation code and exceeding max OTP guesses" do
+    given_the_service_is_open
+    and_the_eligibility_screener_is_enabled
+    and_the_referral_form_feature_is_active
+
+    when_i_visit_the_service
+    and_click_start_now
+    and_i_start_new_referral
+    and_i_complete_the_eligibility_screener
+    then_i_should_see_sign_up_page
+
+    when_i_submit_my_email
+    then_i_should_see_the_otp_page
+
+    when_i_request_another_confirmation_code
+    then_i_should_see_sign_up_page
+
+    when_i_submit_my_email
+    then_i_should_see_the_otp_page
+
+    when_i_max_out_my_otp_guesses
+    then_i_see_an_error_screen
+
+    when_i_press_continue
+    then_i_should_see_sign_up_page
+
+    when_i_submit_my_email
+    then_i_should_see_the_otp_page
+
+    when_i_provide_the_expected_otp
+    then_i_should_see_the_start_new_referral_page
+  end
+
+  private
+
+  def and_click_start_now
+    click_on "Start now"
+  end
+
+  def and_i_start_new_referral
+    choose "No", visible: false
+    click_on "Continue"
+  end
+
+  def and_i_complete_the_eligibility_screener
+    choose "I’m referring as an employer", visible: false
+    click_on "Continue"
+
+    3.times do
+      choose "Yes", visible: false
+      click_on "Continue"
+    end
+
+    click_on "Continue"
+  end
+
+  def then_i_should_see_sign_up_page
+    expect(page).to have_content "Your email address"
+    expect(page).to have_current_path(new_user_session_path(new_referral: true))
+  end
+
+  def when_i_submit_my_email
+    fill_in "user-email-field", with: "test@example.com"
+    click_on "Continue"
+  end
+
+  def then_i_should_see_the_otp_page
+    expect(page).to have_content "Check your email"
+    expect(page).to have_link(
+      "request another confirmation code",
+      href: new_user_session_path(new_referral: true)
+    )
+  end
+
+  def when_i_request_another_confirmation_code
+    click_on "request another confirmation code"
+  end
+
+  def when_i_max_out_my_otp_guesses
+    Users::OtpForm::MAX_GUESSES.times do
+      fill_in "Confirmation code", with: "123456"
+      within("main") { click_on "Continue" }
+    end
+  end
+
+  def then_i_see_an_error_screen
+    expect(page).to have_content "There was a problem signing in"
+    expect(page).to have_current_path(
+      retry_user_sign_in_path(error: :exhausted, new_referral: true)
+    )
+  end
+
+  def when_i_provide_the_expected_otp
+    perform_enqueued_jobs
+
+    user = User.find_by(email: "test@example.com")
+    expected_otp = Devise::Otp.derive_otp(user.secret_key)
+
+    email = ActionMailer::Base.deliveries.last
+    expect(email.body).to include expected_otp
+
+    fill_in "Confirmation code", with: expected_otp
+    within("main") { click_on "Continue" }
+  end
+
+  def then_i_should_see_the_start_new_referral_page
+    expect(page).to have_content "Your allegation of serious misconduct"
+  end
+
+  def when_i_press_continue
+    click_on "Continue"
+  end
+
+  def when_i_provide_a_short_otp
+    fill_in "Confirmation code", with: "123"
+    within("main") { click_on "Continue" }
+  end
+end


### PR DESCRIPTION
### Context

Reordering the flow so that signup is only completed after the eligibility check preventing ineligible applicants from wasting time signing up

### Changes proposed in this pull request

Create a Users::Registrations#exists page to allow the user to make a choice between new and existing referral: app/controllers/users/registrations_controller.rb. Named so that it will live on the devise controller if that is ever used

* If the user selects new referral:
* We redirect them to the eligibility check to run through that before asking for an email
* We Remove StoreUserLocation and AuthenticateUser from EligibilityScreenerController as they aren't needed there any more
* At the end of the eligibility check we send them to the new session page with the new=true param set
* We also add this new param to sessions and otp controller and the links in that process so whatever happens with the otp the user still sees the "new" copy
* When the user has entered their email and otp they are redirected to the edit referral screen

* If the user selects existing referral:
* They are sent to the new session but the copy is different for existing users
* Once they sign in with email and OTP they are redirected to their referral

The eligibility check was already saved against the user in the ReferralsController as its id comes from the session

Email address and confirmation page content also updated as per the prototype

New test added to cover the new parameter passaround

### Guidance to review

https://www.loom.com/share/9b369d7fc4a04d088ee6718745d61b5d 

### Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/oXwcNM6E/1158-update-the-referral-signin-flow-to-match-the-prototype)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
