### PR TITLE
Remove hint text option for eligibility screener form

### DIFF
--- a/app/views/serious_misconduct/new.html.erb
+++ b/app/views/serious_misconduct/new.html.erb
@@ -52,11 +52,7 @@
         <%= f.hidden_field :serious_misconduct %>
         <%= f.govuk_radio_button :serious_misconduct, "yes", label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :serious_misconduct, "no", label: { text: "No" } %>
-        <%= f.govuk_radio_button :serious_misconduct, "not_sure", label: { text: "I’m not sure" } do %>
-          <p class="govuk_body">
-            If you’re not sure, you should continue to make a referral and TRA will assess it.
-          </p>
-        <% end %>
+        <%= f.govuk_radio_button :serious_misconduct, "not_sure", label: { text: "I’m not sure" } %>
       <% end %>
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/teaching_in_england/new.html.erb
+++ b/app/views/teaching_in_england/new.html.erb
@@ -9,11 +9,7 @@
         <%= f.hidden_field :teaching_in_england %>
         <%= f.govuk_radio_button :teaching_in_england, "yes", label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :teaching_in_england, "no", label: { text: "No" } %>
-        <%= f.govuk_radio_button :teaching_in_england, "not_sure", label: { text: "I’m not sure" } do %>
-          <p class="govuk_body">
-            If you’re not sure, you should continue to make a referral and TRA will assess it.
-          </p>
-        <% end %>
+        <%= f.govuk_radio_button :teaching_in_england, "not_sure", label: { text: "I’m not sure" } %>
       <% end %>
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/unsupervised_teaching/new.html.erb
+++ b/app/views/unsupervised_teaching/new.html.erb
@@ -20,11 +20,7 @@
         <%= f.hidden_field :unsupervised_teaching %>
         <%= f.govuk_radio_button :unsupervised_teaching, "yes", label: { text: "Yes, they do unsupervised teaching work" }, link_errors: true %>
         <%= f.govuk_radio_button :unsupervised_teaching, "no", label: { text: "No" } %>
-        <%= f.govuk_radio_button :unsupervised_teaching, "not_sure", label: { text: "I’m not sure" } do %>
-          <p class="govuk_body">
-            If you’re not sure, you should continue to make a referral and TRA will assess it.
-          </p>
-        <% end %>
+        <%= f.govuk_radio_button :unsupervised_teaching, "not_sure", label: { text: "I’m not sure" } %>
       <% end %>
       <%= f.govuk_submit %>
     <% end %>

--- a/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
@@ -49,7 +49,6 @@ RSpec.feature "Eligibility screener", type: :system do
     when_i_press_continue
     then_i_see_a_validation_error
     when_i_choose_not_sure
-    then_i_see_the_not_sure_hint
     when_i_choose_no
     when_i_press_continue
     then_i_see_the_no_jurisdiction_unsupervised_page
@@ -61,7 +60,6 @@ RSpec.feature "Eligibility screener", type: :system do
     when_i_press_continue
     then_i_see_a_validation_error
     when_i_choose_not_sure
-    then_i_see_the_not_sure_hint
     when_i_choose_no
     when_i_press_continue
     then_i_see_the_no_jurisdiction_page
@@ -73,7 +71,6 @@ RSpec.feature "Eligibility screener", type: :system do
     when_i_press_continue
     then_i_see_a_validation_error
     when_i_choose_not_sure
-    then_i_see_the_not_sure_hint
     when_i_choose_no
     when_i_press_continue
     then_i_see_the_not_serious_misconduct_page
@@ -146,12 +143,6 @@ RSpec.feature "Eligibility screener", type: :system do
     )
     expect(page).to have_content(
       "You cannot use this service to refer someone who is not a teacher"
-    )
-  end
-
-  def then_i_see_the_not_sure_hint
-    expect(page).to have_content(
-      "If you’re not sure, you should continue to make a referral and TRA will assess it."
     )
   end
 


### PR DESCRIPTION
### Context

Remove hint text option for eligibility screener form

### Changes proposed in this pull request

<img width="862" alt="Screenshot 2023-02-20 at 13 14 59" src="https://user-images.githubusercontent.com/1955084/220119375-e2b5157c-c5ef-4354-8daf-44079ada216f.png">
<img width="857" alt="Screenshot 2023-02-20 at 13 15 49" src="https://user-images.githubusercontent.com/1955084/220119378-28fb3f90-d116-4dff-adf1-72202f54664f.png">
<img width="1043" alt="Screenshot 2023-02-20 at 13 16 30" src="https://user-images.githubusercontent.com/1955084/220119383-c8be52a3-855d-4046-a584-49e6ba46d53c.png">

### Link to Trello card

https://trello.com/c/3cR2olBt

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
