### PR TITLE
Prevent staff from accessing unsubmitted referrals

### DIFF
--- a/app/controllers/manage_interface/referrals_controller.rb
+++ b/app/controllers/manage_interface/referrals_controller.rb
@@ -24,7 +24,7 @@ module ManageInterface
     private
 
     def referral
-      @referral ||= Referral.find(params[:id])
+      @referral ||= Referral.submitted.find(params[:id])
     end
 
     def referral_zip_file


### PR DESCRIPTION
Incomplete referrals were accessible by changing the ID in the URL.