### PR TITLE
1081 - User sees only COMPLETE/INCOMPLETE statuses

### DIFF
--- a/app/components/task_list_section_component.html.erb
+++ b/app/components/task_list_section_component.html.erb
@@ -11,7 +11,7 @@
         </span>
         <% tag_css = item.status != :completed ? " govuk-tag--grey" : "" -%>
         <strong class="govuk-tag app-task-list__tag<%= tag_css %>" id="<%= item.label.parameterize %>">
-          <%= item.status.to_s.humanize %>
+          <%= I18n.t("referral_form.statuses.#{item.status}") %>
         </strong>
       </li>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
     previous_allegations: Previous allegations
     evidence_and_supporting_information: Evidence and supporting information
     statuses:
-      not_started_yet: Not started yet
+      not_started_yet: Incomplete
       incomplete: Incomplete
       completed: Completed
   referral_evidence:

--- a/spec/components/task_list_component_spec.rb
+++ b/spec/components/task_list_component_spec.rb
@@ -108,10 +108,10 @@ RSpec.describe TaskListComponent, type: :component do
     expect(rendered.css(".app-task-list__tag")[0].text).to include("Completed")
   end
 
-  it "renders the Not started yet tag with the correct colour" do
+  it "renders the Incomplete tag even if the sections was not started yet with the correct colour" do
     expect(
       rendered.css(".app-task-list__tag.govuk-tag--grey")[0].text
-    ).to include("Not started yet")
+    ).to include("Incomplete")
   end
 
   it "renders the Incomplete tag with the correct colour" do

--- a/spec/system/public_referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_teacher_role_details_spec.rb
@@ -13,9 +13,7 @@ RSpec.feature "Teacher role", type: :system do
     and_i_am_a_member_of_the_public_with_an_existing_referral
     and_i_visit_the_public_referral
     then_i_see_the_public_referral_summary
-    and_i_see_the_status_section_in_the_referral_summary(
-      status: "NOT STARTED YET"
-    )
+    and_i_see_the_status_section_in_the_referral_summary(status: "INCOMPLETE")
 
     when_i_edit_teacher_role_details
 

--- a/spec/system/referrals/user_adds_contact_details_spec.rb
+++ b/spec/system/referrals/user_adds_contact_details_spec.rb
@@ -12,9 +12,7 @@ RSpec.feature "Contact details", type: :system do
     and_the_referral_form_feature_is_active
     and_i_have_an_existing_referral
     when_i_visit_the_referral
-    then_i_see_the_status_section_in_the_referral_summary(
-      status: "NOT STARTED YET"
-    )
+    then_i_see_the_status_section_in_the_referral_summary(status: "INCOMPLETE")
     and_i_click_on_contact_details
 
     # Do you know the personal email address

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -13,9 +13,7 @@ RSpec.feature "Teacher role", type: :system do
     and_i_have_an_existing_referral
     and_i_visit_the_referral
     then_i_see_the_referral_summary
-    and_i_see_the_status_section_in_the_referral_summary(
-      status: "NOT STARTED YET"
-    )
+    and_i_see_the_status_section_in_the_referral_summary(status: "INCOMPLETE")
 
     when_i_edit_teacher_role_details
 


### PR DESCRIPTION
### Context

 User sees only COMPLETE/INCOMPLETE statuses

### Changes proposed in this pull request

On the task-list user only sees COMPLETE/INCOMPLETE statuses for a better UX. However, we do keep the logic behind that relies on three statuses currently:
- :complete
- :incomplete
- :not_started_yet

These are still needed to ensure correct service behavior.

### Guidance to review

![Screenshot 2023-02-07 at 14 51 22](https://user-images.githubusercontent.com/1955084/217278606-f184f276-2bd8-434a-a2aa-6aba6a3b5398.png)

### Link to Trello card

https://trello.com/c/VadMIhzi

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
