### PR TITLE
Fix broken user flow for Your Details section

### DIFF
--- a/app/views/referrals/referrers/show.html.erb
+++ b/app/views/referrals/referrers/show.html.erb
@@ -3,14 +3,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l">Your details</span>
-      Check and confirm your answers
-    </h1>
-
-    <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
+    
 
     <%= form_with model: @referrer_form, url: [current_referral.routing_scope, current_referral, :referrer], method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Your details</span>
+        Check and confirm your answers
+      </h1>
+
+      <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
+
+      <%= f.hidden_field :complete %>
+
       <%= f.govuk_radio_buttons_fieldset :complete, hint: { text: 'You can still make changes to a completed section' }, legend: { size: 'm', text: 'Have you completed this section?' } do %>
         <%= f.govuk_radio_button :complete, 'true', label: { text: "Yes, I’ve completed this section" }, link_errors: true %>
         <%= f.govuk_radio_button :complete, 'false', label: { text: "No, I’ll come back to it later" } %>

--- a/spec/support/system/common_steps.rb
+++ b/spec/support/system/common_steps.rb
@@ -75,6 +75,10 @@ module CommonSteps
     )
   end
 
+  def then_i_see_check_answers_form_validation_errors
+    expect(page).to have_content("Select yes if you’ve completed this section")
+  end
+
   def and_i_see_personal_details_flagged_as_incomplete
     within(".app-task-list__item", text: "Personal details") do
       status_tag = find(".app-task-list__tag")

--- a/spec/system/public_referrals/user_adds_their_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_their_details_spec.rb
@@ -27,6 +27,9 @@ RSpec.feature "Public Referral: About You", type: :system do
     then_i_see_the_referrer_check_your_answers_page
     and_i_see_my_answers_on_the_referrer_check_your_answers_page
 
+    when_i_click_save_and_continue
+    then_i_see_check_answers_form_validation_errors
+
     when_i_click_on_change_name
     then_i_am_on_the_your_name_page
     and_i_see_my_name_in_the_form_field

--- a/spec/system/referrals/user_adds_their_details_spec.rb
+++ b/spec/system/referrals/user_adds_their_details_spec.rb
@@ -34,6 +34,9 @@ RSpec.feature "Employer Referral: About You", type: :system do
     then_i_see_the_referrer_check_your_answers_page
     and_i_see_my_answers_on_the_referrer_check_your_answers_page
 
+    when_i_click_save_and_continue
+    then_i_see_check_answers_form_validation_errors
+
     when_i_click_on_change_name
     then_i_am_on_the_your_name_page
     and_i_see_my_name_in_the_form_field


### PR DESCRIPTION
### Context

Fix broken user flow for Your Details section

### Changes proposed in this pull request

If a user chooses to select neither Yes, nor No when asked if one has completed the section, then one should see a validation error

![Screenshot 2023-02-22 at 12 04 23](https://user-images.githubusercontent.com/1955084/220615997-d53b5932-5ca1-4314-80eb-71ac1b48092c.png)
 and the flow should not be interrupted.

### Link to Trello card

https://trello.com/c/ZamdjrA7

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
