### PR TITLE
Update the about their role flow

### DIFF
--- a/app/components/their_role_component.rb
+++ b/app/components/their_role_component.rb
@@ -98,12 +98,13 @@ class TheirRoleComponent < ViewComponent::Base
         {
           text: "Change",
           href: path_for(:same_organisation),
-          visually_hidden_text: "working in the same organisation"
+          visually_hidden_text:
+            "if they were employed at the same organisation as you at the time of the alleged misconduct"
         }
       ],
       key: {
         text:
-          "Did they work at the same organisation as you at the time of the alleged misconduct?"
+          "Were they employed at the same organisation as you at the time of the alleged misconduct?"
       },
       value: {
         text: referral.same_organisation ? "Yes" : "No"
@@ -157,11 +158,11 @@ class TheirRoleComponent < ViewComponent::Base
         {
           text: "Change",
           href: path_for(:start_date),
-          visually_hidden_text: "if you know when they started their job"
+          visually_hidden_text: "if you know when they started the job"
         }
       ],
       key: {
-        text: "Do you know when they started their job?"
+        text: "Do you know when they started the job?"
       },
       value: {
         text: referral.role_start_date_known ? "Yes" : "No"
@@ -175,7 +176,7 @@ class TheirRoleComponent < ViewComponent::Base
         {
           text: "Change",
           href: path_for(:start_date),
-          visually_hidden_text: "their job start date"
+          visually_hidden_text: "the job start date"
         }
       ],
       key: {
@@ -194,12 +195,12 @@ class TheirRoleComponent < ViewComponent::Base
           text: "Change",
           href: path_for(:employment_status),
           visually_hidden_text:
-            "if they are still employed in the job where the alleged misconduct took place"
+            "if are they still employed at the organisation where the alleged misconduct took place?"
         }
       ],
       key: {
         text:
-          "Are they still employed in the job where the alleged misconduct took place?"
+          "Are they still employed at the organisation where the alleged misconduct took place?"
       },
       value: {
         text: employment_status(referral)
@@ -231,7 +232,7 @@ class TheirRoleComponent < ViewComponent::Base
         {
           text: "Change",
           href: path_for(:end_date),
-          visually_hidden_text: "their job end date"
+          visually_hidden_text: "the job end date"
         }
       ],
       key: {
@@ -256,7 +257,7 @@ class TheirRoleComponent < ViewComponent::Base
         text: "Reason they left the job"
       },
       value: {
-        text: referral.reason_leaving_role&.humanize
+        text: reason_leaving_role
       }
     }
   end
@@ -274,7 +275,7 @@ class TheirRoleComponent < ViewComponent::Base
         text: "Are they employed somewhere else?"
       },
       value: {
-        text: referral.working_somewhere_else&.humanize
+        text: working_somewhere_else
       }
     }
   end
@@ -286,12 +287,12 @@ class TheirRoleComponent < ViewComponent::Base
           text: "Change",
           href: path_for(:work_location_known),
           visually_hidden_text:
-            "if you know the name and address of the organisation where they’re currently working"
+            "if you know the name and address of the organisation where they’re employed"
         }
       ],
       key: {
         text:
-          "Do you know the name and address of the organisation where they’re currently working?"
+          "Do you know the name and address of the organisation where they’re employed?"
       },
       value: {
         text: referral.work_location_known ? "Yes" : "No"
@@ -305,11 +306,12 @@ class TheirRoleComponent < ViewComponent::Base
         {
           text: "Change",
           href: path_for(:work_location),
-          visually_hidden_text: "where they currently work"
+          visually_hidden_text:
+            "name and address of the organisation where they’re employed"
         }
       ],
       key: {
-        text: "Where they currently work"
+        text: "Name and address of the organisation where they’re employed"
       },
       value: {
         text: teaching_address(referral)
@@ -332,5 +334,17 @@ class TheirRoleComponent < ViewComponent::Base
     polymorphic_path(
       [:edit, referral.routing_scope, referral, :teacher_role, :check_answers]
     )
+  end
+
+  def reason_leaving_role
+    return "I'm not sure" if referral.reason_leaving_role.to_sym == :unknown
+
+    referral.reason_leaving_role&.humanize
+  end
+
+  def working_somewhere_else
+    return "I'm not sure" if referral.working_somewhere_else.to_sym == :not_sure
+
+    referral.working_somewhere_else&.humanize
   end
 end

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -25,7 +25,7 @@ module ReferralHelper
     when "suspended"
       "They’re still employed but they’ve been suspended"
     when "left_role"
-      "No, they have left the organisation"
+      "No"
     else
       "Incomplete"
     end

--- a/app/views/referrals/teacher_role/employment_status/edit.html.erb
+++ b/app/views/referrals/teacher_role/employment_status/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @employment_status_form.errors.any?}Are they still employed in the job where the alleged misconduct took place?" %>
+<% content_for :page_title, "#{'Error: ' if @employment_status_form.errors.any?}Are they still employed at the organisation where the alleged misconduct took place?" %>
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :start_date])) %>
 
 <div class="govuk-grid-row">
@@ -8,11 +8,11 @@
 
       <span class="govuk-caption-l">About their role</span>
       <%= f.govuk_radio_buttons_fieldset :employment_status,
-        legend: { text: "Are they still employed in the job where the alleged misconduct took place?", tag: 'h1', size: "l" }  do %>
+        legend: { text: "Are they still employed at the organisation where the alleged misconduct took place?", tag: 'h1', size: "l" }  do %>
         <%= f.hidden_field :employment_status %>
         <%= f.govuk_radio_button :employment_status, "employed", label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :employment_status, "suspended", label: { text: "They’re still employed but they’ve been suspended" } %>
-        <%= f.govuk_radio_button :employment_status, "left_role", label: { text: "No, they have left the organisation" } %>
+        <%= f.govuk_radio_button :employment_status, "left_role", label: { text: "No" } %>
       <% end %>
       <%= f.govuk_submit "Save and continue" %>
     <% end %>

--- a/app/views/referrals/teacher_role/same_organisation/edit.html.erb
+++ b/app/views/referrals/teacher_role/same_organisation/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @same_organisation_form.errors.any?}Did they work at the same organisation as you at the time of the alleged misconduct?" %>
+<% content_for :page_title, "#{'Error: ' if @same_organisation_form.errors.any?}Were they employed at the same organisation as you at the time of the alleged misconduct?" %>
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :duties])) %>
 
 <div class="govuk-grid-row">
@@ -8,7 +8,7 @@
 
       <span class="govuk-caption-l">About their role</span>
       <%= f.govuk_radio_buttons_fieldset :same_organisation,
-        legend: { text: "Did they work at the same organisation as you at the time of the alleged misconduct?", tag: 'h1', size: "l" } do %>
+        legend: { text: "Were they employed at the same organisation as you at the time of the alleged misconduct?", tag: 'h1', size: "l" } do %>
         <%= f.hidden_field :same_organisation %>
         <%= f.govuk_radio_button :same_organisation, true, label: { text: "Yes" }, link_errors: true %>
       <%= f.govuk_radio_button :same_organisation, false, label: { text: "No" } %>

--- a/app/views/referrals/teacher_role/start_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/start_date/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @role_start_date_form.errors.any?}Do you know when they started their job?" %>
+<% content_for :page_title, "#{'Error: ' if @role_start_date_form.errors.any?}Do you know when they started the job?" %>
 <% content_for :back_link_url, return_to_session_or(back_link) %>
 
 <div class="govuk-grid-row">
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
       <span class="govuk-caption-l">About their role</span>
       <%= f.govuk_radio_buttons_fieldset :role_start_date_known,
-        legend: { text: "Do you know when they started their job?", tag: 'h1', size: "l" } do %>
+        legend: { text: "Do you know when they started the job?", tag: 'h1', size: "l" } do %>
         <%= f.hidden_field :role_start_date_known %>
         <%= f.govuk_radio_button :role_start_date_known, true, label: { text: "Yes" }, link_errors: true do %>
           <%= f.govuk_date_field :role_start_date,

--- a/app/views/referrals/teacher_role/work_location/edit.html.erb
+++ b/app/views/referrals/teacher_role/work_location/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{"Error: " if @work_location_form.errors.any?}Where they currently work" %>
+<% content_for :page_title, "#{"Error: " if @work_location_form.errors.any?}Name and address of the organisation where they’re employed" %>
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :work_location_known])) %>
 
 <div class="govuk-grid-row">
@@ -8,7 +8,7 @@
 
       <span class="govuk-caption-l">About their role</span>
       <h1 class="govuk-heading-l">
-        Where they currently work
+        Name and address of the organisation where they’re employed
       </h1>
 
       <%= f.govuk_text_field :work_organisation_name, label: { text: "Organisation name", size: "m" } %>

--- a/app/views/referrals/teacher_role/work_location_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/work_location_known/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @work_location_known_form.errors.any?}Do you know the name and address of the organisation where they’re currently working?" %>
+<% content_for :page_title, "#{'Error: ' if @work_location_known_form.errors.any?}Do you know the name and address of the organisation where they’re employed?" %>
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :working_somewhere_else])) %>
 
 <div class="govuk-grid-row">
@@ -8,7 +8,7 @@
 
       <span class="govuk-caption-l">About their role</span>
       <%= f.govuk_radio_buttons_fieldset :work_location_known,
-        legend: { text: "Do you know the name and address of the organisation where they’re currently working?", tag: 'h1', size: "l" } do %>
+        legend: { text: "Do you know the name and address of the organisation where they’re employed?", tag: 'h1', size: "l" } do %>
         <%= f.hidden_field :work_location_known %>
         <%= f.govuk_radio_button :work_location_known, true, label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :work_location_known, false, label: { text: "No" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,7 +164,7 @@ en:
         "referrals/teacher_role/start_date_form":
           attributes:
             role_start_date_known:
-              inclusion: Select yes if you know when they started their job
+              inclusion: Select yes if you know when they started the job
             role_start_date:
               blank: Enter the job start date
               in_the_future: Job start date must be in the past
@@ -214,7 +214,7 @@ en:
         "referrals/teacher_role/work_location_known_form":
           attributes:
             work_location_known:
-              inclusion: Select yes if you know the name and address of the organisation where they’re currently working
+              inclusion: Select yes if you know the name and address of the organisation where they’re employed
         "referrals/teacher_role/organisation_address_known_form":
           attributes:
             organisation_address_known:
@@ -224,11 +224,11 @@ en:
             organisation_name:
               blank: Enter the organisation name
             organisation_address_line_1:
-              blank: Enter the first line of their organisation's address
+              blank: Enter the first line of the organisation's address
             organisation_town_or_city:
-              blank: Enter a town or city for their organisation
+              blank: Enter a town or city for the organisation
             organisation_postcode:
-              blank: Enter a postcode for their organisation
+              blank: Enter a postcode for the organisation
               invalid: Enter a real postcode
         "referrals/teacher_role/end_date_form":
           attributes:

--- a/spec/forms/referrals/teacher_role/organisation_address_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/organisation_address_form_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Referrals::TeacherRole::OrganisationAddressForm, type: :model do
 
       it "adds an error" do
         expect(form.errors[:organisation_address_line_1]).to eq(
-          ["Enter the first line of their organisation's address"]
+          ["Enter the first line of the organisation's address"]
         )
       end
     end
@@ -63,7 +63,7 @@ RSpec.describe Referrals::TeacherRole::OrganisationAddressForm, type: :model do
 
       it "adds an error" do
         expect(form.errors[:organisation_town_or_city]).to eq(
-          ["Enter a town or city for their organisation"]
+          ["Enter a town or city for the organisation"]
         )
       end
     end
@@ -75,7 +75,7 @@ RSpec.describe Referrals::TeacherRole::OrganisationAddressForm, type: :model do
 
       it "adds an error" do
         expect(form.errors[:organisation_postcode]).to eq(
-          ["Enter a postcode for their organisation"]
+          ["Enter a postcode for the organisation"]
         )
       end
     end

--- a/spec/forms/referrals/teacher_role/start_date_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/start_date_form_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Referrals::TeacherRole::StartDateForm, type: :model do
 
       it "adds an error" do
         expect(form.errors[:role_start_date_known]).to eq(
-          ["Select yes if you know when they started their job"]
+          ["Select yes if you know when they started the job"]
         )
       end
     end

--- a/spec/forms/referrals/teacher_role/work_location_known_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/work_location_known_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Referrals::TeacherRole::WorkLocationKnownForm, type: :model do
 
     it do
       expect(form).to validate_presence_of(:work_location_known).with_message(
-        "Select yes if you know the name and address of the organisation where they’re currently working"
+        "Select yes if you know the name and address of the organisation where they’re employed"
       )
     end
   end
@@ -30,7 +30,7 @@ RSpec.describe Referrals::TeacherRole::WorkLocationKnownForm, type: :model do
       it "adds an error" do
         expect(form.errors[:work_location_known]).to eq(
           [
-            "Select yes if you know the name and address of the organisation where they’re currently working"
+            "Select yes if you know the name and address of the organisation where they’re employed"
           ]
         )
       end

--- a/spec/system/public_referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_teacher_role_details_spec.rb
@@ -286,10 +286,10 @@ RSpec.feature "Teacher role", type: :system do
   def then_i_see_organisation_address_fields_validation_errors
     expect(page).to have_content("Enter the organisation name")
     expect(page).to have_content(
-      "Enter the first line of their organisation's address"
+      "Enter the first line of the organisation's address"
     )
-    expect(page).to have_content("Enter a town or city for their organisation")
-    expect(page).to have_content("Enter a postcode for their organisation")
+    expect(page).to have_content("Enter a town or city for the organisation")
+    expect(page).to have_content("Enter a postcode for the organisation")
   end
 
   def then_i_see_a_completed_error

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature "Teacher role", type: :system do
     when_i_fill_in_the_teaching_address_details
     and_i_click_save_and_continue
 
-    # Do you know when they started their job?
+    # Do you know when they started the job?
 
     then_i_see_the_job_start_date_page
 
@@ -171,7 +171,7 @@ RSpec.feature "Teacher role", type: :system do
     and_i_choose_yes
     and_i_click_save_and_continue
 
-    # Do you know the name and address of the organisation where they’re currently working?
+    # Do you know the name and address of the organisation where they’re employed?
 
     then_i_see_the_work_location_known_page
 
@@ -271,10 +271,10 @@ RSpec.feature "Teacher role", type: :system do
       edit_referral_teacher_role_employment_status_path(@referral)
     )
     expect(page).to have_title(
-      "Are they still employed in the job where the alleged misconduct took place?"
+      "Are they still employed at the organisation where the alleged misconduct took place?"
     )
     expect(page).to have_content(
-      "Are they still employed in the job where the alleged misconduct took place?"
+      "Are they still employed at the organisation where the alleged misconduct took place?"
     )
   end
 
@@ -291,10 +291,10 @@ RSpec.feature "Teacher role", type: :system do
       edit_referral_teacher_role_same_organisation_path(@referral)
     )
     expect(page).to have_title(
-      "Did they work at the same organisation as you at the time of the alleged misconduct?"
+      "Were they employed at the same organisation as you at the time of the alleged misconduct?"
     )
     expect(page).to have_content(
-      "Did they work at the same organisation as you at the time of the alleged misconduct?"
+      "Were they employed at the same organisation as you at the time of the alleged misconduct?"
     )
   end
 
@@ -338,8 +338,8 @@ RSpec.feature "Teacher role", type: :system do
     expect(page).to have_current_path(
       edit_referral_teacher_role_start_date_path(@referral)
     )
-    expect(page).to have_title("Do you know when they started their job?")
-    expect(page).to have_content("Do you know when they started their job?")
+    expect(page).to have_title("Do you know when they started the job?")
+    expect(page).to have_content("Do you know when they started the job?")
   end
 
   def then_i_see_the_job_end_date_page
@@ -371,10 +371,10 @@ RSpec.feature "Teacher role", type: :system do
       edit_referral_teacher_role_work_location_known_path(@referral)
     )
     expect(page).to have_title(
-      "Do you know the name and address of the organisation where they’re currently working?"
+      "Do you know the name and address of the organisation where they’re employed?"
     )
     expect(page).to have_content(
-      "Do you know the name and address of the organisation where they’re currently working?"
+      "Do you know the name and address of the organisation where they’re employed?"
     )
   end
 
@@ -382,8 +382,12 @@ RSpec.feature "Teacher role", type: :system do
     expect(page).to have_current_path(
       edit_referral_teacher_role_work_location_path(@referral)
     )
-    expect(page).to have_title("Where they currently work")
-    expect(page).to have_content("Where they currently work")
+    expect(page).to have_title(
+      "Name and address of the organisation where they’re employed"
+    )
+    expect(page).to have_content(
+      "Name and address of the organisation where they’re employed"
+    )
   end
 
   def then_i_see_the_check_answers_page
@@ -417,7 +421,7 @@ RSpec.feature "Teacher role", type: :system do
   end
 
   def and_i_choose_left
-    choose "No, they have left the organisation", visible: false
+    choose "No", visible: false
   end
 
   def when_i_choose_resigned
@@ -489,7 +493,7 @@ RSpec.feature "Teacher role", type: :system do
 
   def then_i_see_role_start_date_known_field_validation_errors
     expect(page).to have_content(
-      "Select yes if you know when they started their job"
+      "Select yes if you know when they started the job"
     )
   end
 
@@ -522,10 +526,10 @@ RSpec.feature "Teacher role", type: :system do
   def then_i_see_organisation_address_fields_validation_errors
     expect(page).to have_content("Enter the organisation name")
     expect(page).to have_content(
-      "Enter the first line of their organisation's address"
+      "Enter the first line of the organisation's address"
     )
-    expect(page).to have_content("Enter a town or city for their organisation")
-    expect(page).to have_content("Enter a postcode for their organisation")
+    expect(page).to have_content("Enter a town or city for the organisation")
+    expect(page).to have_content("Enter a postcode for the organisation")
   end
 
   def then_i_see_duties_format_field_validation_errors
@@ -552,7 +556,7 @@ RSpec.feature "Teacher role", type: :system do
 
   def then_i_see_work_location_field_validation_errors
     expect(page).to have_content(
-      "Select yes if you know the name and address of the organisation where they’re currently working"
+      "Select yes if you know the name and address of the organisation where they’re employed"
     )
   end
 


### PR DESCRIPTION

The designs have updated the copy for the 'About their role' flow.

This change ensures those changes are reflected in the app. It also brings the change links in line with current conventions.

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1029" alt="Screenshot 2023-02-06 at 11 37 49 am" src="https://user-images.githubusercontent.com/3126/216965235-b4b9ab56-2f07-4a96-81e6-cd4f4a7a4b79.png">

<img width="1022" alt="Screenshot 2023-02-06 at 11 56 19 am" src="https://user-images.githubusercontent.com/3126/216965533-770f1fbb-85ed-4cb1-a2cb-d8aa2891609a.png">
<img width="1010" alt="Screenshot 2023-02-06 at 11 56 32 am" src="https://user-images.githubusercontent.com/3126/216965535-fb952d84-fa0f-4e69-82f0-54ffc0bfffe7.png">
<img width="1029" alt="Screenshot 2023-02-06 at 11 56 52 am" src="https://user-images.githubusercontent.com/3126/216965538-675bf819-359a-49b3-aa4d-a4ef8140721e.png">
<img width="1024" alt="Screenshot 2023-02-06 at 11 57 05 am" src="https://user-images.githubusercontent.com/3126/216965540-9a375be9-8540-410c-bae5-bdb229280619.png">
