### PR TITLE
Refactor section status

### DIFF
--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -52,22 +52,10 @@ class Referral < ApplicationRecord
     name_has_changed == "yes"
   end
 
-  def organisation_status
-    return :not_started_yet if organisation.blank?
-
-    organisation.status
-  end
-
   def previous_misconduct_reported?
     return true if previous_misconduct_reported == "true"
 
     false
-  end
-
-  def referrer_status
-    return :not_started_yet if referrer.blank?
-
-    referrer.status
   end
 
   def working_somewhere_else?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,6 @@ en:
     previous_allegations: Previous allegations
     evidence_and_supporting_information: Evidence and supporting information
     statuses:
-      not_started_yet: Incomplete
       incomplete: Incomplete
       completed: Completed
   referral_evidence:

--- a/spec/components/task_list_component_spec.rb
+++ b/spec/components/task_list_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TaskListComponent, type: :component do
           OpenStruct.new(
             label: "Dark wash",
             path: "/dark-wash",
-            status: :not_started_yet
+            status: :incomplete
           )
         ]
       ),
@@ -33,7 +33,7 @@ RSpec.describe TaskListComponent, type: :component do
           OpenStruct.new(
             label: "Add filling",
             path: "/add-filling",
-            status: :not_started_yet
+            status: :incomplete
           )
         ]
       )

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -27,36 +27,6 @@ RSpec.describe Referral, type: :model do
     it { is_expected.to eq [public_referral] }
   end
 
-  describe "#referrer_status" do
-    subject { referral.referrer_status }
-
-    let(:referral) { build(:referral) }
-
-    it { is_expected.to eq(:not_started_yet) }
-
-    context "when a referrer is present" do
-      let(:referral) do
-        build(:referral, referrer: build(:referrer, :incomplete))
-      end
-
-      it { is_expected.to eq(:incomplete) }
-    end
-  end
-
-  describe "#organisation_status" do
-    subject { referral.organisation_status }
-
-    let(:referral) { build(:referral) }
-
-    it { is_expected.to eq(:not_started_yet) }
-
-    context "when an organisation is present" do
-      let(:referral) { build(:organisation).referral }
-
-      it { is_expected.to eq(:incomplete) }
-    end
-  end
-
   describe "#previous_misconduct_reported?" do
     subject { referral.previous_misconduct_reported? }
 


### PR DESCRIPTION
The section status was responsible for two different things from a
logical perspective: setting the section link to go to the check
answers page and display the status badge for the section row. With
the removal of the `not_started_yet` status these logical checks weren't
aligning anymore.