### PR TITLE
Modify change links

### DIFF
--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -76,7 +76,7 @@ class PersonalDetailsComponent < ViewComponent::Base
               [:edit, referral.routing_scope, referral, :personal_details_name],
               return_to: request.path
             ),
-          visually_hidden_text: "their other name"
+          visually_hidden_text: "other name"
         }
       ],
       key: {
@@ -241,7 +241,7 @@ class PersonalDetailsComponent < ViewComponent::Base
               ],
               return_to: request.path
             ),
-          visually_hidden_text: "their National Insurance number"
+          visually_hidden_text: "National Insurance number"
         }
       ],
       key: {

--- a/app/components/previous_misconduct_component.rb
+++ b/app/components/previous_misconduct_component.rb
@@ -65,7 +65,7 @@ class PreviousMisconductComponent < ViewComponent::Base
               :detailed_account,
               { return_to: }
             ],
-            visually_hidden_text: "details"
+            visually_hidden_text: "detailed account"
           }
         ],
         key: {

--- a/app/components/public_allegation_component.rb
+++ b/app/components/public_allegation_component.rb
@@ -54,7 +54,7 @@ class PublicAllegationComponent < ViewComponent::Base
                 return_to: request.path
               ),
             visually_hidden_text:
-              "how you want to give details about the allegation?"
+              "how you want to give details about the allegation"
           }
         ],
         key: {

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -166,7 +166,7 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
   end
 
   def when_i_click_change_details
-    click_on "Change details"
+    click_on "Change detailed account"
   end
 
   def when_i_click_change_previous_misconduct_reported


### PR DESCRIPTION
The convention from the designers is to ensure the change link for the
check answers pages simply prefix the related label with the word
"Change".

This change ensures we style aligned with that convention.

### Link to Trello card

https://trello.com/c/zkogJ9PS/1137-change-links-have-visually-hidden-text

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
