### PR TITLE
Add Content Security Policy headers

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -21,9 +21,9 @@
   </head>
 
   <body class="govuk-template__body">
-    <script>
+    <%= javascript_tag nonce: true do %>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <% end %>
 
     <%= govuk_skip_link %>
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,24 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src :self, :https, :data
+    policy.img_src :self, :https, :data
+    policy.object_src :none
+    policy.script_src :self, :https
+    policy.style_src :self, :https
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap and inline scripts
+  config.content_security_policy_nonce_generator = ->(request) do
+    request.session.id.to_s
+  end
+  config.content_security_policy_nonce_directives = %w[script-src]
+
+  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
+end


### PR DESCRIPTION
The default headers provided by Rails are a good fit for our purposes.

One thing this disallows is inline <script> tags.

To use them, they needed to be signed using the `nonce: true` option.

### Link to Trello card

https://trello.com/c/IIC75rSh/1190-add-missing-security-headers

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1161" alt="Screenshot 2023-02-09 at 12 26 44 pm" src="https://user-images.githubusercontent.com/3126/217812573-3684a88c-d7f0-401c-bc59-b51c982157cf.png">
