### PR TITLE
1081 - Update the allegation user journey

### DIFF
--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -70,7 +70,26 @@ class ReferralForm
         section.items = [
           ReferralSectionItem.new(
             I18n.t("referral_form.personal_details"),
-            personal_details_section_path,
+            path_for_section_status(
+              section_status(:personal_details_complete),
+              polymorphic_path(
+                [
+                  :edit,
+                  referral.routing_scope,
+                  referral,
+                  :personal_details_name
+                ]
+              ),
+              polymorphic_path(
+                [
+                  :edit,
+                  referral.routing_scope,
+                  referral,
+                  :personal_details,
+                  :check_answers
+                ]
+              )
+            ),
             section_status(:personal_details_complete)
           )
         ]
@@ -79,7 +98,26 @@ class ReferralForm
           section.items.append(
             ReferralSectionItem.new(
               I18n.t("referral_form.contact_details"),
-              contact_details_section_path,
+              path_for_section_status(
+                section_status(:contact_details_complete),
+                polymorphic_path(
+                  [
+                    :edit,
+                    referral.routing_scope,
+                    referral,
+                    :contact_details_email
+                  ]
+                ),
+                polymorphic_path(
+                  [
+                    :edit,
+                    referral.routing_scope,
+                    referral,
+                    :contact_details,
+                    :check_answers
+                  ]
+                )
+              ),
               section_status(:contact_details_complete)
             )
           )
@@ -88,7 +126,27 @@ class ReferralForm
         section.items.append(
           ReferralSectionItem.new(
             I18n.t("referral_form.about_their_role"),
-            about_their_role_section_path,
+            path_for_section_status(
+              section_status(:teacher_role_complete),
+              polymorphic_path(
+                [
+                  :edit,
+                  referral.routing_scope,
+                  referral,
+                  :teacher_role,
+                  :job_title
+                ]
+              ),
+              polymorphic_path(
+                [
+                  :edit,
+                  referral.routing_scope,
+                  referral,
+                  :teacher_role,
+                  :check_answers
+                ]
+              )
+            ),
             section_status(:teacher_role_complete)
           )
         )
@@ -102,8 +160,20 @@ class ReferralForm
         section.items = [
           ReferralSectionItem.new(
             I18n.t("referral_form.details_of_the_allegation"),
-            polymorphic_path(
-              [:edit, referral.routing_scope, referral, :allegation_details]
+            path_for_section_status(
+              section_status(:allegation_details_complete),
+              polymorphic_path(
+                [:edit, referral.routing_scope, referral, :allegation_details]
+              ),
+              polymorphic_path(
+                [
+                  :edit,
+                  referral.routing_scope,
+                  referral,
+                  :allegation,
+                  :check_answers
+                ]
+              )
             ),
             section_status(:allegation_details_complete)
           )
@@ -113,14 +183,7 @@ class ReferralForm
           section.items.append(
             ReferralSectionItem.new(
               I18n.t("referral_form.previous_allegations"),
-              polymorphic_path(
-                [
-                  :edit,
-                  referral.routing_scope,
-                  referral,
-                  :previous_misconduct_reported
-                ]
-              ),
+              previous_allegations_path,
               referral.previous_misconduct_status
             )
           )
@@ -149,6 +212,24 @@ class ReferralForm
       end
   end
 
+  def previous_allegations_path
+    if referral.previous_misconduct_completed_at.nil? &&
+         referral.previous_misconduct_deferred_at.nil?
+      return(
+        polymorphic_path(
+          [
+            :edit,
+            referral.routing_scope,
+            referral,
+            :previous_misconduct_reported
+          ]
+        )
+      )
+    end
+
+    polymorphic_path([referral.routing_scope, referral, :previous_misconduct])
+  end
+
   def section_status(section_complete_method)
     status = referral.send(section_complete_method)
     return :not_started_yet if status.nil?
@@ -169,60 +250,6 @@ class ReferralForm
 
     polymorphic_path(
       [:edit, referral.routing_scope, referral, :organisation_address]
-    )
-  end
-
-  def personal_details_section_path
-    if referral.personal_details_complete.nil?
-      return(
-        polymorphic_path(
-          [:edit, referral.routing_scope, referral, :personal_details_name]
-        )
-      )
-    end
-
-    polymorphic_path(
-      [
-        :edit,
-        referral.routing_scope,
-        referral,
-        :personal_details,
-        :check_answers
-      ]
-    )
-  end
-
-  def contact_details_section_path
-    if referral.contact_details_complete.nil?
-      return(
-        polymorphic_path(
-          [:edit, referral.routing_scope, referral, :contact_details_email]
-        )
-      )
-    end
-
-    polymorphic_path(
-      [
-        :edit,
-        referral.routing_scope,
-        referral,
-        :contact_details,
-        :check_answers
-      ]
-    )
-  end
-
-  def about_their_role_section_path
-    if referral.teacher_role_complete.nil?
-      return(
-        polymorphic_path(
-          [:edit, referral.routing_scope, referral, :teacher_role, :job_title]
-        )
-      )
-    end
-
-    polymorphic_path(
-      [:edit, referral.routing_scope, referral, :teacher_role, :check_answers]
     )
   end
 end

--- a/app/views/referrals/previous_misconduct/show.html.erb
+++ b/app/views/referrals/previous_misconduct/show.html.erb
@@ -1,4 +1,6 @@
 <% content_for :page_title, "Check and confirm your answers" %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -61,6 +61,17 @@ module CommonSteps
   alias_method :when_i_choose_no_come_back_later,
                :and_i_choose_no_come_back_later
 
+  def and_the_allegation_section_is_incomplete
+    within(all(".app-task-list__section")[2]) do
+      within(all(".app-task-list__item")[0]) do
+        expect(find(".app-task-list__task-name a").text).to eq(
+          "Details of the allegation"
+        )
+        expect(find(".app-task-list__tag").text).to eq("INCOMPLETE")
+      end
+    end
+  end
+
   def then_i_see_the_referral_summary
     expect(page).to have_current_path(edit_referral_path(@referral))
     expect(page).to have_title(

--- a/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
+++ b/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
@@ -33,7 +33,13 @@ RSpec.feature "Details of the allegation", type: :system do
     when_i_click_save_and_continue
     then_i_see_check_answers_form_validation_errors
 
-    when_i_choose_to_confirm
+    when_i_choose_no_come_back_later
+    and_i_click_save_and_continue
+    then_i_see_the_public_referral_summary
+    and_the_allegation_section_is_incomplete
+
+    when_i_edit_details_of_the_allegation
+    and_i_choose_complete
     and_i_click_save_and_continue
     then_i_see_the_public_referral_summary
     and_the_allegation_section_is_complete
@@ -110,10 +116,6 @@ RSpec.feature "Details of the allegation", type: :system do
 
   def then_i_see_check_answers_form_validation_errors
     expect(page).to have_content("Select yes if you’ve completed this section")
-  end
-
-  def when_i_choose_to_confirm
-    choose "Yes, I’ve completed this section", visible: false
   end
 
   def and_the_allegation_section_is_complete

--- a/spec/system/referrals/user_adds_an_allegation_spec.rb
+++ b/spec/system/referrals/user_adds_an_allegation_spec.rb
@@ -47,7 +47,13 @@ RSpec.feature "Allegation", type: :system do
     when_i_click_save_and_continue
     then_i_see_check_answers_form_validation_errors
 
-    when_i_choose_to_confirm
+    when_i_choose_no_come_back_later
+    and_i_click_save_and_continue
+    then_i_see_the_referral_summary
+    and_the_allegation_section_is_incomplete
+
+    when_i_edit_the_allegation
+    and_i_choose_complete
     and_i_click_save_and_continue
     then_i_see_the_referral_summary
     and_the_allegation_section_is_complete

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -12,7 +12,11 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
     when_i_click_on_previous_misconduct
     then_i_see_the_previous_misconduct_reported_page
 
-    when_i_click_save_and_continue
+    when_i_click_back
+    then_i_see_the_referral_summary
+
+    when_i_click_on_previous_misconduct
+    and_i_click_save_and_continue
     then_i_see_the_missing_reported_error
 
     when_i_choose_no


### PR DESCRIPTION
### Context

New journey rules:

### Changes proposed in this pull request

- when the user clicks on details (The allegation), and the clicked sub-section has not been started yet, one gets redirected to the first question for the corresponding subsection.
- when the user clicks on details (The allegation), and the clicked sub-section has been started already (complete/incomplete, one gets redirected to the check your answers page.


https://user-images.githubusercontent.com/1955084/216319809-eb203d92-6def-434e-8abf-8018753cd85b.mov

### Link to Trello card

https://trello.com/c/gxrf0YWA

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
