### PR TITLE
1213 - User sees new copy when the security code has expired

### DIFF
--- a/app/views/users/otp/retry.html.erb
+++ b/app/views/users/otp/retry.html.erb
@@ -1,18 +1,18 @@
-<h1 class="govuk-heading-l">There was a problem signing in</h1>
+<h1 class="govuk-heading-l"><%= t("users.retry.#{@error}.heading") %></h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% case @error %>
     <% when 'expired' %>
       <p>
-        <%= t('users.retry.expired') %>
+        <%= t("users.retry.#{@error}.body_html", href: govuk_link_to('request a new confirmation code', new_user_session_path(new_referral:), method: :get)) %>
       </p>
     <% when 'exhausted' %>
       <p>
-        <%= t('users.retry.exhausted') %>
+        <%= t('users.retry.exhausted.body') %>
       </p>
-    <% end %>
 
-    <%= govuk_button_link_to('Continue', new_user_session_path(new_referral:), method: :get) %>
+      <%= govuk_button_link_to('Continue', new_user_session_path(new_referral:), method: :get) %>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,8 +45,12 @@ en:
       minutes_strategy_meetings: Minutes of strategy meetings
   users:
     retry:
-      expired: Your security code has expired. Try again.
-      exhausted: You've had too many incorrect sign in attempts. Try again.
+      expired:
+        heading: Your confirmation code has expired
+        body_html: You need to %{href}.
+      exhausted:
+        heading: There was a problem signing in
+        body: You've had too many incorrect sign in attempts. Try again.
 
   activemodel:
     errors:

--- a/spec/system/user_auth/user_reaches_max_otp_guesses_spec.rb
+++ b/spec/system/user_auth/user_reaches_max_otp_guesses_spec.rb
@@ -43,8 +43,8 @@ RSpec.feature "User accounts" do
   end
 
   def then_i_see_an_error_screen
-    expect(page).to have_content "There was a problem signing in"
-    expect(page).to have_content I18n.t("users.retry.exhausted")
+    expect(page).to have_content I18n.t("users.retry.exhausted.heading")
+    expect(page).to have_content I18n.t("users.retry.exhausted.body")
   end
 
   def and_can_return_to_the_email_screen

--- a/spec/system/user_auth/user_tries_signing_in_with_expired_otp_spec.rb
+++ b/spec/system/user_auth/user_tries_signing_in_with_expired_otp_spec.rb
@@ -50,12 +50,12 @@ RSpec.feature "User accounts" do
   end
 
   def then_i_see_an_error_screen
-    expect(page).to have_content "There was a problem signing in"
-    expect(page).to have_content I18n.t("users.retry.expired")
+    expect(page).to have_content I18n.t("users.retry.expired.heading")
+    expect(page).to have_content "You need to request a new confirmation code."
   end
 
   def and_can_return_to_the_email_screen
-    click_link "Continue"
+    click_link "request a new confirmation code"
     expect(page).to have_content "Sign in"
   end
 


### PR DESCRIPTION
### Context

User sees new copy when the security code has expired

### Changes proposed in this pull request

![Screenshot 2023-02-17 at 11 19 26](https://user-images.githubusercontent.com/1955084/219636967-2d45183d-11bf-4f4d-b13a-60888e566e48.png)

### Link to Trello card

https://trello.com/c/g3XRtxGo

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
