### PR TITLE
Disable public access for allegations str accounts

### DIFF
--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -7,7 +7,7 @@ resource "azurerm_storage_account" "allegations" {
   account_kind                      = "StorageV2"
   min_tls_version                   = "TLS1_2"
   infrastructure_encryption_enabled = true
-  public_network_access_enabled     = false
+  allow_nested_items_to_be_public   = false
 
   blob_properties {
     last_access_time_enabled = true

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -7,6 +7,7 @@ resource "azurerm_storage_account" "allegations" {
   account_kind                      = "StorageV2"
   min_tls_version                   = "TLS1_2"
   infrastructure_encryption_enabled = true
+  public_network_access_enabled     = false
 
   blob_properties {
     last_access_time_enabled = true


### PR DESCRIPTION
### Context

ITHC finding recommends blocking public access to blobs at the account level.  Access is already set to private at the container level, this change reduces the likelihood of it being inadvertently made public.

### Changes proposed in this pull request

Sets `allow_nested_items_to_be_public` to false for the allegations storage account.

### Guidance to review

- Check deployed successfully
- Check that `Blob public access` is set to false in Azure Portal for `s165d01rsmallegr509` storage account

### Link to Trello card

https://trello.com/c/qm1eXTME

### Checklist

- [x] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
