### PR TITLE
Remove validate_inclusion_of for booleans

### DIFF
--- a/spec/forms/referrals/teacher_role/end_date_form_spec.rb
+++ b/spec/forms/referrals/teacher_role/end_date_form_spec.rb
@@ -9,12 +9,6 @@ RSpec.describe Referrals::TeacherRole::EndDateForm, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:referral) }
-
-    specify do
-      expect(form).to validate_inclusion_of(:role_end_date_known).in_array(
-        [true, false]
-      )
-    end
   end
 
   describe "#valid?" do

--- a/spec/forms/referrer_form_spec.rb
+++ b/spec/forms/referrer_form_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe ReferrerForm, type: :model do
 
     let(:referrer) { build(:referrer) }
 
-    specify do
-      expect(form).to validate_inclusion_of(:complete).in_array([true, false])
-    end
-
     it { is_expected.to validate_presence_of(:referrer) }
   end
 end


### PR DESCRIPTION
The use of `validate_inclusion_of` for booleans is [discouraged](https://www.rubydoc.info/gems/shoulda-matchers/5.1.0/Shoulda/Matchers/ActiveModel).

```
We discourage using `validate_inclusion_of` with boolean columns. In fact, there is never a case where a boolean column will be anything but true, false, or nil, as ActiveRecord will type-cast an incoming value to one of these three values. That means there isn't any way we can refute this logic in a test. Hence, this will produce a warning.
```

