### PR TITLE
Skip account page if referral_form flag is disabled

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,7 +6,7 @@ class PagesController < ApplicationController
       if FeatureFlags::FeatureFlag.active?(:referral_form)
         current_user ? referral_type_path : users_registrations_exists_path
       else
-        users_registrations_exists_path
+        referral_type_path
       end
   end
 

--- a/spec/system/screener/user_completes_eligibility_screener_with_inactive_employer_form_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_with_inactive_employer_form_spec.rb
@@ -30,9 +30,6 @@ RSpec.feature "Eligibility screener", type: :system do
   def when_i_complete_the_screener
     click_on "Start now"
 
-    choose "No", visible: false
-    click_on "Continue"
-
     choose "I’m referring as an employer", visible: false
     click_on "Continue"
 


### PR DESCRIPTION
### Context

Check 'referral form' feature flag for 'Do you have an account' page (and disable it)

### Changes proposed in this pull request

We only want to ask people if they have an account when the referral form is active.

Add a check for the flag and if it is disabled skip the ‘Do you have an account’ page and go to the public/employer page.


### Link to Trello card

https://trello.com/c/KViu0loh/1193-check-referral-form-feature-flag-for-do-you-have-an-account-page-and-disable-it

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
