### PR TITLE
Stop eligibility checker skipping questions if they are complete

### DIFF
--- a/app/controllers/eligibility_screener_controller.rb
+++ b/app/controllers/eligibility_screener_controller.rb
@@ -3,4 +3,16 @@ class EligibilityScreenerController < ApplicationController
   include RedirectIfFeatureFlagInactive
 
   before_action { redirect_if_feature_flag_inactive(:eligibility_screener) }
+
+  private
+
+  # Eligibility check is saved in the form objects
+  def eligibility_check
+    @eligibility_check ||=
+      EligibilityCheck.find_or_initialize_by(id: session[:eligibility_check_id])
+  end
+
+  def assign_eligibility_check_to_session
+    session[:eligibility_check_id] ||= eligibility_check.reload.id
+  end
 end

--- a/app/controllers/have_complained_controller.rb
+++ b/app/controllers/have_complained_controller.rb
@@ -8,9 +8,10 @@ class HaveComplainedController < EligibilityScreenerController
       HaveComplainedForm.new(
         have_complained_form_params.merge(eligibility_check:)
       )
+
     if @have_complained_form.save
       if eligibility_check.complained?
-        next_question
+        redirect_to_next_question
       else
         redirect_to(no_complaint_path)
       end

--- a/app/controllers/is_teacher_controller.rb
+++ b/app/controllers/is_teacher_controller.rb
@@ -6,8 +6,9 @@ class IsTeacherController < EligibilityScreenerController
   def create
     @is_teacher_form =
       IsTeacherForm.new(is_teacher_form_params.merge(eligibility_check:))
+
     if @is_teacher_form.save
-      next_question
+      redirect_to_next_question
     else
       render :new
     end

--- a/app/controllers/referral_type_controller.rb
+++ b/app/controllers/referral_type_controller.rb
@@ -6,9 +6,10 @@ class ReferralTypeController < EligibilityScreenerController
   def create
     @reporting_as_form =
       ReportingAsForm.new(reporting_as_params.merge(eligibility_check:))
+
     if @reporting_as_form.save
-      session[:eligibility_check_id] = eligibility_check.id
-      next_question
+      assign_eligibility_check_to_session
+      redirect_to_next_question
     else
       render :new
     end

--- a/app/controllers/serious_misconduct_controller.rb
+++ b/app/controllers/serious_misconduct_controller.rb
@@ -8,9 +8,10 @@ class SeriousMisconductController < EligibilityScreenerController
       SeriousMisconductForm.new(
         serious_misconduct_form_params.merge(eligibility_check:)
       )
+
     if @serious_misconduct_form.save
       if eligibility_check.serious_misconduct?
-        next_question
+        redirect_to_next_question
       else
         redirect_to(not_serious_misconduct_path)
       end

--- a/app/controllers/teaching_in_england_controller.rb
+++ b/app/controllers/teaching_in_england_controller.rb
@@ -8,9 +8,10 @@ class TeachingInEnglandController < EligibilityScreenerController
       TeachingInEnglandForm.new(
         teaching_in_england_form_params.merge(eligibility_check:)
       )
+
     if @teaching_in_england_form.save
       if eligibility_check.teaching_in_england?
-        next_question
+        redirect_to_next_question
       else
         redirect_to(no_jurisdiction_path)
       end
@@ -20,11 +21,6 @@ class TeachingInEnglandController < EligibilityScreenerController
   end
 
   private
-
-  def eligibility_check
-    @eligibility_check ||=
-      EligibilityCheck.find_by(id: session[:eligibility_check_id])
-  end
 
   def teaching_in_england_form_params
     params.require(:teaching_in_england_form).permit(:teaching_in_england)

--- a/app/controllers/unsupervised_teaching_controller.rb
+++ b/app/controllers/unsupervised_teaching_controller.rb
@@ -8,9 +8,10 @@ class UnsupervisedTeachingController < EligibilityScreenerController
       UnsupervisedTeachingForm.new(
         unsupervised_teaching_form_params.merge(eligibility_check:)
       )
+
     if @unsupervised_teaching_form.save
       if eligibility_check.unsupervised_teaching?
-        next_question
+        redirect_to_next_question
       else
         redirect_to(no_jurisdiction_unsupervised_path)
       end

--- a/lib/generators/form/templates/form_controller.erb
+++ b/lib/generators/form/templates/form_controller.erb
@@ -6,7 +6,7 @@ class <%= plural_name.camelize %>Controller < BaseController
   def create
     @<%= model_resource_name %>_form = <%= class_name %>Form.new(<%= model_resource_name %>_form_params.merge(<%= model.downcase %>: current_<%= model.downcase %>))
     if @<%= model_resource_name %>_form.save
-      next_question
+      redirect_to_next_question
     else
       render :new
     end

--- a/spec/system/screener/question_order_spec.rb
+++ b/spec/system/screener/question_order_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Question order", type: :system do
     when_i_visit_the_service
     then_i_see_the_start_page
 
+    # Visiting pages before completion
     when_i_visit_the_unsupervised_teaching_page
     then_i_see_the_start_page
 
@@ -24,6 +25,7 @@ RSpec.feature "Question order", type: :system do
     when_i_visit_the_complete_page
     then_i_see_the_start_page
 
+    # Partially completing screener
     when_i_press_start
     then_i_see_the_start_new_referral_page
 
@@ -32,21 +34,35 @@ RSpec.feature "Question order", type: :system do
     when_i_press_continue
     then_i_see_the_is_a_teacher_page
 
-    when_i_visit_unsupervised_teaching_page
+    # Visiting pages out of order before completion
+    when_i_visit_the_is_a_teacher_page
     then_i_see_the_is_a_teacher_page
 
-    when_i_visit_the_serious_misconduct_page
+    when_i_visit_the_unsupervised_teaching_page
+    then_i_see_the_start_page
+
+    # Resume and complete screener
+    when_i_visit_the_is_a_teacher_page
     then_i_see_the_is_a_teacher_page
 
     when_i_choose_yes
     when_i_press_continue
     then_i_see_the_teaching_in_england_page
 
-    when_i_visit_the_serious_misconduct_page
-    then_i_see_the_teaching_in_england_page
+    when_i_choose_yes
+    when_i_press_continue
+    then_i_see_the_serious_misconduct_page
+
+    when_i_choose_yes
+    when_i_press_continue
+    then_i_see_the_you_should_know_page
   end
 
   private
+
+  def then_i_see_the_have_you_complained_page
+    expect(page).to have_current_path("/have-you-complained")
+  end
 
   def then_i_see_the_is_a_teacher_page
     expect(page).to have_current_path("/is-a-teacher")
@@ -70,6 +86,14 @@ RSpec.feature "Question order", type: :system do
 
   def then_i_see_the_start_new_referral_page
     expect(page).to have_current_path("/users/registrations/exists")
+  end
+
+  def then_i_see_the_serious_misconduct_page
+    expect(page).to have_current_path("/serious-misconduct")
+  end
+
+  def then_i_see_the_you_should_know_page
+    expect(page).to have_current_path("/you-should-know")
   end
 
   def when_i_start_new_referral
@@ -105,7 +129,7 @@ RSpec.feature "Question order", type: :system do
     visit root_path
   end
 
-  def when_i_visit_unsupervised_teaching_page
+  def when_i_visit_the_unsupervised_teaching_page
     visit unsupervised_teaching_path
   end
 
@@ -119,5 +143,13 @@ RSpec.feature "Question order", type: :system do
 
   def when_i_visit_the_unsupervised_teaching_page
     visit unsupervised_teaching_path
+  end
+
+  def when_i_visit_the_have_you_complained_page
+    visit have_you_complained_path
+  end
+
+  def when_i_visit_the_is_a_teacher_page
+    visit is_a_teacher_path
   end
 end


### PR DESCRIPTION
### Context

To provide a consistent user experience every time someone visits the eligibility checker even if they have visited it before and answered some of the questions

### Changes proposed in this pull request

Fairly aggressive refactor of the `EnforceQuestionOrder` module. I had some difficulty understanding it and lost a couple of hours getting the tests to work. This could be because I'm new to the project but I thought I would make it easier to understand for the future. Please confirm this is the case!

### Link to Trello card

https://trello.com/c/VbZDKBS8/1219-use-of-session-data-in-the-eligibility-checker

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
