### PR TITLE
Remove solargraph's require_not_found

### DIFF
--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -10,7 +10,6 @@ require: []
 domains: []
 reporters:
   - rubocop
-  - require_not_found
 formatter:
   rubocop:
     cops: safe


### PR DESCRIPTION
It inaccurately reports missing path for `rails_helper`
https://github.com/castwide/vscode-solargraph/issues/94