### PR TITLE
1207 - Allow videos(mp4, mov) to be uploaded

### DIFF
--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -1,7 +1,7 @@
 class FileUploadValidator < ActiveModel::EachValidator
   include ActionView::Helpers::NumberHelper
 
-  MAX_FILE_SIZE = 25.megabytes
+  MAX_FILE_SIZE = 50.megabytes
   MAX_FILES = 10
 
   CONTENT_TYPES = {
@@ -16,6 +16,8 @@ class FileUploadValidator < ActiveModel::EachValidator
     ".jpg" => "image/jpeg",
     ".jpeg" => "image/jpeg",
     ".mp3" => "audio/mpeg",
+    ".mp4" => "video/mp4",
+    ".mov" => "video/quicktime",
     ".pdf" => "application/pdf",
     ".png" => "image/png",
     ".txt" => "text/plain",
@@ -33,7 +35,7 @@ class FileUploadValidator < ActiveModel::EachValidator
     uploaded_files.each do |uploaded_file|
       next if uploaded_file.nil?
 
-      if uploaded_file.size >= MAX_FILE_SIZE
+      if uploaded_file.size > MAX_FILE_SIZE
         record.errors.add(
           attribute,
           :file_size_too_big,

--- a/spec/validators/file_upload_validator_spec.rb
+++ b/spec/validators/file_upload_validator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe FileUploadValidator do
   context "with a large file" do
     let(:files) { fixture_file_upload("upload1.pdf", "application/pdf") }
 
-    before { allow(files).to receive(:size).and_return(25 * 1024 * 1024) }
+    before { allow(files).to receive(:size).and_return(51.megabytes) }
 
     it { is_expected.to be_invalid }
   end
@@ -73,6 +73,8 @@ RSpec.describe FileUploadValidator do
         .jpg
         .jpeg
         .mp3
+        .mp4
+        .mov
         .pdf
         .png
         .txt


### PR DESCRIPTION
### Context

 Allow videos(mp4, mov) to be uploaded
 Also adjust the max file size to 50MB.

### Changes proposed in this pull request

 Allow users to upload videos(mp4, mov) as evidence. Also increase the max file size to 50MB.

![Screenshot 2023-02-20 at 09 02 49](https://user-images.githubusercontent.com/1955084/220060519-3fcdd5f6-0b14-4b99-9a15-6718a3a4a137.png)


### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/HbMGSRS2

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
