### PR TITLE
1180 - Update about you section user journey

### DIFF
--- a/app/controllers/referrals/organisation_controller.rb
+++ b/app/controllers/referrals/organisation_controller.rb
@@ -3,7 +3,11 @@ module Referrals
     def show
       @organisation =
         current_referral.organisation || current_referral.build_organisation
-      @organisation_form = OrganisationForm.new(referral: current_referral)
+      @organisation_form =
+        OrganisationForm.new(
+          referral: current_referral,
+          complete: @organisation.complete
+        )
     end
 
     def update

--- a/app/controllers/referrals/referrers_controller.rb
+++ b/app/controllers/referrals/referrers_controller.rb
@@ -2,7 +2,8 @@ module Referrals
   class ReferrersController < BaseController
     def show
       @referrer = current_referral.referrer
-      @referrer_form = ReferrerForm.new(referrer: @referrer)
+      @referrer_form =
+        ReferrerForm.new(referrer: @referrer, complete: @referrer.complete)
     end
 
     def update

--- a/app/forms/organisation_form.rb
+++ b/app/forms/organisation_form.rb
@@ -2,19 +2,19 @@ class OrganisationForm
   include ActiveModel::Model
 
   attr_accessor :referral
-  attr_writer :complete
+  attr_reader :complete
 
-  validates :complete, inclusion: { in: %w[true false] }
+  validates :complete, inclusion: { in: [true, false] }
   validates :referral, presence: true
 
-  def complete
-    @complete || organisation&.completed_at? || nil
+  def complete=(value)
+    @complete = ActiveModel::Type::Boolean.new.cast(value)
   end
 
   def save
     return false unless valid?
 
-    organisation.update(completed_at: complete == "true" ? Time.current : nil)
+    organisation.update(complete:)
   end
 
   private

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -56,11 +56,15 @@ class ReferralForm
   end
 
   def about_you_section_path
-    if referral.referrer.present?
-      return polymorphic_path([referral.routing_scope, referral, :referrer])
+    if referral.referrer&.complete.nil?
+      return(
+        polymorphic_path(
+          [:edit, referral.routing_scope, referral, :referrer_name]
+        )
+      )
     end
 
-    polymorphic_path([:edit, referral.routing_scope, referral, :referrer_name])
+    polymorphic_path([referral.routing_scope, referral, :referrer])
   end
 
   def about_the_person_you_are_referring_section

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -267,12 +267,14 @@ class ReferralForm
   end
 
   def about_your_organisation_section_path
-    if referral.organisation.present?
-      return polymorphic_path([referral.routing_scope, referral, :organisation])
+    if referral.organisation&.complete.nil?
+      return(
+        polymorphic_path(
+          [:edit, referral.routing_scope, referral, :organisation_address]
+        )
+      )
     end
 
-    polymorphic_path(
-      [:edit, referral.routing_scope, referral, :organisation_address]
-    )
+    polymorphic_path([referral.routing_scope, referral, :organisation])
   end
 end

--- a/app/forms/referrer_form.rb
+++ b/app/forms/referrer_form.rb
@@ -2,18 +2,18 @@ class ReferrerForm
   include ActiveModel::Model
 
   attr_accessor :referrer
-  attr_writer :complete
+  attr_reader :complete
 
-  validates :complete, inclusion: { in: %w[true false] }
+  validates :complete, inclusion: { in: [true, false] }
   validates :referrer, presence: true
 
-  def complete
-    @complete || referrer&.completed_at? || nil
+  def complete=(value)
+    @complete = ActiveModel::Type::Boolean.new.cast(value)
   end
 
   def save
     return false unless valid?
 
-    referrer.update(completed_at: complete == "true" ? Time.current : nil)
+    referrer.update(complete:)
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -6,7 +6,7 @@ class Organisation < ApplicationRecord
   end
 
   def completed?
-    completed_at.present?
+    complete
   end
 
   def status

--- a/app/models/referrer.rb
+++ b/app/models/referrer.rb
@@ -2,7 +2,7 @@ class Referrer < ApplicationRecord
   belongs_to :referral
 
   def completed?
-    completed_at.present?
+    complete
   end
 
   def name

--- a/app/views/referrals/referrers/show.html.erb
+++ b/app/views/referrals/referrers/show.html.erb
@@ -8,11 +8,10 @@
       Check and confirm your answers
     </h1>
 
-     <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
+    <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
 
     <%= form_with model: @referrer_form, url: [current_referral.routing_scope, current_referral, :referrer], method: :patch do |f| %>
       <%= f.govuk_radio_buttons_fieldset :complete, hint: { text: 'You can still make changes to a completed section' }, legend: { size: 'm', text: 'Have you completed this section?' } do %>
-        <%= f.hidden_field :complete %>
         <%= f.govuk_radio_button :complete, 'true', label: { text: "Yes, I’ve completed this section" }, link_errors: true %>
         <%= f.govuk_radio_button :complete, 'false', label: { text: "No, I’ll come back to it later" } %>
       <% end %>

--- a/db/migrate/20230206120315_change_referrer_fields.rb
+++ b/db/migrate/20230206120315_change_referrer_fields.rb
@@ -1,0 +1,15 @@
+class ChangeReferrerFields < ActiveRecord::Migration[7.0]
+  change_table :referrers, bulk: true do |t|
+    reversible do |dir|
+      dir.up do
+        t.remove :completed_at, if_exists: true
+        t.boolean :complete, if_not_exists: true
+      end
+
+      dir.down do
+        t.datetime :completed_at, if_not_exists: true
+        t.remove :complete, if_exists: true
+      end
+    end
+  end
+end

--- a/db/migrate/20230206144743_change_organisation_fields.rb
+++ b/db/migrate/20230206144743_change_organisation_fields.rb
@@ -1,0 +1,15 @@
+class ChangeOrganisationFields < ActiveRecord::Migration[7.0]
+  change_table :organisations, bulk: true do |t|
+    reversible do |dir|
+      dir.up do
+        t.remove :completed_at, if_exists: true
+        t.boolean :complete, if_not_exists: true
+      end
+
+      dir.down do
+        t.datetime :completed_at, if_not_exists: true
+        t.remove :complete, if_exists: true
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_02_140718) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_06_120315) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -164,8 +164,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_140718) do
     t.datetime "updated_at", null: false
     t.string "phone"
     t.string "job_title"
-    t.datetime "completed_at", precision: nil
     t.string "last_name"
+    t.boolean "complete"
     t.index ["referral_id"], name: "index_referrers_on_referral_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_06_120315) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_06_144743) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -70,12 +70,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_120315) do
     t.bigint "referral_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "completed_at", precision: nil
     t.string "name"
     t.string "street_1"
     t.string "street_2"
     t.string "city"
     t.string "postcode"
+    t.boolean "complete"
     t.index ["referral_id"], name: "index_organisations_on_referral_id"
   end
 

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     trait :complete do
       name { "Example School" }
-      completed_at { Time.current }
+      complete { true }
       street_1 { "1 Example Street" }
       city { "Example City" }
       postcode { "AB1 2CD" }

--- a/spec/factories/referrers.rb
+++ b/spec/factories/referrers.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     end
 
     trait :complete do
-      completed_at { Time.current }
+      complete { true }
       job_title { "Headteacher" }
       first_name { "Jane" }
       last_name { "Smith" }

--- a/spec/forms/organisation_form_spec.rb
+++ b/spec/forms/organisation_form_spec.rb
@@ -24,29 +24,4 @@ RSpec.describe OrganisationForm, type: :model do
       it { is_expected.to be_falsey }
     end
   end
-
-  describe "#complete" do
-    subject(:form_complete) { form.complete }
-
-    let(:form) { described_class.new(complete:, referral:) }
-    let(:organisation) { build(:organisation) }
-    let(:referral) { organisation.referral }
-
-    context "when the value of complete is nil" do
-      let(:complete) { nil }
-      let(:organisation) { build(:organisation) }
-
-      it "returns the value from the organisation" do
-        expect(form_complete).to eq(organisation.completed?)
-      end
-    end
-
-    context "when the value of complete is set" do
-      let(:complete) { true }
-
-      it "returns the value of complete" do
-        expect(complete).to eq(true)
-      end
-    end
-  end
 end

--- a/spec/forms/organisation_form_spec.rb
+++ b/spec/forms/organisation_form_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe OrganisationForm, type: :model do
 
     context "when the value of complete is nil" do
       let(:complete) { nil }
-      let(:organisation) { build(:organisation, completed_at: Time.current) }
+      let(:organisation) { build(:organisation) }
 
       it "returns the value from the organisation" do
         expect(form_complete).to eq(organisation.completed?)

--- a/spec/forms/referrer_form_spec.rb
+++ b/spec/forms/referrer_form_spec.rb
@@ -12,28 +12,4 @@ RSpec.describe ReferrerForm, type: :model do
 
     it { is_expected.to validate_presence_of(:referrer) }
   end
-
-  describe "#complete" do
-    subject(:form_complete) { referrer_form.complete }
-
-    let(:complete) { nil }
-    let(:referrer) { build(:referrer) }
-    let(:referrer_form) { described_class.new(complete:, referrer:) }
-
-    context "when the value of complete is nil" do
-      let(:referrer) { build(:referrer) }
-
-      it "returns the value from referrer" do
-        expect(form_complete).to eq(referrer.completed?)
-      end
-    end
-
-    context "when the value of complete is set" do
-      let(:complete) { true }
-
-      it "returns the value of complete" do
-        expect(complete).to eq(true)
-      end
-    end
-  end
 end

--- a/spec/forms/referrer_form_spec.rb
+++ b/spec/forms/referrer_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ReferrerForm, type: :model do
     let(:referrer) { build(:referrer) }
 
     specify do
-      expect(form).to validate_inclusion_of(:complete).in_array(%w[true false])
+      expect(form).to validate_inclusion_of(:complete).in_array([true, false])
     end
 
     it { is_expected.to validate_presence_of(:referrer) }
@@ -21,7 +21,7 @@ RSpec.describe ReferrerForm, type: :model do
     let(:referrer_form) { described_class.new(complete:, referrer:) }
 
     context "when the value of complete is nil" do
-      let(:referrer) { build(:referrer, completed_at: Time.current) }
+      let(:referrer) { build(:referrer) }
 
       it "returns the value from referrer" do
         expect(form_complete).to eq(referrer.completed?)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe Organisation, type: :model do
   end
 
   describe "#completed?" do
-    context "when completed_at is not nil" do
-      subject { build(:organisation, completed_at: Time.current) }
+    context "when it is completed" do
+      subject { build(:organisation, complete: true) }
 
       it { is_expected.to be_completed }
     end
 
-    context "when completed_at is nil" do
-      subject { build(:organisation, completed_at: nil) }
+    context "when complete is nil" do
+      subject { build(:organisation) }
 
       it { is_expected.not_to be_completed }
     end
@@ -43,14 +43,14 @@ RSpec.describe Organisation, type: :model do
   describe "#status" do
     subject { organisation.status }
 
-    context "when completed_at is not nil" do
-      let(:organisation) { build(:organisation, completed_at: Time.current) }
+    context "when complete is true" do
+      let(:organisation) { build(:organisation, complete: true) }
 
       it { is_expected.to eq(:completed) }
     end
 
-    context "when completed_at is nil" do
-      let(:organisation) { build(:organisation, completed_at: nil) }
+    context "when complete is nil" do
+      let(:organisation) { build(:organisation, complete: nil) }
 
       it { is_expected.to eq(:incomplete) }
     end

--- a/spec/models/referrer_spec.rb
+++ b/spec/models/referrer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Referrer, type: :model do
     it { is_expected.to eq(:incomplete) }
 
     context "when completed_at is present" do
-      let(:referrer) { build(:referrer, completed_at: Time.current) }
+      let(:referrer) { build(:referrer, complete: true) }
 
       it { is_expected.to eq(:completed) }
     end
@@ -27,7 +27,7 @@ RSpec.describe Referrer, type: :model do
     end
 
     context "when completed_at is present" do
-      let(:referrer) { build(:referrer, completed_at: Time.current) }
+      let(:referrer) { build(:referrer, complete: true) }
 
       it { is_expected.to be_truthy }
     end

--- a/spec/system/public_referrals/user_submits_referral_spec.rb
+++ b/spec/system/public_referrals/user_submits_referral_spec.rb
@@ -81,6 +81,6 @@ RSpec.feature "A member of the public submits a referral", type: :system do
   def when_i_have_a_complete_referral
     @referral.update(attributes_for(:referral, :complete))
     create(:organisation, completed_at: Time.current, referral: @referral)
-    create(:referrer, completed_at: Time.current, referral: @referral)
+    create(:referrer, complete: true, referral: @referral)
   end
 end

--- a/spec/system/public_referrals/user_submits_referral_spec.rb
+++ b/spec/system/public_referrals/user_submits_referral_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature "A member of the public submits a referral", type: :system do
 
   def when_i_have_a_complete_referral
     @referral.update(attributes_for(:referral, :complete))
-    create(:organisation, completed_at: Time.current, referral: @referral)
+    create(:organisation, complete: true, referral: @referral)
     create(:referrer, complete: true, referral: @referral)
   end
 end

--- a/spec/system/referrals/user_submits_referral_spec.rb
+++ b/spec/system/referrals/user_submits_referral_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature "User submits a referral", type: :system do
 
   def when_i_have_a_complete_referral
     @referral.update(attributes_for(:referral, :complete))
-    create(:organisation, completed_at: Time.current, referral: @referral)
+    create(:organisation, complete: true, referral: @referral)
     create(:referrer, complete: true, referral: @referral)
   end
 end

--- a/spec/system/referrals/user_submits_referral_spec.rb
+++ b/spec/system/referrals/user_submits_referral_spec.rb
@@ -79,6 +79,6 @@ RSpec.feature "User submits a referral", type: :system do
   def when_i_have_a_complete_referral
     @referral.update(attributes_for(:referral, :complete))
     create(:organisation, completed_at: Time.current, referral: @referral)
-    create(:referrer, completed_at: Time.current, referral: @referral)
+    create(:referrer, complete: true, referral: @referral)
   end
 end


### PR DESCRIPTION
### Context

Additional tweaks to the user journey for About you section.

### Changes proposed in this pull request

- If the user starts filling the About you section - Your details, but does not get to the check your answers page (e.g does select whether the form is complete or not), one starts from the first question.
- If the user starts filling the About you section - Your organisation, but does not get to the check your answers page (e.g does select whether the form is complete or not), one starts from the first question.

Otherwise, one lands on the check you answers page in both cases


https://user-images.githubusercontent.com/1955084/217013441-c973d406-8006-4424-9e9c-e96aed8533cc.mov


### Link to Trello card

https://trello.com/c/i3wl0AM8

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
