### PR TITLE
Position the error summary correctly for evidence form

### DIFF
--- a/app/views/public_referrals/evidence/upload/edit.html.erb
+++ b/app/views/public_referrals/evidence/upload/edit.html.erb
@@ -3,40 +3,41 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">
-    <span class="govuk-caption-l">Evidence and supporting information</span>
-    <h1 class="govuk-heading-l">Upload evidence</h1>
-
-    <p>For example:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>complaint made to the school</li>
-      <li>correspondence with the school</li>
-      <li>school complaints policy</li>
-      <li>complaint made to the police</li>
-      <li>complaint made to the local authority or any other agency or body</li>
-      <li>signed witness statements</li>
-    </ul>
-
-    <p>Make sure the file names describe the content, for example ‘signed witness statement’.</p>
-
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive"></span>
-        Do not include explicit content, for example indecent photos. You’ll be asked for these separately if needed.
-      </strong>
-    </div>
-
     <%= form_with model: @evidence_upload_form, url: public_referral_evidence_upload_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
-
+    
+      <span class="govuk-caption-l">Evidence and supporting information</span>
+      <h1 class="govuk-heading-l">Upload evidence</h1>
+    
+      <p>For example:</p>
+    
+      <ul class="govuk-list govuk-list--bullet">
+        <li>complaint made to the school</li>
+        <li>correspondence with the school</li>
+        <li>school complaints policy</li>
+        <li>complaint made to the police</li>
+        <li>complaint made to the local authority or any other agency or body</li>
+        <li>signed witness statements</li>
+      </ul>
+    
+      <p>Make sure the file names describe the content, for example ‘signed witness statement’.</p>
+    
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive"></span>
+          Do not include explicit content, for example indecent photos. You’ll be asked for these separately if needed.
+        </strong>
+      </div>
+    
       <%= f.govuk_file_field(
           :evidence_uploads,
           multiple: true,
           label: { text: "Upload files", size: "m" }
       ) %>
-
+  
       <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>
 </div>
+


### PR DESCRIPTION
### Context

Position the error summary correctly for evidence form

### Changes proposed in this pull request

#### Before

![Screenshot 2023-02-21 at 13 39 28](https://user-images.githubusercontent.com/1955084/220361077-d3c329cb-1aca-4e4d-b2ca-82864ff73c47.png)

#### After
![Screenshot 2023-02-21 at 13 35 35](https://user-images.githubusercontent.com/1955084/220360624-2a5f1dcc-ab76-4f99-991f-17affad46252.png)

### Link to Trello card

N/A

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
