### PR TITLE
Update password policy

### DIFF
--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -12,6 +12,17 @@ class Staff < ApplicationRecord
     :validatable
   )
 
+  validate :password_complexity
+
+  def password_complexity
+    if password.blank? ||
+         password =~ /(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-])/
+      return
+    end
+
+    errors.add(:password, :password_complexity)
+  end
+
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -228,7 +228,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
@@ -244,27 +244,27 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
-  # config.unlock_keys = [:email]
+  config.unlock_keys = [:email]
 
   # Defines which strategy will be used to unlock an account.
   # :email = Sends an unlock link to the user email
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :time
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 5
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
+  config.unlock_in = 15.minutes
 
   # Warn on the last attempt before the account is locked.
-  # config.last_attempt_warning = true
+  config.last_attempt_warning = true
 
   # ==> Configuration for :recoverable
   #

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -368,6 +368,10 @@ en:
             email:
               blank: Enter your email
               invalid: Enter an email address in the correct format, like name@example.com
+        staff:
+          attributes:
+            password:
+              password_complexity: "complexity requirement not met. Please use: 1 uppercase, 1 lowercase, 1 digit and 1 special character"
 
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com

--- a/spec/factories/staffs.rb
+++ b/spec/factories/staffs.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :staff do
     email { "test@example.org" }
-    password { "example" }
+    password { "Example123!" }
   end
 end

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -1,1 +1,45 @@
 require "rails_helper"
+
+RSpec.describe Staff, type: :model do
+  describe "validations" do
+    subject { staff.valid? }
+
+    context "when the password is valid" do
+      let(:staff) { build(:staff, password: "Password123!") }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when the password is invalid" do
+      context "when the password is too short" do
+        let(:staff) { build(:staff, password: "password") }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context "when the password does not contain an uppercase letter" do
+        let(:staff) { build(:staff, password: "password123!") }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context "when the password does not contain a lowercase letter" do
+        let(:staff) { build(:staff, password: "PASSWORD123!") }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context "when the password does not contain a digit" do
+        let(:staff) { build(:staff, password: "Password!") }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context "when the password does not contain a special character" do
+        let(:staff) { build(:staff, password: "Password123") }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
+end

--- a/spec/system/support/staff_user_sends_account_invitation_spec.rb
+++ b/spec/system/support/staff_user_sends_account_invitation_spec.rb
@@ -97,8 +97,8 @@ RSpec.feature "Staff invitations", type: :system do
   end
 
   def when_i_fill_password
-    fill_in "staff-password-field", with: "password"
-    fill_in "staff-password-confirmation-field", with: "password"
+    fill_in "staff-password-field", with: "Password123!"
+    fill_in "staff-password-confirmation-field", with: "Password123!"
   end
 
   def and_i_set_password


### PR DESCRIPTION
### Context

The password policy applied to staff user accounts was found to be too
weak.

### Changes proposed in this pull request

- password minimum length 8 characters
- lowercase letter, uppercase letter, number and special character
- lockout after 5 attempts for 15 minutes

### Link to Trello card

https://trello.com/c/SV8XV0mW/1189-update-password-policy

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
