### PR TITLE
Enable connection throttle for postgres server

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -54,6 +54,12 @@ resource "azurerm_postgresql_flexible_server_configuration" "postgres-extensions
   value     = "PGCRYPTO"
 }
 
+resource "azurerm_postgresql_flexible_server_configuration" "postgres-connection-throttle-enable" {
+  name      = "connection_throttle.enable"
+  server_id = azurerm_postgresql_flexible_server.postgres-server.id
+  value     = "ON"
+}
+
 resource "azurerm_postgresql_flexible_server_database" "postgres-database" {
   name      = local.postgres_database_name
   server_id = azurerm_postgresql_flexible_server.postgres-server.id


### PR DESCRIPTION
### Context

ITHC finding recommends enabling connection throttling to improve database security.

### Changes proposed in this pull request

Set `connection_throttle.enable` server configuration setting to ON.

### Guidance to review

- Check deployed successfully
- Check that setting enabled on review app Postgres SQL db

### Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/kUFzG5bO)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
