### PR TITLE
Remove PLPGSQL extension

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,6 @@
 ActiveRecord::Schema[7.0].define(version: 2023_02_06_144743) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
-  enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -49,7 +49,7 @@ resource "azurerm_postgresql_flexible_server" "postgres-server" {
 resource "azurerm_postgresql_flexible_server_configuration" "postgres-extensions" {
   name      = "azure.extensions"
   server_id = azurerm_postgresql_flexible_server.postgres-server.id
-  value     = "PLPGSQL,PGCRYPTO"
+  value     = "PGCRYPTO"
 }
 
 resource "azurerm_postgresql_flexible_server_database" "postgres-database" {


### PR DESCRIPTION
### Context

The plgpsql extension has got into the DB schema. We don't need it. 

### Changes proposed in this pull request
* Remove from the schema

It's causing issues deploying review apps and we don't use it. This will get readded with local migrations if the local DB has it so we'll need to take care not to reintroduce it.