### PR TITLE
Update the contact details flow

### DIFF
--- a/app/components/contact_details_component.rb
+++ b/app/components/contact_details_component.rb
@@ -5,53 +5,13 @@ class ContactDetailsComponent < ViewComponent::Base
   attr_accessor :referral
 
   def rows
-    [
-      {
-        actions: [
-          {
-            text: "Change",
-            href: path_for(:email),
-            visually_hidden_text: "email"
-          }
-        ],
-        key: {
-          text: "Email address"
-        },
-        value: {
-          text: referral.email_known ? referral.email_address : "Not known"
-        }
-      },
-      {
-        actions: [
-          {
-            text: "Change",
-            href: path_for(:telephone),
-            visually_hidden_text: "phone number"
-          }
-        ],
-        key: {
-          text: "Phone number"
-        },
-        value: {
-          text: referral.phone_known ? referral.phone_number : "Not known"
-        }
-      },
-      {
-        actions: [
-          {
-            text: "Change",
-            href: path_for(:address),
-            visually_hidden_text: "address"
-          }
-        ],
-        key: {
-          text: "Address"
-        },
-        value: {
-          text: referral.address_known ? address(referral) : "Not known"
-        }
-      }
-    ]
+    rows = [email_known_row]
+    rows.push(email_row) if referral.email_known
+    rows.push(phone_number_known_row)
+    rows.push(phone_number_row) if referral.phone_known
+    rows.push(address_known_row)
+    rows.push(address_row) if referral.address_known
+    rows
   end
 
   def path_for(part)
@@ -69,5 +29,113 @@ class ContactDetailsComponent < ViewComponent::Base
     polymorphic_path(
       [:edit, referral.routing_scope, referral, :contact_details_check_answers]
     )
+  end
+
+  def email_known_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href: path_for(:email),
+          visually_hidden_text: "if you know their email address"
+        }
+      ],
+      key: {
+        text: "Do you know their email address?"
+      },
+      value: {
+        text: referral.email_known ? "Yes" : "No"
+      }
+    }
+  end
+
+  def email_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href: path_for(:email),
+          visually_hidden_text: "email address"
+        }
+      ],
+      key: {
+        text: "Email address"
+      },
+      value: {
+        text: referral.email_known ? referral.email_address : "Not known"
+      }
+    }
+  end
+
+  def phone_number_known_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href: path_for(:telephone),
+          visually_hidden_text: "if you know their phone number"
+        }
+      ],
+      key: {
+        text: "Do you know their phone number?"
+      },
+      value: {
+        text: referral.phone_known ? "Yes" : "No"
+      }
+    }
+  end
+
+  def phone_number_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href: path_for(:telephone),
+          visually_hidden_text: "phone number"
+        }
+      ],
+      key: {
+        text: "Phone number"
+      },
+      value: {
+        text: referral.phone_number
+      }
+    }
+  end
+
+  def address_known_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href: path_for(:address_known),
+          visually_hidden_text: "if you know their home address"
+        }
+      ],
+      key: {
+        text: "Do you know their home address?"
+      },
+      value: {
+        text: referral.address_known ? "Yes" : "No"
+      }
+    }
+  end
+
+  def address_row
+    {
+      actions: [
+        {
+          text: "Change",
+          href: path_for(:address),
+          visually_hidden_text: "home address"
+        }
+      ],
+      key: {
+        text: "Home address"
+      },
+      value: {
+        text: address(referral)
+      }
+    }
   end
 end

--- a/app/controllers/referrals/contact_details/address_controller.rb
+++ b/app/controllers/referrals/contact_details/address_controller.rb
@@ -4,7 +4,6 @@ module Referrals
       def edit
         @contact_details_address_form =
           AddressForm.new(
-            address_known: current_referral.address_known,
             address_line_1: current_referral.address_line_1,
             address_line_2: current_referral.address_line_2,
             town_or_city: current_referral.town_or_city,
@@ -31,7 +30,6 @@ module Referrals
 
       def contact_details_address_form_params
         params.require(:referrals_contact_details_address_form).permit(
-          :address_known,
           :address_line_1,
           :address_line_2,
           :town_or_city,

--- a/app/controllers/referrals/contact_details/address_known_controller.rb
+++ b/app/controllers/referrals/contact_details/address_known_controller.rb
@@ -1,0 +1,52 @@
+module Referrals
+  module ContactDetails
+    class AddressKnownController < Referrals::BaseController
+      def edit
+        @contact_details_address_known_form =
+          AddressKnownForm.new(address_known: current_referral.address_known)
+      end
+
+      def update
+        @contact_details_address_known_form =
+          AddressKnownForm.new(
+            contact_details_address_known_form_params.merge(
+              referral: current_referral
+            )
+          )
+        if @contact_details_address_known_form.save
+          redirect_to next_page
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def contact_details_address_known_form_params
+        params.require(:referrals_contact_details_address_known_form).permit(
+          :address_known
+        )
+      end
+
+      def next_page
+        if current_referral.address_known
+          return [
+            :edit,
+            current_referral.routing_scope,
+            current_referral,
+            :contact_details,
+            :address
+          ]
+        end
+
+        [
+          :edit,
+          current_referral.routing_scope,
+          current_referral,
+          :contact_details,
+          :check_answers
+        ]
+      end
+    end
+  end
+end

--- a/app/controllers/referrals/contact_details/telephone_controller.rb
+++ b/app/controllers/referrals/contact_details/telephone_controller.rb
@@ -38,7 +38,7 @@ module Referrals
           current_referral.routing_scope,
           current_referral,
           :contact_details,
-          :address
+          :address_known
         ]
       end
     end

--- a/app/forms/referrals/contact_details/address_form.rb
+++ b/app/forms/referrals/contact_details/address_form.rb
@@ -9,51 +9,29 @@ module Referrals
                     :town_or_city,
                     :postcode,
                     :country
-      attr_reader :address_known
 
       validates :referral, presence: true
-      validates :address_known, inclusion: { in: [true, false] }
-      validates :address_line_1,
-                :town_or_city,
-                :postcode,
-                presence: true,
-                if: -> { address_known }
-      validate :postcode_is_valid, if: -> { postcode.present? && address_known }
-
-      def address_known=(value)
-        @address_known = ActiveModel::Type::Boolean.new.cast(value)
-      end
+      validates :address_line_1, :town_or_city, :postcode, presence: true
+      validate :postcode_is_valid, if: -> { postcode.present? }
 
       def save
         return false unless valid?
 
-        address_attrs = {
-          address_known:,
-          address_line_1: nil,
-          address_line_2: nil,
-          town_or_city: nil,
-          postcode: nil,
-          country: nil
-        }
-
-        if address_known
-          address_attrs.merge!(
-            address_line_1:,
-            address_line_2:,
-            town_or_city:,
-            postcode:,
-            country:
-          )
-        end
-        referral.update(address_attrs)
+        referral.update(
+          address_line_1:,
+          address_line_2:,
+          town_or_city:,
+          postcode:,
+          country:
+        )
       end
 
       private
 
       def postcode_is_valid
-        unless UKPostcode.parse(postcode).full_valid?
-          errors.add(:postcode, :invalid)
-        end
+        return if UKPostcode.parse(postcode).full_valid?
+
+        errors.add(:postcode, :invalid)
       end
     end
   end

--- a/app/forms/referrals/contact_details/address_known_form.rb
+++ b/app/forms/referrals/contact_details/address_known_form.rb
@@ -1,0 +1,23 @@
+module Referrals
+  module ContactDetails
+    class AddressKnownForm
+      include ActiveModel::Model
+
+      attr_accessor :referral
+      attr_reader :address_known
+
+      validates :referral, presence: true
+      validates :address_known, inclusion: { in: [true, false] }
+
+      def address_known=(value)
+        @address_known = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def save
+        return false unless valid?
+
+        referral.update(address_known:)
+      end
+    end
+  end
+end

--- a/app/views/referrals/contact_details/address/edit.html.erb
+++ b/app/views/referrals/contact_details/address/edit.html.erb
@@ -1,5 +1,5 @@
-<% content_for :page_title, "#{"Error: " if @contact_details_address_form.errors.any?}Do you know their home address?" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :contact_details_telephone])) %>
+<% content_for :page_title, "#{"Error: " if @contact_details_address_form.errors.any?}Their home address" %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :contact_details_address_known])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -7,19 +7,12 @@
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Contact details</span>
-      <%= f.govuk_radio_buttons_fieldset :address_known, legend: { size: "xl", text: "Do you know their home address?" }  do %>
-        <%= f.hidden_field :address_known %>
-        <%= f.govuk_radio_button :address_known, true, label: { text: "Yes" }, link_errors: true do %>
-          <%= f.govuk_fieldset legend: { text: "What is their address?" } do %>
-            <%= f.govuk_text_field :address_line_1, label: { text: "Address line 1" } %>
-            <%= f.govuk_text_field :address_line_2, label: { text: "Address line 2 (optional)" } %>
-            <%= f.govuk_text_field :town_or_city, label: { text: "Town or city" } %>
-            <%= f.govuk_text_field :postcode, label: { text: "Postcode" } %>
-            <%= f.govuk_text_field :country, label: { text: "Country (optional)" } %>
-          <% end %>
-        <% end %>
-        <%= f.govuk_radio_button :address_known, false, label: { text: "No" } %>
-      <% end %>
+      <h1 class="govuk-heading-l">Their home address</h1>
+      <%= f.govuk_text_field :address_line_1, label: { size: 'm', text: "Address line 1" } %>
+      <%= f.govuk_text_field :address_line_2, label: { size: 'm', text: "Address line 2 (optional)" } %>
+      <%= f.govuk_text_field :town_or_city, label: { size: 'm', text: "Town or city" } %>
+      <%= f.govuk_text_field :postcode, label: { size: 'm', text: "Postcode" } %>
+      <%= f.govuk_text_field :country, label: { size: 'm', text: "Country (optional)" } %>
       <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>

--- a/app/views/referrals/contact_details/address_known/edit.html.erb
+++ b/app/views/referrals/contact_details/address_known/edit.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, "#{"Error: " if @contact_details_address_known_form.errors.any?}Do you know their home address?" %>
+<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :contact_details_telephone])) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @contact_details_address_known_form, url: [current_referral.routing_scope, current_referral, :contact_details_address_known], method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l">Contact details</span>
+      <%= f.govuk_radio_buttons_fieldset :address_known, legend: { size: "l", text: "Do you know their home address?" }  do %>
+        <%= f.hidden_field :address_known %>
+        <%= f.govuk_radio_button :address_known, true, label: { text: "Yes" }, link_errors: true do %>
+        <% end %>
+        <%= f.govuk_radio_button :address_known, false, label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/referrals/contact_details/email/edit.html.erb
+++ b/app/views/referrals/contact_details/email/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{"Error: " if @contact_details_email_form.errors.any?}Do you know the personal email address of the person you are referring?" %>
+<% content_for :page_title, "#{"Error: " if @contact_details_email_form.errors.any?}Do you know their email address?" %>
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Contact details</span>
-      <%= f.govuk_radio_buttons_fieldset :email_known, legend: { size: "l", text: "Do you know the personal email address of the person you are referring?" }  do %>
+      <%= f.govuk_radio_buttons_fieldset :email_known, legend: { size: "l", text: "Do you know their email address?" }  do %>
         <%= f.hidden_field :email_known %>
         <%= f.govuk_radio_button :email_known, true, label: { text: "Yes" }, link_errors: true do %>
           <%= f.govuk_text_field :email_address, label: { text: "Email address" } %>

--- a/app/views/referrals/contact_details/telephone/edit.html.erb
+++ b/app/views/referrals/contact_details/telephone/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{"Error: " if @contact_details_telephone_form.errors.any?}Do you know their main contact number?" %>
+<% content_for :page_title, "#{"Error: " if @contact_details_telephone_form.errors.any?}Do you know their phone number?" %>
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :contact_details_email])) %>
 
 <div class="govuk-grid-row">
@@ -7,10 +7,10 @@
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">Contact details</span>
-      <%= f.govuk_radio_buttons_fieldset :phone_known, legend: { size: "xl", text: "Do you know their main contact number?" }  do %>
+      <%= f.govuk_radio_buttons_fieldset :phone_known, legend: { size: "l", text: "Do you know their phone number?" }  do %>
         <%= f.hidden_field :phone_known %>
         <%= f.govuk_radio_button :phone_known, true, label: { text: "Yes" }, link_errors: true do %>
-          <%= f.govuk_text_field :phone_number, label: { text: "Main contact number" } %>
+          <%= f.govuk_text_field :phone_number, label: { text: "Phone number" } %>
         <% end %>
         <%= f.govuk_radio_button :phone_known, false, label: { text: "No" } %>
       <% end %>

--- a/app/views/referrals/personal_details/ni_number/edit.html.erb
+++ b/app/views/referrals/personal_details/ni_number/edit.html.erb
@@ -11,7 +11,7 @@
         <%= f.govuk_radio_buttons_fieldset(:ni_number_known, legend: { size: "l", text: "Do you know their National Insurance number?" }) do %>
           <%= f.govuk_radio_button :ni_number_known, true, label: { text: "Yes" }, link_errors: true do %>
             <%= f.govuk_text_field :ni_number, label: { text: "National Insurance number", size: "m" },
-                hint: { text: "For example, ‘QQ 12 34 56 C’" } %>
+                hint: { size: 's', text: "For example, ‘QQ 12 34 56 C’" } %>
           <% end %>
           <%= f.govuk_radio_button :ni_number_known, false, label: { text: "No" } %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,7 +106,7 @@ en:
         "referrals/personal_details/ni_number_form":
           attributes:
             ni_number_known:
-              inclusion: Choose if you know their National Insurance number
+              inclusion: Select yes if you know their National Insurance number
             ni_number:
               blank: Enter their National Insurance number
         "referrals/personal_details/name_form":
@@ -151,8 +151,6 @@ en:
               invalid: Enter a phone number in the correct format, like 07700 900 982
         "referrals/contact_details/address_form":
           attributes:
-            address_known:
-              inclusion: Select yes if you know their home address
             address_line_1:
               blank: Enter the first line of their address
             town_or_city:
@@ -160,6 +158,10 @@ en:
             postcode:
               blank: Enter the postcode
               invalid: Enter a real postcode
+        "referrals/contact_details/address_known_form":
+          attributes:
+            address_known:
+              inclusion: Select yes if you know their home address
         "referrals/contact_details/check_answers_form":
           attributes:
             contact_details_complete:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,9 @@ Rails.application.routes.draw do
 
   root to: redirect("/start")
 
-  resources :public_referrals, except: %i[index show], path: "public-referrals" do
+  resources :public_referrals,
+            except: %i[index show],
+            path: "public-referrals" do
     scope module: :public_referrals do
       constraints(RouteConstraints::PublicConstraint.new) do
         namespace :personal_details, path: "personal-details" do
@@ -87,7 +89,9 @@ Rails.application.routes.draw do
           resource :start, only: %i[edit update], controller: :start
           resource :upload, only: %i[edit update], controller: :upload
           resource :uploaded, only: %i[edit update], controller: :uploaded
-          resource :check_answers, only: %i[edit update], controller: :check_answers
+          resource :check_answers,
+                   only: %i[edit update],
+                   controller: :check_answers
         end
 
         namespace :allegation do
@@ -98,18 +102,18 @@ Rails.application.routes.draw do
 
         namespace :teacher_role, path: "teacher-role" do
           resource :job_title,
-            path: "job-title",
-            only: %i[edit update],
-            controller: :job_title
+                   path: "job-title",
+                   only: %i[edit update],
+                   controller: :job_title
           resource :duties, only: %i[edit update]
           resource :organisation_address_known,
-            path: "organisation-address-known",
-            only: %i[edit update],
-            controller: :organisation_address_known
+                   path: "organisation-address-known",
+                   only: %i[edit update],
+                   controller: :organisation_address_known
           resource :organisation_address,
-            path: "organisation-address",
-            only: %i[edit update],
-            controller: :organisation_address
+                   path: "organisation-address",
+                   only: %i[edit update],
+                   controller: :organisation_address
           resource :check_answers, path: "check-answers", only: %i[edit update]
         end
 
@@ -148,41 +152,42 @@ Rails.application.routes.draw do
         resource :referrer, only: %i[show update]
         resource :referrer_details, only: %i[show], path: "referrer-details"
         resource :referrer_name,
-          only: %i[edit update],
-          path: "referrer-name",
-          controller: :referrer_name
+                 only: %i[edit update],
+                 path: "referrer-name",
+                 controller: :referrer_name
         resource :referrer_job_title,
-          only: %i[edit update],
-          path: "referrer-job-title",
-          controller: :referrer_job_title
+                 only: %i[edit update],
+                 path: "referrer-job-title",
+                 controller: :referrer_job_title
         resource :referrer_phone,
-          only: %i[edit update],
-          path: "referrer-phone",
-          controller: :referrer_phone
+                 only: %i[edit update],
+                 path: "referrer-phone",
+                 controller: :referrer_phone
 
         namespace :contact_details, path: "contact-details" do
           resource :email, only: %i[edit update], controller: :email
           resource :telephone, only: %i[edit update], controller: :telephone
+          resource :address_known,
+                   only: %i[edit update],
+                   controller: :address_known
           resource :address, only: %i[edit update], controller: :address
           resource :check_answers, path: "check-answers", only: %i[edit update]
         end
 
         resource :organisation, only: %i[show update], controller: :organisation
         resource :organisation_name,
-          only: %i[edit update],
-          controller: :organisation_name
+                 only: %i[edit update],
+                 controller: :organisation_name
         resource :organisation_address,
-          only: %i[edit update],
-          controller: :organisation_address
+                 only: %i[edit update],
+                 controller: :organisation_address
 
         namespace :previous_misconduct, path: "previous-misconduct" do
-          resource :reported,
-            only: %i[edit update],
-            controller: :reported
+          resource :reported, only: %i[edit update], controller: :reported
           resource :detailed_account,
-            path: "detailed-account",
-            only: %i[edit update],
-            controller: :detailed_account
+                   path: "detailed-account",
+                   only: %i[edit update],
+                   controller: :detailed_account
           resource :check_answers, path: "check-answers", only: %i[edit update]
         end
 
@@ -194,50 +199,50 @@ Rails.application.routes.draw do
 
         namespace :teacher_role, path: "teacher-role" do
           resource :start_date,
-            path: "start-date",
-            only: %i[edit update],
-            controller: :start_date
+                   path: "start-date",
+                   only: %i[edit update],
+                   controller: :start_date
           resource :employment_status,
-            path: "employment-status",
-            only: %i[edit update],
-            controller: :employment_status
+                   path: "employment-status",
+                   only: %i[edit update],
+                   controller: :employment_status
           resource :job_title,
-            path: "job-title",
-            only: %i[edit update],
-            controller: :job_title
+                   path: "job-title",
+                   only: %i[edit update],
+                   controller: :job_title
           resource :same_organisation,
-            path: "same-organisation",
-            only: %i[edit update],
-            controller: :same_organisation
+                   path: "same-organisation",
+                   only: %i[edit update],
+                   controller: :same_organisation
           resource :duties, only: %i[edit update]
           resource :working_somewhere_else,
-            path: "working-somewhere-else",
-            only: %i[edit update],
-            controller: :working_somewhere_else
+                   path: "working-somewhere-else",
+                   only: %i[edit update],
+                   controller: :working_somewhere_else
           resource :work_location_known,
-            path: "work-location-known",
-            only: %i[edit update],
-            controller: :work_location_known
+                   path: "work-location-known",
+                   only: %i[edit update],
+                   controller: :work_location_known
           resource :work_location,
-            path: "work-location",
-            only: %i[edit update],
-            controller: :work_location
+                   path: "work-location",
+                   only: %i[edit update],
+                   controller: :work_location
           resource :organisation_address_known,
-            path: "organisation-address-known",
-            only: %i[edit update],
-            controller: :organisation_address_known
+                   path: "organisation-address-known",
+                   only: %i[edit update],
+                   controller: :organisation_address_known
           resource :organisation_address,
-            path: "organisation-address",
-            only: %i[edit update],
-            controller: :organisation_address
+                   path: "organisation-address",
+                   only: %i[edit update],
+                   controller: :organisation_address
           resource :end_date,
-            path: "end-date",
-            only: %i[edit update],
-            controller: :end_date
+                   path: "end-date",
+                   only: %i[edit update],
+                   controller: :end_date
           resource :reason_leaving_role,
-            path: "reason-leaving-role",
-            only: %i[edit update],
-            controller: :reason_leaving_role
+                   path: "reason-leaving-role",
+                   only: %i[edit update],
+                   controller: :reason_leaving_role
           resource :check_answers, path: "check-answers", only: %i[edit update]
         end
 

--- a/spec/forms/referrals/contact_details/address_form_spec.rb
+++ b/spec/forms/referrals/contact_details/address_form_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
 
   let(:params) do
     {
-      address_known: true,
       address_line_1: "1428 Elm Street",
       address_line_2: "Sunset Boulevard",
       country: "United Kingdom",
@@ -18,16 +17,9 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:referral) }
-
-    context "when address is known" do
-      subject { form }
-
-      let(:params) { { address_known: true } }
-
-      it { is_expected.to validate_presence_of(:address_line_1) }
-      it { is_expected.to validate_presence_of(:town_or_city) }
-      it { is_expected.to validate_presence_of(:postcode) }
-    end
+    it { is_expected.to validate_presence_of(:address_line_1) }
+    it { is_expected.to validate_presence_of(:town_or_city) }
+    it { is_expected.to validate_presence_of(:postcode) }
   end
 
   describe "#valid?" do
@@ -36,18 +28,6 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
     before { valid }
 
     it { is_expected.to be_truthy }
-
-    context "when address_known is blank" do
-      let(:params) { super().merge(address_known: "") }
-
-      it { is_expected.to be_falsy }
-
-      it "adds an error" do
-        expect(form.errors[:address_known]).to eq(
-          ["Select yes if you know their home address"]
-        )
-      end
-    end
 
     context "when address_line_1 is blank" do
       let(:params) { super().merge(address_line_1: "") }
@@ -95,10 +75,6 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
   describe "#save" do
     before { form.save }
 
-    it "saves address_known" do
-      expect(referral.address_known).to be_truthy
-    end
-
     it "saves address_line_1" do
       expect(referral.address_line_1).to eq("1428 Elm Street")
     end
@@ -117,34 +93,6 @@ RSpec.describe Referrals::ContactDetails::AddressForm, type: :model do
 
     it "saves country" do
       expect(referral.country).to eq("United Kingdom")
-    end
-
-    context "when the address is not known" do
-      let(:params) { super().merge(address_known: false) }
-
-      it "sets the address_known to false" do
-        expect(referral.address_known).to be_falsy
-      end
-
-      it "sets the address_line_1 to nil" do
-        expect(referral.address_line_1).to be_nil
-      end
-
-      it "sets the address_line_2 to nil" do
-        expect(referral.address_line_2).to be_nil
-      end
-
-      it "sets the town_or_city to nil" do
-        expect(referral.town_or_city).to be_nil
-      end
-
-      it "sets the postcode to nil" do
-        expect(referral.postcode).to be_nil
-      end
-
-      it "sets the country to nil" do
-        expect(referral.country).to be_nil
-      end
     end
   end
 end

--- a/spec/forms/referrals/contact_details/address_known_form_spec.rb
+++ b/spec/forms/referrals/contact_details/address_known_form_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Referrals::ContactDetails::AddressKnownForm, type: :model do
+  it { is_expected.to validate_presence_of(:referral) }
+
+  describe "#save" do
+    subject(:save) { described_class.new(referral:, address_known:).save }
+
+    let(:address_known) { true }
+    let(:referral) { build(:referral) }
+
+    it "saves address_known" do
+      save
+      expect(referral.address_known).to be_truthy
+    end
+
+    context "when the address is not known" do
+      let(:address_known) { false }
+
+      it "sets the address_known to false" do
+        save
+        expect(referral.address_known).to be_falsy
+      end
+    end
+  end
+end

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Contact details", type: :system do
     # Phone number known
     when_i_select_no
     and_i_click_save_and_continue
-    then_i_see_the_home_address_page
+    then_i_see_the_home_address_known_page
 
     # Phone number unknown
     when_i_go_back
@@ -60,16 +60,7 @@ RSpec.feature "Contact details", type: :system do
     and_i_click_save_and_continue
 
     # Do you know their home address?
-    then_i_see_the_home_address_page
-
-    # Address errors
-    when_i_select_yes
-    and_i_click_save_and_continue
-    then_i_see_a_missing_address_fields_error
-
-    when_i_fill_in_an_incorrect_postcode
-    and_i_click_save_and_continue
-    then_i_see_a_invalid_postcode_error
+    then_i_see_the_home_address_known_page
 
     # Address unknown
     when_i_select_no
@@ -79,6 +70,17 @@ RSpec.feature "Contact details", type: :system do
     # Address known
     when_i_click_change_address
     when_i_select_yes
+    and_i_click_save_and_continue
+    then_i_see_the_home_address_page
+
+    # Address errors
+    and_i_click_save_and_continue
+    then_i_see_a_missing_address_fields_error
+
+    when_i_fill_in_an_incorrect_postcode
+    and_i_click_save_and_continue
+    then_i_see_a_invalid_postcode_error
+
     when_i_fill_in_the_address_details
     and_i_click_save_and_continue
     then_i_see_the_check_answers_page
@@ -135,28 +137,32 @@ RSpec.feature "Contact details", type: :system do
     expect(page).to have_current_path(
       edit_referral_contact_details_email_path(@referral)
     )
-    expect(page).to have_title(
-      "Do you know the personal email address of the person you are referring?"
-    )
-    expect(page).to have_content(
-      "Do you know the personal email address of the person you are referring?"
-    )
+    expect(page).to have_title("Do you know their email address?")
+    expect(page).to have_content("Do you know their email address?")
   end
 
   def then_i_see_the_contact_number_page
     expect(page).to have_current_path(
       edit_referral_contact_details_telephone_path(@referral)
     )
-    expect(page).to have_title("Do you know their main contact number?")
-    expect(page).to have_content("Do you know their main contact number?")
+    expect(page).to have_title("Do you know their phone number?")
+    expect(page).to have_content("Do you know their phone number?")
+  end
+
+  def then_i_see_the_home_address_known_page
+    expect(page).to have_current_path(
+      edit_referral_contact_details_address_known_path(@referral)
+    )
+    expect(page).to have_title("Do you know their home address?")
+    expect(page).to have_content("Do you know their home address?")
   end
 
   def then_i_see_the_home_address_page
     expect(page).to have_current_path(
       edit_referral_contact_details_address_path(@referral)
     )
-    expect(page).to have_title("Do you know their home address?")
-    expect(page).to have_content("Do you know their home address?")
+    expect(page).to have_title("Their home address")
+    expect(page).to have_content("Their home address")
   end
 
   def when_i_select_yes
@@ -189,7 +195,7 @@ RSpec.feature "Contact details", type: :system do
 
   def when_i_select_yes_with_an_invalid_phone_number
     when_i_select_yes
-    fill_in "Main contact number", with: "1234"
+    fill_in "Phone number", with: "1234"
   end
 
   def then_i_see_an_invalid_phone_number_error
@@ -200,7 +206,7 @@ RSpec.feature "Contact details", type: :system do
 
   def when_i_select_yes_with_a_valid_phone_number
     when_i_select_yes
-    fill_in "Main contact number", with: "07700 900 982"
+    fill_in "Phone number", with: "07700 900 982"
   end
 
   def then_i_get_redirected_to_the_referral_summary
@@ -262,7 +268,7 @@ RSpec.feature "Contact details", type: :system do
     )
 
     expect_summary_row(
-      key: "Address",
+      key: "Home address",
       value: "1428 Elm Street\nLondon\nNW1 4NP",
       change_link:
         edit_referral_contact_details_address_path(
@@ -298,12 +304,12 @@ RSpec.feature "Contact details", type: :system do
   end
 
   def and_i_click_the_change_address_link
-    within(page.find(".govuk-summary-list__row", text: "Address")) do
+    within(page.find(".govuk-summary-list__row", text: "Home address")) do
       click_link "Change"
     end
   end
 
   def when_i_click_change_address
-    click_link "Change address"
+    click_link "Change if you know their home address"
   end
 end


### PR DESCRIPTION
The copy has changed in the designs and the address has been split over
2 screens.

This ensures those changes are reflected and also updates the check
answers page to reflect the questions about whether a datapoint is
known.

Finally, the change links have been updated in line with the conventions
specified by the design team.

### Link to Trello card

https://trello.com/c/SAjBeKis/1172-update-the-their-contact-details-flow-to-match-prototype

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1071" alt="Screenshot 2023-02-06 at 11 14 11 am" src="https://user-images.githubusercontent.com/3126/216957929-7773f507-1bac-4951-a1d6-312f2e441a86.png">
<img width="1018" alt="Screenshot 2023-02-06 at 11 14 21 am" src="https://user-images.githubusercontent.com/3126/216957949-c9ac766c-45c3-4623-ab4c-9240a4cb7b2a.png">
<img width="733" alt="Screenshot 2023-02-06 at 11 15 11 am" src="https://user-images.githubusercontent.com/3126/216958017-b7f27ae3-7ec9-4074-bb95-34b992c75789.png">
