### PR TITLE
Add missing methods to support policy

### DIFF
--- a/app/policies/support_policy.rb
+++ b/app/policies/support_policy.rb
@@ -16,4 +16,16 @@ class SupportPolicy < ApplicationPolicy
 
     false
   end
+
+  def activate?
+    return user.view_support? if user.is_a?(Staff)
+
+    false
+  end
+
+  def deactivate?
+    return user.view_support? if user.is_a?(Staff)
+
+    false
+  end
 end

--- a/spec/policies/management_policy_spec.rb
+++ b/spec/policies/management_policy_spec.rb
@@ -11,44 +11,12 @@ RSpec.describe ManagementPolicy do
   describe "#index?" do
     subject(:index?) { policy.index? }
 
-    context "without permission" do
-      let(:user) { create(:staff, :confirmed) }
-
-      it { is_expected.to be false }
-    end
-
-    context "with permission" do
-      let(:user) { create(:staff, :confirmed, :can_manage_referrals) }
-
-      it { is_expected.to be true }
-    end
-
-    context "with AnonymousSupportUser" do
-      let(:user) { AnonymousSupportUser.new }
-
-      it { is_expected.to be false }
-    end
+    it_behaves_like "staff policy with permission", :can_manage_referrals
   end
 
   describe "#show?" do
     subject(:show?) { policy.show? }
 
-    context "without permission" do
-      let(:user) { create(:staff, :confirmed) }
-
-      it { is_expected.to be false }
-    end
-
-    context "with permission" do
-      let(:user) { create(:staff, :confirmed, :can_manage_referrals) }
-
-      it { is_expected.to be true }
-    end
-
-    context "with AnonymousSupportUser" do
-      let(:user) { AnonymousSupportUser.new }
-
-      it { is_expected.to be false }
-    end
+    it_behaves_like "staff policy with permission", :can_manage_referrals
   end
 end

--- a/spec/policies/support_policy_spec.rb
+++ b/spec/policies/support_policy_spec.rb
@@ -11,66 +11,24 @@ RSpec.describe SupportPolicy do
   describe "#index?" do
     subject(:index?) { policy.index? }
 
-    context "without permission" do
-      let(:user) { create(:staff, :confirmed) }
-
-      it { is_expected.to be false }
-    end
-
-    context "with permission" do
-      let(:user) { create(:staff, :confirmed, :can_view_support) }
-
-      it { is_expected.to be true }
-    end
-
-    context "with AnonymousSupportUser" do
-      let(:user) { AnonymousSupportUser.new }
-
-      it { is_expected.to be false }
-    end
+    it_behaves_like "staff policy with permission", :can_view_support
   end
 
   describe "#create?" do
     subject(:create?) { policy.create? }
 
-    context "without permission" do
-      let(:user) { create(:staff, :confirmed) }
-
-      it { is_expected.to be false }
-    end
-
-    context "with permission" do
-      let(:user) { create(:staff, :confirmed, :can_view_support) }
-
-      it { is_expected.to be true }
-    end
-
-    context "with AnonymousSupportUser" do
-      let(:user) { AnonymousSupportUser.new }
-
-      it { is_expected.to be false }
-    end
+    it_behaves_like "staff policy with permission", :can_view_support
   end
 
-  describe "#authenticate?" do
-    subject(:authenticate?) { policy.authenticate? }
+  describe "#activate?" do
+    subject(:activate?) { policy.authenticate? }
 
-    context "without permission" do
-      let(:user) { create(:staff, :confirmed) }
+    it_behaves_like "staff policy with permission", :can_view_support
+  end
 
-      it { is_expected.to be false }
-    end
+  describe "#deactivate?" do
+    subject(:deactivate?) { policy.authenticate? }
 
-    context "with permission" do
-      let(:user) { create(:staff, :confirmed, :can_view_support) }
-
-      it { is_expected.to be true }
-    end
-
-    context "with AnonymousSupportUser" do
-      let(:user) { AnonymousSupportUser.new }
-
-      it { is_expected.to be false }
-    end
+    it_behaves_like "staff policy with permission", :can_view_support
   end
 end

--- a/spec/support/shared_examples/staff_policy_permission.rb
+++ b/spec/support/shared_examples/staff_policy_permission.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples "staff policy with permission" do |permission|
+  context "without permission" do
+    let(:user) { create(:staff, :confirmed) }
+
+    it { is_expected.to be false }
+  end
+
+  context "with permission" do
+    let(:user) { create(:staff, :confirmed, permission) }
+
+    it { is_expected.to be true }
+  end
+
+  context "with AnonymousSupportUser" do
+    let(:user) { AnonymousSupportUser.new }
+
+    it { is_expected.to be false }
+  end
+end


### PR DESCRIPTION
### Context

Without these permission activating/deactivating a feature was crashing the page. I also refactored the specs to use a shared example. @tavy88 related to https://github.com/DFE-Digital/refer-serious-misconduct/pull/472
