### PR TITLE
Update file upload designs

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -41,3 +41,9 @@ $govuk-assets-path: "/";
   padding-bottom: govuk-spacing(6);
   padding-top: govuk-spacing(5);
 }
+
+.app-uploaded-file {
+  background: #f3f2f1;
+  padding: 10px 15px;
+  margin-bottom: 30px;
+}

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -59,4 +59,8 @@ module ReferralHelper
       "Incomplete"
     end
   end
+
+  def file_size(attachment)
+    attachment.byte_size.to_fs(:human_size)
+  end
 end

--- a/app/views/referrals/allegation/details/edit.html.erb
+++ b/app/views/referrals/allegation/details/edit.html.erb
@@ -10,11 +10,27 @@
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset(:allegation_format, legend: { size: "l", text: "How do you want to give details about the allegation?", tag: 'h1' }) do %>
           <%= f.govuk_radio_button :allegation_format, "upload", label: { text: "Upload file" }, link_errors: true do %>
-            <%= f.govuk_file_field :allegation_upload, label: { text: "Upload file", size: "s" } %>
+            <% if current_referral.allegation_upload.attached? %>
+              <div class="app-uploaded-file">
+                <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
+                    Currently uploaded file
+                </h2>
+                <p>
+                  <%= govuk_link_to(
+                    "#{current_referral.allegation_upload.filename} (#{file_size(current_referral.allegation_upload)})",
+                    rails_blob_path(current_referral.allegation_upload, disposition: "attachment")
+                    )
+                  %>
+                </p>
+                <%= f.govuk_file_field :allegation_upload, label: { text: "Upload new file", size: "s" } %>
+              </div>
+            <% else %>
+              <%= f.govuk_file_field :allegation_upload, label: { text: "Upload file", size: "s" } %>
+            <% end %>
           <% end %>
           <%= f.govuk_radio_button :allegation_format, "details", label: { text: "Describe the allegation" } do %>
             <%= f.govuk_text_area :allegation_details,
-                                  label: { text: "Description of the allegation", size: "m" },
+                                  label: { text: "Description of the allegation", size: "s" },
                                   rows: 20 %>
           <% end %>
         <% end %>

--- a/app/views/referrals/previous_misconduct/detailed_account/edit.html.erb
+++ b/app/views/referrals/previous_misconduct/detailed_account/edit.html.erb
@@ -17,11 +17,27 @@
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset(:previous_misconduct_format, legend: { size: "m", text: "How do you want to give details about previous allegations?" }) do %>
           <%= f.govuk_radio_button :previous_misconduct_format, "upload", label: { text: "Upload file" }, link_errors: true do %>
-            <%= f.govuk_file_field :previous_misconduct_upload, label: { text: "Upload file", size: "s" } %>
+            <% if current_referral.previous_misconduct_upload.attached? %>
+              <div class="app-uploaded-file">
+                <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
+                    Currently uploaded file
+                </h2>
+                <p>
+                  <%= govuk_link_to(
+                    "#{current_referral.previous_misconduct_upload.filename} (#{file_size(current_referral.previous_misconduct_upload)})",
+                    rails_blob_path(current_referral.previous_misconduct_upload, disposition: "attachment")
+                    )
+                  %>
+                </p>
+                <%= f.govuk_file_field :previous_misconduct_upload, label: { text: "Upload new file", size: "s" } %>
+              </div>
+            <% else %>
+              <%= f.govuk_file_field :previous_misconduct_upload, label: { text: "Upload file", size: "s" } %>
+            <% end %>
           <% end %>
           <%= f.govuk_radio_button :previous_misconduct_format, "details", label: { text: "Describe the previous allegations" } do %>
             <%= f.govuk_text_area :previous_misconduct_details,
-                                  label: { text: "Description of previous allegations", size: "m" },
+                                  label: { text: "Description of previous allegations", size: "s" },
                                   rows: 20 %>
           <% end %>
         <% end %>

--- a/app/views/referrals/teacher_role/duties/edit.html.erb
+++ b/app/views/referrals/teacher_role/duties/edit.html.erb
@@ -10,10 +10,26 @@
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset(:duties_format, legend: { text: "How do you want to give details about their main duties?", tag: 'h1', size: "l" }) do %>
           <%= f.govuk_radio_button :duties_format, "upload", label: { text: "Upload file" }, link_errors: true do %>
-            <%= f.govuk_file_field :duties_upload,
-              label: { text: "Upload file", size: "s" },
-              hint: { text: current_referral.duties_upload.attached? ? "Uploaded file: #{current_referral.duties_upload.filename}" : "For example, a job description"  }
-              %>
+            <% if current_referral.duties_upload.attached? %>
+              <div class="app-uploaded-file">
+                <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
+                    Currently uploaded file
+                </h2>
+                <p>
+                  <%= govuk_link_to(
+                    "#{current_referral.duties_upload.filename} (#{file_size(current_referral.duties_upload)})",
+                    rails_blob_path(current_referral.duties_upload, disposition: "attachment")
+                    )
+                  %>
+                </p>
+                <%= f.govuk_file_field :duties_upload,
+                  label: { text: "Upload new file", size: "s" },
+                  hint: { text: "For example, a job description"  }
+                %>
+              </div>
+            <% else %>
+              <%= f.govuk_file_field :duties_upload, label: { text: "Upload file", size: "s" } %>
+            <% end %>
           <% end %>
           <%= f.govuk_radio_button :duties_format, "details", label: { text: "Describe their main duties" } do %>
             <%= f.govuk_text_area :duties_details,

--- a/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
+++ b/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
@@ -30,6 +30,15 @@ RSpec.feature "Details of the allegation", type: :system do
     and_i_click_save_and_continue
     then_i_am_asked_to_confirm_the_allegation_details
 
+    when_i_click_change_allegation_details_link
+    and_i_choose_upload
+    and_i_attach_an_allegation_file
+    when_i_click_save_and_continue
+    when_i_click_change_allegation_details_link
+    then_i_can_see_the_allegation_file
+    when_i_click_save_and_continue
+    then_i_can_see_the_allegation_file_in_the_summary
+
     when_i_click_save_and_continue
     then_i_see_check_answers_form_validation_errors
 
@@ -132,5 +141,41 @@ RSpec.feature "Details of the allegation", type: :system do
 
   def then_i_see_the_public_referral_summary
     expect(page).to have_current_path(edit_public_referral_path(@referral))
+  end
+
+  def when_i_click_change_allegation_details_link
+    within(
+      page.find(
+        ".govuk-summary-list__row",
+        text: "How do you want to give details about the allegation?"
+      )
+    ) { click_link "Change" }
+  end
+
+  def and_i_choose_upload
+    choose "Upload file", visible: false
+  end
+
+  def and_i_attach_an_allegation_file
+    attach_file(
+      "Upload file",
+      File.absolute_path(Rails.root.join("spec/fixtures/files/upload1.pdf"))
+    )
+  end
+
+  def then_i_can_see_the_allegation_file_in_the_summary
+    expect_summary_row(
+      key: "Description of the allegation",
+      value: "upload1.pdf",
+      change_link:
+        edit_public_referral_allegation_details_path(
+          @referral,
+          return_to: current_path
+        )
+    )
+  end
+
+  def then_i_can_see_the_allegation_file
+    expect(page).to have_content("upload1.pdf (4.98 KB)")
   end
 end

--- a/spec/system/public_referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_teacher_role_details_spec.rb
@@ -250,7 +250,7 @@ RSpec.feature "Teacher role", type: :system do
 
   def and_i_attach_a_second_job_description_file
     attach_file(
-      "Upload file",
+      "Upload new file",
       File.absolute_path(Rails.root.join("spec/fixtures/files/upload2.pdf"))
     )
   end
@@ -299,11 +299,11 @@ RSpec.feature "Teacher role", type: :system do
   # Page content
 
   def and_i_see_the_uploaded_filename
-    expect(page).to have_content("Uploaded file: upload1.pdf")
+    expect(page).to have_content("upload1.pdf (4.98 KB)")
   end
 
   def and_i_see_the_second_uploaded_filename
-    expect(page).to have_content("Uploaded file: upload2.pdf")
+    expect(page).to have_content("upload2.pdf (5.11 KB)")
   end
 
   def and_i_see_the_status_section_in_the_referral_summary(status: "COMPLETED")

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -48,6 +48,10 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
     then_i_see_the_previous_misconduct_page
     and_i_see_the_uploaded_file_name
 
+    when_i_click_change_previous_misconduct_details_link
+    then_i_can_see_the_previous_misconduct_file
+    when_i_click_save_and_continue
+
     when_i_click_save_and_continue
     then_i_am_asked_to_make_a_choice
 
@@ -185,5 +189,18 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
   def when_i_upload_a_file
     choose "Upload file", visible: :all
     attach_file "Upload file", Rails.root.join("spec/support/upload.txt")
+  end
+
+  def when_i_click_change_previous_misconduct_details_link
+    within(
+      page.find(
+        ".govuk-summary-list__row",
+        text: "How do you want to give details about previous allegations?"
+      )
+    ) { click_link "Change" }
+  end
+
+  def then_i_can_see_the_previous_misconduct_file
+    expect(page).to have_content("upload.txt (15 Bytes)")
   end
 end

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -474,7 +474,7 @@ RSpec.feature "Teacher role", type: :system do
 
   def and_i_attach_a_second_job_description_file
     attach_file(
-      "Upload file",
+      "Upload new file",
       File.absolute_path(Rails.root.join("spec/fixtures/files/upload2.pdf"))
     )
   end
@@ -574,11 +574,11 @@ RSpec.feature "Teacher role", type: :system do
   # Page content
 
   def and_i_see_the_uploaded_filename
-    expect(page).to have_content("Uploaded file: upload1.pdf")
+    expect(page).to have_content("upload1.pdf (4.98 KB)")
   end
 
   def and_i_see_the_second_uploaded_filename
-    expect(page).to have_content("Uploaded file: upload2.pdf")
+    expect(page).to have_content("upload2.pdf (5.11 KB)")
   end
 
   def and_i_see_the_status_section_in_the_referral_summary(status: "COMPLETED")


### PR DESCRIPTION
This change also makes the file uploads similar to the duties section, where you can click Continue when the upload already exists without selecting a new file.

<img width="743" alt="Screenshot 2023-02-06 at 11 05 36" src="https://user-images.githubusercontent.com/1636476/217005265-47ee0879-cdda-4b2f-afaa-66463c00098f.png">
<img width="681" alt="Screenshot 2023-02-06 at 11 33 51" src="https://user-images.githubusercontent.com/1636476/217005274-af6f4940-3c7f-4884-a0d3-e0ac2ab4b6c7.png">
<img width="722" alt="Screenshot 2023-02-06 at 14 52 00" src="https://user-images.githubusercontent.com/1636476/217005281-09a05e8f-6cca-4d65-ae7d-258aba699c81.png">

### Link to Trello card

https://trello.com/c/Jd2JHIrA/1174-file-upload-design-and-logic-changes

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
