### PR TITLE
1173 - Update copy for exit pages

### DIFF
--- a/app/views/pages/no_complaint.html.erb
+++ b/app/views/pages/no_complaint.html.erb
@@ -1,18 +1,27 @@
-<% content_for :page_title, 'Make a complaint to the school, school governors or your local council first' %>
+<% content_for :page_title, 'Consider making a complaint first' %>
 <% content_for :back_link_url, have_you_complained_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Make a complaint to the school, school governors or your local council first</h1>
+    <h1 class="govuk-heading-l">Consider making a complaint first</h1>
+    <p class="govuk-body">Before referring a teacher, first consider making a complaint to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        the school
+      </li>
+      <li>
+        the school governors
+      </li>
+      <li>
+        your local council
+      </li>
+    </ul>
     <p class="govuk-body">
       View guidance about <%= link_to "how to make an informal complaint", "https://www.gov.uk/report-teacher-misconduct" %></a>.
     </p>
 
-    <p class="govuk-body">You’ll need to provide proof to support your complaint.</p>
+    <p class="govuk-body">You can still refer a teacher without making an informal complaint. Your allegation may not be investigated unless you have made a complaint first.</p>
 
-    <p class="govuk-body">
-      You can still refer serious misconduct without making an informal complaint. Depending on the allegation, it may not be investigated unless you have tried to deal with the matter informally.
-    </p>
     <%= govuk_button_link_to "Continue without an informal complaint", is_a_teacher_path %>
   </div>
 </div>

--- a/app/views/pages/no_jurisdiction.html.erb
+++ b/app/views/pages/no_jurisdiction.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, 'You need to make your referral somewhere else' %>
+<% content_for :page_title, 'You cannot refer a teacher who was not employed in England' %>
 <% content_for :back_link_url, url_for(:back) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You need to make your referral somewhere else</h1>
+    <h1 class="govuk-heading-l">You cannot refer a teacher who was not employed in England</h1>
     <p class="govuk_body">You can refer misconduct in Wales, Scotland or Northern&nbsp;Ireland by contacting:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>the <a rel="external" href="http://www.ewc.wales/">Education Workforce Council for Wales</a></li>
-      <li>the <a rel="external" href="http://www.gtcs.org.uk/fitness-to-teach/process/referral.aspx">General Teaching Council for Scotland</a></li>
+      <li>the <a rel="external" href="https://www.ewc.wales/">Education Workforce Council for Wales</a></li>
+      <li>the <a rel="external" href="https://www.gtcs.org.uk/fitness-to-teach/making-a-referral-or-recommendation/">General Teaching Council for Scotland</a></li>
       <li>the <a rel="external" href="https://gtcni.org.uk/regulation/making-a-referral">General Teaching Council for Northern Ireland</a></li>
     </ul>
   </div>

--- a/app/views/pages/no_jurisdiction_unsupervised.html.erb
+++ b/app/views/pages/no_jurisdiction_unsupervised.html.erb
@@ -1,28 +1,11 @@
-<% content_for :page_title, 'You need to report this misconduct somewhere else' %>
+<% content_for :page_title, 'You cannot use this service to refer someone who is not a teacher' %>
 <% content_for :back_link_url, url_for(:back) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You need to report this misconduct somewhere else</h1>
-    <h2 class="govuk-heading-m">Why you can’t refer them using this service</h2>
-    <p class="govuk_body">
-      Cases of serious misconduct must be related to teachers who are (or have been) employed or engaged at:
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>a school in England</li>
-      <li>a sixth form college in England</li>
-      <li>relevant youth accommodation in England</li>
-      <li>a children’s home in England</li>
-      <li>a 16 to 19 Academy</li>
-    </ul>
-
-    <p class="govuk_body">
-      This does not include cases relating to teaching assistants, higher level teaching assistants or other support staff.
-    </p>
-    <h2 class="govuk-heading-m">Reporting someone who is not a teacher</h2>
-    <p class="govuk_body">
-      You will need to <a href="https://www.gov.uk/report-teacher-misconduct">make an informal complaint</a>.
+    <h1 class="govuk-heading-l">You cannot use this service to refer someone who is not a teacher</h1>
+    <p class="govuk-body">
+      View guidance about <%= link_to "how to make an informal complaint", "https://www.gov.uk/report-teacher-misconduct" %></a>.
     </p>
   </div>
 </div>

--- a/app/views/pages/no_jurisdiction_unsupervised.html.erb
+++ b/app/views/pages/no_jurisdiction_unsupervised.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">You cannot use this service to refer someone who is not a teacher</h1>
     <p class="govuk-body">
-      View guidance about <%= link_to "how to make an informal complaint", "https://www.gov.uk/report-teacher-misconduct" %></a>.
+      View guidance about how to <%= link_to "make an informal complaint", "https://www.gov.uk/report-teacher-misconduct" %></a>.
     </p>
   </div>
 </div>

--- a/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
@@ -126,20 +126,26 @@ RSpec.feature "Eligibility screener", type: :system do
   def then_i_see_the_no_jurisdiction_page
     expect(page).to have_current_path("/no-jurisdiction")
     expect(page).to have_title(
-      "You need to make your referral somewhere else - Refer serious misconduct by a teacher in England"
+      [
+        "You cannot refer a teacher who was not employed in England",
+        "Refer serious misconduct by a teacher in England"
+      ].join(" - ")
     )
     expect(page).to have_content(
-      "You need to make your referral somewhere else"
+      "You cannot refer a teacher who was not employed in England"
     )
   end
 
   def then_i_see_the_no_jurisdiction_unsupervised_page
     expect(page).to have_current_path("/no-jurisdiction-unsupervised")
     expect(page).to have_title(
-      "You need to report this misconduct somewhere else - Refer serious misconduct by a teacher in England"
+      [
+        "You cannot use this service to refer someone who is not a teacher",
+        "Refer serious misconduct by a teacher in England"
+      ].join(" - ")
     )
     expect(page).to have_content(
-      "You need to report this misconduct somewhere else"
+      "You cannot use this service to refer someone who is not a teacher"
     )
   end
 
@@ -176,13 +182,11 @@ RSpec.feature "Eligibility screener", type: :system do
     expect(page).to have_current_path("/no-complaint")
     expect(page).to have_title(
       [
-        "Make a complaint to the school, school governors or your local council first",
+        "Consider making a complaint first",
         "Refer serious misconduct by a teacher in England"
       ].join(" - ")
     )
-    expect(page).to have_content(
-      "Make a complaint to the school, school governors or your local council first"
-    )
+    expect(page).to have_content("Consider making a complaint first")
   end
 
   def then_i_see_the_you_should_know_page


### PR DESCRIPTION
### Context

Update copy for exit pages

### Changes proposed in this pull request

Update the copy for the following pages:
- /no-jurisdiction
- /no-jurisdiction-unsupervised
- /no-complaint

<img width="1143" alt="Screenshot 2023-02-08 at 11 52 25" src="https://user-images.githubusercontent.com/1955084/217532083-f2972023-251a-405d-8052-5fb72e1d150a.png">

<img width="1146" alt="Screenshot 2023-02-08 at 11 56 02" src="https://user-images.githubusercontent.com/1955084/217532093-19ac3e81-ac52-4456-b670-6e7055e03967.png">

<img width="1086" alt="Screenshot 2023-02-08 at 12 04 16" src="https://user-images.githubusercontent.com/1955084/217532096-06acbb3a-4ae4-4fe3-8bde-8d7f67a9d7a3.png">

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/JQjdRXan

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
