### PR TITLE
Add fallback redis URL in production cache config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,9 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_URL") }
+  config.cache_store =
+    :redis_cache_store,
+    { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
Needed in the deploy pipeline when building the app, the actual deployed environments have a REDIS_URL configured.
