### PR TITLE
Configure review apps

### DIFF
--- a/bin/start-review-app.sh
+++ b/bin/start-review-app.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
 /usr/sbin/sshd
-export DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-bundle exec rails db:schema_load_or_migrate && bundle exec rails server -b 0.0.0.0
+
+bundle exec rails db:schema_load_or_migrate
+bundle exec rails runner "%i(eligibility_screener referral_form).each {|flag| FeatureFlags::FeatureFlag.activate(flag)}" 
+bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
### Context

When review apps are first created they don't work as the initial feature flags required aren't enabled.

### Changes proposed in this pull request

Enable 'em in the review app startup script

### Guidance to review

The review app on this PR should work.

### Checklist

- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
