### PR TITLE
Users with a submitted referral redirect to confirmation page after login

### DIFF
--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -58,7 +58,11 @@ class Users::OtpController < DeviseController
     latest_referral = resource.latest_referral
 
     if latest_referral
-      [:edit, latest_referral.routing_scope, latest_referral]
+      if latest_referral.submitted_at?
+        [latest_referral.routing_scope, latest_referral, :confirmation]
+      else
+        [:edit, latest_referral.routing_scope, latest_referral]
+      end
     else
       referral_type_path
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,7 @@
 class UserMailer < ApplicationMailer
   def send_otp(user)
     @otp = Devise::Otp.derive_otp(user.secret_key)
+    Rails.logger.info "OTP: #{@otp}" if Rails.env.development?
     mailer_options = { to: user.email, subject: "Confirm your email address" }
 
     notify_email(mailer_options)

--- a/spec/system/user_auth/user_with_completed_referral_signs_in_spec.rb
+++ b/spec/system/user_auth/user_with_completed_referral_signs_in_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "User accounts" do
+  include CommonSteps
+
+  scenario "User with completed referral signs in" do
+    given_the_service_is_open
+    and_the_eligibility_screener_feature_is_active
+    and_the_referral_form_feature_is_active
+
+    when_i_visit_the_service
+    and_i_have_a_completed_referral
+    and_click_start_now
+    and_i_submit_my_email
+
+    when_i_provide_the_expected_otp
+    then_i_am_signed_in
+    then_i_see_the_confirmation_page
+  end
+
+  private
+
+  def and_i_have_a_completed_referral
+    @user = create(:user)
+    @referral = create(:referral, user: @user, submitted_at: 1.day.ago)
+  end
+
+  def and_click_start_now
+    click_on "Start now"
+  end
+
+  def and_i_submit_my_email
+    fill_in "user-email-field", with: @user.email
+    click_on "Continue"
+  end
+
+  def when_i_provide_the_expected_otp
+    perform_enqueued_jobs
+
+    user = User.find(@user.id)
+    expected_otp = Devise::Otp.derive_otp(user.secret_key)
+
+    email = ActionMailer::Base.deliveries.last
+    expect(email.body).to include expected_otp
+
+    fill_in "Enter your code", with: expected_otp
+    within("main") { click_on "Continue" }
+  end
+
+  def then_i_am_signed_in
+    within(".govuk-header") { expect(page).to have_content "Sign out" }
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_current_path("/referrals/#{@referral.id}/confirmation")
+    expect(page).to have_title("Referral sent")
+    expect(page).to have_content("Referral sent")
+  end
+end


### PR DESCRIPTION
### Context

To prevent people from making a referral twice and to confirm that they have completed a referral we show them the referral confirmation screen on completion.

### Changes proposed in this pull request

### Guidance to review
The spec covers it pretty well: spec/system/user_auth/user_with_completed_referral_signs_in_spec.rb

https://www.loom.com/share/54ca4b381fe64c0992634bba3c95c7bb

### Link to Trello card

[[<!-- http://trello.com/123-example-card -->](https://trello.com/c/oxSpL168/1077-a-user-with-a-submitted-referral-should-see-the-confirmation-page)](https://trello.com/c/oxSpL168/1077-a-user-with-a-submitted-referral-should-see-the-confirmation-page)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
