### PR TITLE
Add a national insurance question for personal details

### DIFF
--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -13,6 +13,8 @@ class PersonalDetailsComponent < ViewComponent::Base
 
     rows.push(date_of_birth_known_row)
     rows.push(date_of_birth_row) if referral.age_known?
+    rows.push(ni_number_known_row)
+    rows.push(ni_number_row) if referral.ni_number_known?
     rows.push(trn_known_row)
     rows.push(trn_row) if referral.trn_known?
     rows.push(qts_row)
@@ -193,6 +195,60 @@ class PersonalDetailsComponent < ViewComponent::Base
       },
       value: {
         text: referral.has_qts&.humanize
+      }
+    }
+  end
+
+  def ni_number_known_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            polymorphic_path(
+              [
+                :edit,
+                referral.routing_scope,
+                referral,
+                :personal_details_ni_number
+              ],
+              return_to: request.path
+            ),
+          visually_hidden_text: "if you know their National Insurance number"
+        }
+      ],
+      key: {
+        text: "Do you know their National Insurance number?"
+      },
+      value: {
+        text: referral.ni_number_known? ? "Yes" : "No"
+      }
+    }
+  end
+
+  def ni_number_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href:
+            polymorphic_path(
+              [
+                :edit,
+                referral.routing_scope,
+                referral,
+                :personal_details_ni_number
+              ],
+              return_to: request.path
+            ),
+          visually_hidden_text: "their National Insurance number"
+        }
+      ],
+      key: {
+        text: "National Insurance number"
+      },
+      value: {
+        text: referral.ni_number
       }
     }
   end

--- a/app/controllers/referrals/personal_details/age_controller.rb
+++ b/app/controllers/referrals/personal_details/age_controller.rb
@@ -45,7 +45,7 @@ module Referrals
           current_referral.routing_scope,
           current_referral,
           :personal_details,
-          :trn
+          :ni_number
         ]
       end
     end

--- a/app/controllers/referrals/personal_details/ni_number_controller.rb
+++ b/app/controllers/referrals/personal_details/ni_number_controller.rb
@@ -1,0 +1,44 @@
+module Referrals
+  module PersonalDetails
+    class NiNumberController < Referrals::BaseController
+      def edit
+        @ni_number_form =
+          NiNumberForm.new(
+            ni_number: current_referral.ni_number,
+            ni_number_known: current_referral.ni_number_known
+          )
+      end
+
+      def update
+        @ni_number_form =
+          NiNumberForm.new(
+            ni_number_form_params.merge(referral: current_referral)
+          )
+        if @ni_number_form.save
+          redirect_to next_page
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def ni_number_form_params
+        params.require(:referrals_personal_details_ni_number_form).permit(
+          :ni_number,
+          :ni_number_known
+        )
+      end
+
+      def next_path
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :personal_details,
+          :trn
+        ]
+      end
+    end
+  end
+end

--- a/app/forms/referrals/personal_details/ni_number_form.rb
+++ b/app/forms/referrals/personal_details/ni_number_form.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+module Referrals
+  module PersonalDetails
+    class NiNumberForm
+      include ActiveModel::Model
+
+      attr_accessor :referral, :ni_number
+      attr_reader :ni_number_known
+
+      validates :ni_number, presence: true, if: -> { ni_number_known }
+      validates :ni_number_known, inclusion: { in: [true, false] }
+
+      def ni_number_known=(value)
+        @ni_number_known = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save
+        return false unless valid?
+
+        referral.update(
+          ni_number_known:,
+          ni_number: ni_number_known ? ni_number : nil
+        )
+      end
+    end
+  end
+end

--- a/app/views/referrals/personal_details/ni_number/edit.html.erb
+++ b/app/views/referrals/personal_details/ni_number/edit.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, "#{'Error: ' if @ni_number_form.errors.any?}Do you know their National Insurance number?" %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details_age])) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: @ni_number_form, url: [current_referral.routing_scope, current_referral, :personal_details, :ni_number], method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l">Personal details</span>
+      <div class="govuk-form-group">
+        <%= f.govuk_radio_buttons_fieldset(:ni_number_known, legend: { size: "l", text: "Do you know their National Insurance number?" }) do %>
+          <%= f.govuk_radio_button :ni_number_known, true, label: { text: "Yes" }, link_errors: true do %>
+            <%= f.govuk_text_field :ni_number, label: { text: "National Insurance number", size: "m" },
+                hint: { text: "For example, ‘QQ 12 34 56 C’" } %>
+          <% end %>
+          <%= f.govuk_radio_button :ni_number_known, false, label: { text: "No" } %>
+        <% end %>
+      </div>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/personal_details/trn/edit.html.erb
+++ b/app/views/referrals/personal_details/trn/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_trn_form.errors.any?}Do you know their teacher reference number (TRN)?" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details_age])) %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details, :ni_number])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,12 @@ en:
               incomplete_year: Year must include 4 numbers
             age_known:
               inclusion: Select yes if you know their date of birth
+        "referrals/personal_details/ni_number_form":
+          attributes:
+            ni_number_known:
+              inclusion: Choose if you know their National Insurance number
+            ni_number:
+              blank: Enter their National Insurance number
         "referrals/personal_details/name_form":
           attributes:
             first_name:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,7 @@ Rails.application.routes.draw do
         namespace :personal_details, path: "personal-details" do
           resource :name, only: %i[edit update], controller: :name
           resource :age, only: %i[edit update], controller: :age
+          resource :ni_number, only: %i[edit update], controller: :ni_number
           resource :trn, only: %i[edit update], controller: :trn
           resource :qts, only: %i[edit update], controller: :qts
           resource :check_answers, path: "check-answers", only: %i[edit update]

--- a/db/migrate/20230201160849_add_ni_number_to_referral.rb
+++ b/db/migrate/20230201160849_add_ni_number_to_referral.rb
@@ -1,0 +1,8 @@
+class AddNiNumberToReferral < ActiveRecord::Migration[7.0]
+  def change
+    change_table :referrals, bulk: true do |t|
+      t.string :ni_number
+      t.boolean :ni_number_known
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,7 +22,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_140718) do
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+    t.index %w[record_type record_id name blob_id],
+            name: "index_active_storage_attachments_uniqueness",
+            unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
@@ -40,7 +42,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_140718) do
   create_table "active_storage_variant_records", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
-    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+    t.index %w[blob_id variation_digest],
+            name: "index_active_storage_variant_records_uniqueness",
+            unique: true
   end
 
   create_table "eligibility_checks", force: :cascade do |t|
@@ -146,7 +150,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_140718) do
     t.text "allegation_consideration_details"
     t.string "previous_misconduct_format"
     t.boolean "previous_misconduct_complete"
-    t.index ["eligibility_check_id"], name: "index_referrals_on_eligibility_check_id"
+    t.string "ni_number"
+    t.boolean "ni_number_known"
+    t.index ["eligibility_check_id"],
+            name: "index_referrals_on_eligibility_check_id"
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 
@@ -190,12 +197,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_140718) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
-    t.index ["confirmation_token"], name: "index_staff_on_confirmation_token", unique: true
+    t.index ["confirmation_token"],
+            name: "index_staff_on_confirmation_token",
+            unique: true
     t.index ["email"], name: "index_staff_on_email", unique: true
-    t.index ["invitation_token"], name: "index_staff_on_invitation_token", unique: true
+    t.index ["invitation_token"],
+            name: "index_staff_on_invitation_token",
+            unique: true
     t.index ["invited_by_id"], name: "index_staff_on_invited_by_id"
-    t.index ["invited_by_type", "invited_by_id"], name: "index_staff_on_invited_by"
-    t.index ["reset_password_token"], name: "index_staff_on_reset_password_token", unique: true
+    t.index %w[invited_by_type invited_by_id], name: "index_staff_on_invited_by"
+    t.index ["reset_password_token"],
+            name: "index_staff_on_reset_password_token",
+            unique: true
     t.index ["unlock_token"], name: "index_staff_on_unlock_token", unique: true
   end
 
@@ -217,8 +230,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_140718) do
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_attachments",
+                  "active_storage_blobs",
+                  column: "blob_id"
+  add_foreign_key "active_storage_variant_records",
+                  "active_storage_blobs",
+                  column: "blob_id"
   add_foreign_key "organisations", "referrals"
   add_foreign_key "referral_evidences", "referrals"
   add_foreign_key "referrals", "eligibility_checks"

--- a/spec/forms/referrals/personal_details/ni_number_form_spec.rb
+++ b/spec/forms/referrals/personal_details/ni_number_form_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Referrals::PersonalDetails::NiNumberForm, type: :model do
+  context "when ni_number_known is true" do
+    subject { described_class.new(ni_number_known: "true") }
+
+    it { is_expected.to validate_presence_of(:ni_number) }
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:form) { described_class.new(referral:, ni_number_known:, ni_number:) }
+    let(:ni_number) { "AB123456C" }
+    let(:ni_number_known) { "true" }
+    let(:referral) { build(:referral) }
+
+    it "updates the ni_number_known" do
+      save
+      expect(referral.ni_number_known).to be_truthy
+    end
+
+    it "updates the ni_number" do
+      save
+      expect(referral.ni_number).to eq(ni_number)
+    end
+  end
+end

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -37,10 +37,23 @@ RSpec.feature "Personal details", type: :system do
 
     when_i_fill_out_their_date_of_birth
     and_i_click_save_and_continue
-    then_i_am_asked_if_i_know_their_trn
+    then_i_am_asked_if_i_know_their_national_insurance_number
 
     when_i_click_back
     then_i_am_asked_their_date_of_birth
+    and_i_click_save_and_continue
+    then_i_am_asked_if_i_know_their_national_insurance_number
+
+    when_i_choose_yes
+    and_i_click_save_and_continue
+    then_i_see_the_national_insurance_validation_errors
+
+    when_i_fill_in_the_national_insurance_number
+    and_i_click_save_and_continue
+    then_i_am_asked_if_i_know_their_trn
+
+    when_i_click_back
+    then_i_am_asked_if_i_know_their_national_insurance_number
 
     and_i_click_save_and_continue
     then_i_am_asked_if_i_know_their_trn
@@ -213,7 +226,24 @@ RSpec.feature "Personal details", type: :system do
     end
   end
 
+  def then_i_am_asked_if_i_know_their_national_insurance_number
+    expect(page).to have_title("Do you know their National Insurance number?")
+    expect(page).to have_content("Do you know their National Insurance number?")
+  end
+
+  def then_i_see_the_national_insurance_validation_errors
+    expect(page).to have_content("Enter their National Insurance number")
+  end
+
   def when_i_click_change_qts
     click_on "Change if they have qualified teacher status (QTS)"
+  end
+
+  def when_i_choose_yes
+    choose "Yes", visible: false
+  end
+
+  def when_i_fill_in_the_national_insurance_number
+    fill_in "National Insurance number", with: "QQ 12 34 56 C", visible: false
   end
 end


### PR DESCRIPTION
The employer referral design has an extra question not present in the
current version of the flow.

We want to ask for a national insurance number of the person being
referred.

https://trello.com/c/g17zoYm4/1179-add-national-insurance-to-employer-personal-details-flow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="859" alt="Screenshot 2023-01-31 at 4 16 40 pm" src="https://user-images.githubusercontent.com/3126/216301943-91d91092-d614-45ae-8a0c-f8f2773c5288.png">
