### PR TITLE
Add logstop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "govuk_feature_flags",
     tag: "v1.0.0"
 gem "govuk_markdown", "~> 1.0"
 gem "jsbundling-rails"
+gem "logstop"
 gem "mail-notify"
 gem "okcomputer", "~> 1.18"
 gem "pagy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,7 @@ GEM
       kramdown (~> 2.0)
     launchy (2.5.2)
       addressable (~> 2.8)
+    logstop (0.3.0)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -443,6 +444,7 @@ DEPENDENCIES
   govuk_markdown (~> 1.0)
   jsbundling-rails
   launchy
+  logstop
   mail-notify
   okcomputer (~> 1.18)
   pagy

--- a/config/initializers/logstop.rb
+++ b/config/initializers/logstop.rb
@@ -1,0 +1,1 @@
+Logstop.guard(Rails.logger)


### PR DESCRIPTION
Logstop scrubs logs of PII.

The default settings ensure that anything that looks like any of the
following is prevented from being written to the logs:

* password in a URL
* email address
* phone number
* credit card number

### Link to Trello card

https://trello.com/c/mX3itrVw/1166-update-config-initializers-filterparameterloggingrb

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
