### PR TITLE
Extend scrubbing the logs by parameter name

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -13,4 +13,18 @@ Rails.application.config.filter_parameters += %i[
   certificate
   otp
   ssn
+  first_name
+  last_name
+  date_of_birth
+  previous_name
+  phone_number
+  phone
+  trn
+  duties_details
+  allegation_consideration_details
+  previous_misconduct_details
+  current_sign_in_ip
+  last_sign_in_ip
+  ni_number
+  unconfirmed_email
 ]


### PR DESCRIPTION
Rails has a built-in log scrubber that uses a list of parameter names to
scrub.

This change extends that list to include fields that could potentially
contain PII.

### Link to Trello card

https://trello.com/c/mX3itrVw/1166-update-config-initializers-filterparameterloggingrb

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
