### PR TITLE
Fix summary card margin

### DIFF
--- a/app/components/summary_card_component.html.erb
+++ b/app/components/summary_card_component.html.erb
@@ -1,6 +1,6 @@
 <section class="app-govuk-summary-card">
   <%= content %>
   <div class="app-govuk-summary-card__body">
-    <%= govuk_summary_list(rows:) %>
+    <%= govuk_summary_list(rows:, classes: ["govuk-!-margin-bottom-6"],) %>
   </div>
 </section>


### PR DESCRIPTION
### Context

A small tweak to the margin so it matches the prototype

Before

<img width="687" alt="Screenshot 2023-02-15 at 09 15 13" src="https://user-images.githubusercontent.com/1636476/218985437-1ec225de-c158-4eb2-bca7-044f3aa16e36.png">

After

<img width="684" alt="Screenshot 2023-02-15 at 09 14 51" src="https://user-images.githubusercontent.com/1636476/218985497-cb243b9e-db72-4dd0-b923-2cfb43de7642.png">

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
