### PR TITLE
Allow user to submit multiple referrals

### DIFF
--- a/app/components/about_you_component.rb
+++ b/app/components/about_you_component.rb
@@ -1,6 +1,7 @@
 class AboutYouComponent < ViewComponent::Base
   include ActiveModel::Model
   include ReferralHelper
+  include ComponentHelper
 
   attr_accessor :referral, :user
 
@@ -89,6 +90,6 @@ class AboutYouComponent < ViewComponent::Base
       }
     )
 
-    items
+    referral.submitted? ? remove_actions(items) : items
   end
 end

--- a/app/components/contact_details_component.rb
+++ b/app/components/contact_details_component.rb
@@ -1,17 +1,18 @@
 class ContactDetailsComponent < ViewComponent::Base
   include ActiveModel::Model
   include AddressHelper
+  include ComponentHelper
 
   attr_accessor :referral
 
   def rows
-    rows = [email_known_row]
-    rows.push(email_row) if referral.email_known
-    rows.push(phone_number_known_row)
-    rows.push(phone_number_row) if referral.phone_known
-    rows.push(address_known_row)
-    rows.push(address_row) if referral.address_known
-    rows
+    items = [email_known_row]
+    items.push(email_row) if referral.email_known
+    items.push(phone_number_known_row)
+    items.push(phone_number_row) if referral.phone_known
+    items.push(address_known_row)
+    items.push(address_row) if referral.address_known
+    referral.submitted? ? remove_actions(items) : items
   end
 
   def path_for(part)

--- a/app/components/evidence_component.rb
+++ b/app/components/evidence_component.rb
@@ -1,11 +1,13 @@
 class EvidenceComponent < ViewComponent::Base
   include ActiveModel::Model
   include ReferralHelper
+  include ComponentHelper
 
   attr_accessor :referral
 
   def rows
-    [anything_to_upload_row, evidence_row].compact
+    items = [anything_to_upload_row, evidence_row].compact
+    referral.submitted? ? remove_actions(items) : items
   end
 
   private

--- a/app/components/organisation_component.rb
+++ b/app/components/organisation_component.rb
@@ -1,13 +1,14 @@
 class OrganisationComponent < ViewComponent::Base
   include ActiveModel::Model
   include AddressHelper
+  include ComponentHelper
 
   attr_accessor :referral
 
   delegate :organisation, to: :referral
 
   def rows
-    [
+    items = [
       {
         actions: [
           {
@@ -31,6 +32,8 @@ class OrganisationComponent < ViewComponent::Base
         }
       }
     ]
+
+    referral.submitted? ? remove_actions(items) : items
   end
 
   def return_to

--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -1,25 +1,26 @@
 class PersonalDetailsComponent < ViewComponent::Base
   include ActiveModel::Model
   include ReferralHelper
+  include ComponentHelper
 
   attr_accessor :referral
 
   def rows
-    rows = [name_row, any_other_name_row]
+    items = [name_row, any_other_name_row]
 
-    rows.push(other_name_row) if referral.name_has_changed?
+    items.push(other_name_row) if referral.name_has_changed?
 
-    return rows if referral.from_member_of_public?
+    if referral.from_employer?
+      items.push(date_of_birth_known_row)
+      items.push(date_of_birth_row) if referral.age_known?
+      items.push(ni_number_known_row)
+      items.push(ni_number_row) if referral.ni_number_known?
+      items.push(trn_known_row)
+      items.push(trn_row) if referral.trn_known?
+      items.push(qts_row)
+    end
 
-    rows.push(date_of_birth_known_row)
-    rows.push(date_of_birth_row) if referral.age_known?
-    rows.push(ni_number_known_row)
-    rows.push(ni_number_row) if referral.ni_number_known?
-    rows.push(trn_known_row)
-    rows.push(trn_row) if referral.trn_known?
-    rows.push(qts_row)
-
-    rows
+    referral.submitted? ? remove_actions(items) : items
   end
 
   def any_other_name_row

--- a/app/components/previous_misconduct_component.rb
+++ b/app/components/previous_misconduct_component.rb
@@ -1,11 +1,12 @@
 class PreviousMisconductComponent < ViewComponent::Base
   include ActiveModel::Model
   include ApplicationHelper
+  include ComponentHelper
 
   attr_accessor :referral
 
   def rows
-    @rows = [
+    items = [
       {
         actions: [
           {
@@ -30,7 +31,7 @@ class PreviousMisconductComponent < ViewComponent::Base
       }
     ]
     if referral.previous_misconduct_reported?
-      @rows << {
+      items << {
         actions: [
           {
             text: "Change",
@@ -53,7 +54,7 @@ class PreviousMisconductComponent < ViewComponent::Base
           text: detail_type
         }
       }
-      @rows << {
+      items << {
         actions: [
           {
             text: "Change",
@@ -77,7 +78,7 @@ class PreviousMisconductComponent < ViewComponent::Base
       }
     end
 
-    @rows
+    referral.submitted? ? remove_actions(items) : items
   end
 
   def report

--- a/app/components/public_allegation_component.rb
+++ b/app/components/public_allegation_component.rb
@@ -1,5 +1,6 @@
 class PublicAllegationComponent < ViewComponent::Base
   include ActiveModel::Model
+  include ComponentHelper
 
   attr_accessor :referral
 
@@ -43,7 +44,7 @@ class PublicAllegationComponent < ViewComponent::Base
   end
 
   def rows
-    [
+    items = [
       {
         actions: [
           {
@@ -104,5 +105,7 @@ class PublicAllegationComponent < ViewComponent::Base
         }
       }
     ]
+
+    referral.submitted? ? remove_actions(items) : items
   end
 end

--- a/app/components/their_role_component.rb
+++ b/app/components/their_role_component.rb
@@ -2,37 +2,35 @@ class TheirRoleComponent < ViewComponent::Base
   include ActiveModel::Model
   include ReferralHelper
   include AddressHelper
+  include ComponentHelper
 
   attr_accessor :referral
 
   def rows
-    @rows = [job_title_row, role_duties_row, role_duties_description_row]
+    items = [job_title_row, role_duties_row, role_duties_description_row]
 
-    @rows << same_organisation_row if referral.from_employer?
+    items << same_organisation_row if referral.from_employer?
 
     unless referral.same_organisation?
-      @rows << organisation_address_known_row
-      @rows << organisation_address_row if referral.organisation_address_known
+      items << organisation_address_known_row
+      items << organisation_address_row if referral.organisation_address_known
     end
 
-    @rows << start_date_known_row if referral.from_employer?
-    @rows << start_date_row if referral.role_start_date_known
-    @rows << employment_status_row if referral.from_employer?
+    items << start_date_known_row if referral.from_employer?
+    items << start_date_row if referral.role_start_date_known
+    items << employment_status_row if referral.from_employer?
 
-    return @rows unless referral.left_role?
+    if referral.left_role?
+      items << end_date_known_row
+      items << end_date_row if referral.role_end_date_known
+      items << reason_leaving_role_row
+      items << working_somewhere_else_row
 
-    @rows << end_date_known_row
-    @rows << end_date_row if referral.role_end_date_known
-    @rows << reason_leaving_role_row
-    @rows << working_somewhere_else_row
+      items << work_location_known_row if referral.working_somewhere_else?
+      items << work_location_row if referral.work_location_known
+    end
 
-    return @rows unless referral.working_somewhere_else?
-
-    @rows << work_location_known_row
-
-    return @rows unless referral.work_location_known
-
-    @rows << work_location_row
+    referral.submitted? ? remove_actions(items) : items
   end
 
   private

--- a/app/components/what_happened_component.rb
+++ b/app/components/what_happened_component.rb
@@ -1,11 +1,12 @@
 class WhatHappenedComponent < ViewComponent::Base
   include ActiveModel::Model
   include ReferralHelper
+  include ComponentHelper
 
   attr_accessor :referral
 
   def rows
-    [
+    items = [
       {
         actions: [
           {
@@ -73,6 +74,8 @@ class WhatHappenedComponent < ViewComponent::Base
         }
       }
     ]
+
+    referral.submitted? ? remove_actions(items) : items
   end
 
   def return_to

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,11 +10,21 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def redirect_to_referral_if_exists
-    latest_referral = current_user&.latest_referral
+  def referrals_redirect
+    redirect_to users_referrals_path and return if referrals_submitted?
 
-    if latest_referral
-      redirect_to [:edit, latest_referral.routing_scope, latest_referral]
-    end
+    referral_in_progress = current_user&.referral_in_progress
+
+    return unless referral_in_progress
+
+    redirect_to [
+                  :edit,
+                  referral_in_progress.routing_scope,
+                  referral_in_progress
+                ]
+  end
+
+  def referrals_submitted?
+    current_user&.referrals&.submitted&.present?
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 class PagesController < ApplicationController
   def start
-    redirect_to_referral_if_exists
+    referrals_redirect
 
     @start_now_path =
       if FeatureFlags::FeatureFlag.active?(:referral_form)

--- a/app/controllers/referrals_controller.rb
+++ b/app/controllers/referrals_controller.rb
@@ -1,6 +1,6 @@
 class ReferralsController < Referrals::BaseController
   before_action :check_referral_form_feature_flag_enabled
-  before_action :redirect_to_referral_if_exists, only: %i[new create]
+  before_action :referrals_redirect, only: %i[create]
   before_action :redirect_to_screener_if_no_id_in_session, only: %i[new create]
 
   def new

--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -51,18 +51,21 @@ class Users::OtpController < DeviseController
   private
 
   def after_sign_in_path_for(resource)
-    stored_location_for(resource) || latest_referral_path(resource)
+    stored_location_for(resource) || user_referrals(resource) ||
+      latest_referral_path(resource)
+  end
+
+  def user_referrals(resource)
+    return false if resource.referrals.submitted.blank?
+
+    users_referrals_path
   end
 
   def latest_referral_path(resource)
     latest_referral = resource.latest_referral
 
-    if latest_referral
-      if latest_referral.submitted_at?
-        [latest_referral.routing_scope, latest_referral, :confirmation]
-      else
-        [:edit, latest_referral.routing_scope, latest_referral]
-      end
+    if latest_referral.present?
+      [:edit, latest_referral.routing_scope, latest_referral]
     else
       new_referral_path
     end

--- a/app/controllers/users/referrals_controller.rb
+++ b/app/controllers/users/referrals_controller.rb
@@ -1,0 +1,13 @@
+module Users
+  class ReferralsController < Referrals::BaseController
+    def index
+      @referrals_submitted =
+        current_user.referrals.submitted.order(submitted_at: :desc)
+      @referral_in_progress = current_user.referral_in_progress
+    end
+
+    def show
+      @referral = current_user.referrals.find(params[:id])
+    end
+  end
+end

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -16,7 +16,7 @@ class ReferralForm
   end
 
   def submit
-    return false unless valid?
+    return false if !valid? || referral.submitted?
 
     referral.submit
   end

--- a/app/helpers/component_helper.rb
+++ b/app/helpers/component_helper.rb
@@ -1,0 +1,5 @@
+module ComponentHelper
+  def remove_actions(items)
+    items.map { |item| item.tap { |i| i.delete(:actions) } }
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -76,4 +76,8 @@ class Referral < ApplicationRecord
   def name
     [first_name, last_name].join(" ")
   end
+
+  def submitted?
+    submitted_at.present?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,10 @@ class User < ApplicationRecord
           -> { order(created_at: :desc) },
           class_name: "Referral"
 
+  has_one :referral_in_progress,
+          -> { where(submitted_at: nil).order(created_at: :desc) },
+          class_name: "Referral"
+
   scope :newest_first, -> { order(created_at: :desc) }
 
   after_commit :reload_uuid, on: :create

--- a/app/views/public_referrals/review/show.html.erb
+++ b/app/views/public_referrals/review/show.html.erb
@@ -10,32 +10,7 @@
 
           <h1 class="govuk-heading-l govuk-!-margin-bottom-9">Check details and send referral</h1>
 
-          <div class="app-review-panel">
-            <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
-
-            <h3 class="govuk-heading-m">Your details</h3>
-            <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
-          </div>
-
-          <div class="app-review-panel">
-            <h2 class="govuk-heading-m govuk-!-font-size-27">About the teacher</h2>
-
-            <h3 class="govuk-heading-m">Personal details</h3>
-            <%= render PersonalDetailsComponent.new(referral: current_referral) %>
-
-            <h3 class="govuk-heading-m">About their role</h3>
-            <%= render TheirRoleComponent.new(referral: current_referral) %>
-          </div>
-
-          <div class="app-review-panel">
-            <h2 class="govuk-heading-m govuk-!-font-size-27">The allegation</h2>
-
-            <h3 class="govuk-heading-m">Allegation details</h3>
-            <%= render PublicAllegationComponent.new(referral: current_referral) %>
-
-            <h3 class="govuk-heading-m">Evidence and supporting information</h3>
-            <%= render EvidenceComponent.new(referral: current_referral) %>
-          </div>
+          <%= render "public_referrals/shared/review" %>
 
           <h2 class="govuk-heading-m govuk-!-font-size-27">Declaration</h2>
 

--- a/app/views/public_referrals/shared/_review.html.erb
+++ b/app/views/public_referrals/shared/_review.html.erb
@@ -1,0 +1,26 @@
+<div class="app-review-panel">
+  <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
+
+  <h3 class="govuk-heading-m">Your details</h3>
+  <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
+</div>
+
+<div class="app-review-panel">
+  <h2 class="govuk-heading-m govuk-!-font-size-27">About the teacher</h2>
+
+  <h3 class="govuk-heading-m">Personal details</h3>
+  <%= render PersonalDetailsComponent.new(referral: current_referral) %>
+
+  <h3 class="govuk-heading-m">About their role</h3>
+  <%= render TheirRoleComponent.new(referral: current_referral) %>
+</div>
+
+<div class="app-review-panel">
+  <h2 class="govuk-heading-m govuk-!-font-size-27">The allegation</h2>
+
+  <h3 class="govuk-heading-m">Allegation details</h3>
+  <%= render PublicAllegationComponent.new(referral: current_referral) %>
+
+  <h3 class="govuk-heading-m">Evidence and supporting information</h3>
+  <%= render EvidenceComponent.new(referral: current_referral) %>
+</div>

--- a/app/views/referrals/confirmation/show.html.erb
+++ b/app/views/referrals/confirmation/show.html.erb
@@ -7,7 +7,7 @@
       classes: %w[govuk-!-margin-bottom-6]
     ) %>
     <p class="govuk_body">
-      You’ll be sent a confirmation email. This email will include a link to <%= link_to "view your referral", [current_referral.routing_scope, current_referral, :review] %></a>.
+      You’ll be sent a confirmation email. This email will include a link to <%= link_to "view your referral", users_referral_path(current_referral) %></a>.
     </p>
 
     <h2 class="govuk-heading-m">What happens next</h2>

--- a/app/views/referrals/review/show.html.erb
+++ b/app/views/referrals/review/show.html.erb
@@ -10,41 +10,7 @@
 
           <h1 class="govuk-heading-l govuk-!-margin-bottom-9">Check details and send referral</h1>
 
-          <div class="app-review-panel">
-            <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
-
-            <h3 class="govuk-heading-m">Your details</h3>
-            <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
-
-            <h3 class="govuk-heading-m">Your organisation</h3>
-            <%= render OrganisationComponent.new(referral: current_referral) %>
-          </div>
-
-          <div class="app-review-panel">
-            <h2 class="govuk-heading-m govuk-!-font-size-27">About the teacher</h2>
-
-            <h3 class="govuk-heading-m">Personal details</h3>
-            <%= render PersonalDetailsComponent.new(referral: current_referral) %>
-
-            <h3 class="govuk-heading-m">Contact details</h3>
-            <%= render ContactDetailsComponent.new(referral: current_referral) %>
-
-            <h3 class="govuk-heading-m">About their role</h3>
-            <%= render TheirRoleComponent.new(referral: current_referral) %>
-          </div>
-
-          <div class="app-review-panel">
-            <h2 class="govuk-heading-m govuk-!-font-size-27">The allegation</h2>
-
-            <h3 class="govuk-heading-m">Allegation details</h3>
-            <%= render WhatHappenedComponent.new(referral: current_referral) %>
-
-            <h3 class="govuk-heading-m">Previous allegation details</h3>
-            <%= render PreviousMisconductComponent.new(referral: current_referral) %>
-
-            <h3 class="govuk-heading-m">Evidence and supporting information</h3>
-            <%= render EvidenceComponent.new(referral: current_referral) %>
-          </div>
+          <%= render "referrals/shared/review" %>
 
           <h2 class="govuk-heading-m govuk-!-font-size-27">Declaration</h2>
 

--- a/app/views/referrals/shared/_review.html.erb
+++ b/app/views/referrals/shared/_review.html.erb
@@ -1,0 +1,35 @@
+<div class="app-review-panel">
+  <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
+
+  <h3 class="govuk-heading-m">Your details</h3>
+  <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
+
+  <h3 class="govuk-heading-m">Your organisation</h3>
+  <%= render OrganisationComponent.new(referral: current_referral) %>
+</div>
+
+<div class="app-review-panel">
+  <h2 class="govuk-heading-m govuk-!-font-size-27">About the teacher</h2>
+
+  <h3 class="govuk-heading-m">Personal details</h3>
+  <%= render PersonalDetailsComponent.new(referral: current_referral) %>
+
+  <h3 class="govuk-heading-m">Contact details</h3>
+  <%= render ContactDetailsComponent.new(referral: current_referral) %>
+
+  <h3 class="govuk-heading-m">About their role</h3>
+  <%= render TheirRoleComponent.new(referral: current_referral) %>
+</div>
+
+<div class="app-review-panel">
+  <h2 class="govuk-heading-m govuk-!-font-size-27">The allegation</h2>
+
+  <h3 class="govuk-heading-m">Allegation details</h3>
+  <%= render WhatHappenedComponent.new(referral: current_referral) %>
+
+  <h3 class="govuk-heading-m">Previous allegation details</h3>
+  <%= render PreviousMisconductComponent.new(referral: current_referral) %>
+
+  <h3 class="govuk-heading-m">Evidence and supporting information</h3>
+  <%= render EvidenceComponent.new(referral: current_referral) %>
+</div>

--- a/app/views/users/referrals/index.html.erb
+++ b/app/views/users/referrals/index.html.erb
@@ -1,0 +1,37 @@
+<% content_for :page_title, "Your referrals" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Your referrals</h1>
+
+    <% if @referral_in_progress %>
+      <%= govuk_inset_text do %>
+        <p>You have a referral that you have not sent.</p>
+        <%= govuk_button_link_to "Complete referral", [:edit, @referral_in_progress.routing_scope, @referral_in_progress] %>
+      <% end %>
+    <% else %>
+      <%= govuk_button_link_to "Start new referral", new_referral_path %>
+    <% end %>
+
+    <% if @referrals_submitted.any? %>
+      <h2 class="govuk-heading-m">Sent referrals</h2>
+
+      <% @referrals_submitted.each do |referral| %>
+        <div class="app-list govuk-!-margin-top-6">
+          <div class="app-list__item">
+
+            <h2 class="govuk-heading-m">
+              <%= govuk_link_to(referral.name, users_referral_path(referral), { no_visited_state: true }) %>
+            </h2>
+
+            <%= govuk_summary_list(actions: false, classes: ["govuk-summary-list--no-border", "app-summary-list--compact"]) do |summary_list|
+            summary_list.with_row do |row|
+            row.with_key { "Referral date" }
+            row.with_value { referral.submitted_at.to_fs(:day_month_year_time) }
+            end; end %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/referrals/show.html.erb
+++ b/app/views/users/referrals/show.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title, "Your referral #{current_referral.referrer_name}" %>
+<% content_for :back_link_url, users_referrals_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l">Your referral</span>
+        <h1 class="govuk-heading-l"><%= current_referral.referrer_name %></h1>
+        <p class="govuk-!-margin-bottom-8">You sent this referral on <%= current_referral.submitted_at.to_fs(:day_month_year_time) %>.</p>
+
+        <% if current_referral.from_employer? %>
+          <%= render "referrals/shared/review" %>
+        <% else %>
+          <%= render "public_referrals/shared/review" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,10 @@ Rails.application.routes.draw do
         }
 
     get "/users/sign_out", to: "users/sessions#destroy"
+
+    namespace :users do
+      resources :referrals, only: %i[index show]
+    end
   end
 
   constraints(


### PR DESCRIPTION
### Context

Enable users to submit more than one referral.

### Changes proposed in this pull request

- add user referrals index and show pages
- display components without actions if the referral is submitted
- change the login redirect logic to go to the referral in progress or the list of referrals if there are submitted referrals
- use partials for review pages

Index page:
<img width="500" alt="Screenshot 2023-02-23 at 16 14 22" src="https://user-images.githubusercontent.com/1636476/220966920-245202bd-6395-414a-b93a-e6d496420d26.png">
<img width="455" alt="Screenshot 2023-02-23 at 16 14 30" src="https://user-images.githubusercontent.com/1636476/220966959-b3cc89b4-5fac-46c7-b019-f77951508e21.png">

Show page:
<img width="450" alt="Screenshot 2023-02-23 at 16 20 34" src="https://user-images.githubusercontent.com/1636476/220967088-6c2430a4-0ed9-441e-a077-784919831799.png">

### Link to Trello card

https://trello.com/c/kmmoSVaV/1211-enable-users-to-submit-more-than-one-referral

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
