### PR TITLE
Update the allegation details flow

### DIFF
--- a/app/components/what_happened_component.rb
+++ b/app/components/what_happened_component.rb
@@ -40,11 +40,11 @@ class WhatHappenedComponent < ViewComponent::Base
               :details,
               { return_to: }
             ],
-            visually_hidden_text: "how I want to report the allegation"
+            visually_hidden_text: "the description of the allegation"
           }
         ],
         key: {
-          text: "Summary"
+          text: "Description of the allegation"
         },
         value: {
           text: allegation_details(referral)
@@ -62,7 +62,7 @@ class WhatHappenedComponent < ViewComponent::Base
               :dbs,
               { return_to: }
             ],
-            visually_hidden_text: "DBS notified"
+            visually_hidden_text: "if you have told DBS"
           }
         ],
         key: {

--- a/app/views/referrals/allegation/dbs/edit.html.erb
+++ b/app/views/referrals/allegation/dbs/edit.html.erb
@@ -7,7 +7,7 @@
       <span class="govuk-caption-l">The allegation</span>
       <h1 class="govuk-heading-l">Telling DBS about this case</h1>
       <p>DBS (Disclosure and Barring Service) need to know about any allegations that involve harm to a child, or the risk of harm to a child.</p>
-      <p>If you haven’t told DBS about your allegation, we’ll pass your report onto them if it meets all the legal requirements.</p>
+      <p>If you have not told DBS about your allegation, we’ll pass your report onto them if it meets all the legal requirements.</p>
 
       <%= f.govuk_error_summary %>
 

--- a/app/views/referrals/allegation/details/edit.html.erb
+++ b/app/views/referrals/allegation/details/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @allegation_details_form.errors.any?}How do you want to tell us about your allegation?" %>
+<% content_for :page_title, "#{'Error: ' if @allegation_details_form.errors.any?}How do you want to give details about the allegation?" %>
 <% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
 
 <div class="govuk-grid-row">
@@ -8,14 +8,13 @@
 
       <span class="govuk-caption-l">The allegation</span>
       <div class="govuk-form-group">
-        <%= f.govuk_radio_buttons_fieldset(:allegation_format, legend: { size: "xl", text: "How do you want to tell us about your allegation?" }) do %>
-          <%= f.govuk_radio_button :allegation_format, "upload", label: { text: "I’ll upload the allegation details" }, link_errors: true do %>
-            <%= f.govuk_file_field :allegation_upload, label: { text: "Upload allegation details", size: "s" } %>
+        <%= f.govuk_radio_buttons_fieldset(:allegation_format, legend: { size: "l", text: "How do you want to give details about the allegation?", tag: 'h1' }) do %>
+          <%= f.govuk_radio_button :allegation_format, "upload", label: { text: "Upload file" }, link_errors: true do %>
+            <%= f.govuk_file_field :allegation_upload, label: { text: "Upload file", size: "s" } %>
           <% end %>
-          <%= f.govuk_radio_button :allegation_format, "details", label: { text: "I’ll give details of the allegation" } do %>
+          <%= f.govuk_radio_button :allegation_format, "details", label: { text: "Describe the allegation" } do %>
             <%= f.govuk_text_area :allegation_details,
-                                  label: { text: "Details of the allegation", size: "m" },
-                                  hint: { text: "Include dates and locations" },
+                                  label: { text: "Description of the allegation", size: "m" },
                                   rows: 20 %>
           <% end %>
         <% end %>

--- a/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
+++ b/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature "Details of the allegation", type: :system do
 
   def then_i_am_asked_how_i_want_to_make_the_allegation
     expect(page).to have_content(
-      "How do you want to tell us about your allegation?"
+      "How do you want to give details about the allegation?"
     )
   end
 
@@ -64,8 +64,9 @@ RSpec.feature "Details of the allegation", type: :system do
   end
 
   def when_i_fill_out_allegation_details
-    choose "I’ll give details of the allegation", visible: false
-    fill_in "Details of the allegation", with: "Something something something"
+    choose "Describe the allegation", visible: false
+    fill_in "Description of the allegation",
+            with: "Something something something"
   end
 
   def then_i_am_asked_how_the_complaint_has_been_considered

--- a/spec/system/referrals/user_adds_an_allegation_spec.rb
+++ b/spec/system/referrals/user_adds_an_allegation_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Allegation", type: :system do
 
   def then_i_am_asked_how_i_want_to_make_the_allegation
     expect(page).to have_content(
-      "How do you want to tell us about your allegation?"
+      "How do you want to give details about the allegation?"
     )
   end
 
@@ -78,8 +78,9 @@ RSpec.feature "Allegation", type: :system do
   end
 
   def when_i_fill_out_allegation_details
-    choose "I’ll give details of the allegation", visible: false
-    fill_in "Details of the allegation", with: "Something something something"
+    choose "Describe the allegation", visible: false
+    fill_in "Description of the allegation",
+            with: "Something something something"
   end
 
   def then_i_am_asked_if_i_have_notified_dbs
@@ -103,7 +104,7 @@ RSpec.feature "Allegation", type: :system do
     )
 
     expect_summary_row(
-      key: "Summary",
+      key: "Description of the allegation",
       value: "Something something something",
       change_link:
         edit_referral_allegation_details_path(
@@ -140,15 +141,15 @@ RSpec.feature "Allegation", type: :system do
   end
 
   def when_i_click_change_allegation_details
-    click_on "Change how I want to report the allegation"
+    click_on "Change the description of the allegation"
   end
 
   def when_i_choose_upload_the_allegation
-    choose "I’ll upload the allegation details", visible: false
+    choose "Upload file", visible: false
   end
 
   def then_i_am_asked_to_upload_an_allegation_file
-    expect(page).to have_content("Upload allegation details")
+    expect(page).to have_content("Upload file")
   end
 
   def then_i_see_the_upload_form_validation_errors
@@ -163,7 +164,7 @@ RSpec.feature "Allegation", type: :system do
 
   def when_i_upload_the_allegation
     attach_file(
-      "Upload allegation details",
+      "Upload file",
       [Rails.root.join("spec/fixtures/files/upload1.pdf")]
     )
   end


### PR DESCRIPTION
The designs have updated the copy for the allegation details flow.

This change ensures the app matches the prototype.

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="811" alt="Screenshot 2023-02-06 at 12 19 34 pm" src="https://user-images.githubusercontent.com/3126/216971361-2c55f61c-2c5a-48e3-bba3-b5ca11ac82fc.png">
<img width="809" alt="Screenshot 2023-02-06 at 12 19 28 pm" src="https://user-images.githubusercontent.com/3126/216971367-7488411e-52b7-4c3f-a76f-fc407164b09f.png">
