### PR TITLE
1221 - Improve user flow for case workers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,10 @@ Rails/ApplicationController:
   Exclude:
     - app/controllers/support_interface/support_interface_controller.rb
 
+Rails/LexicallyScopedActionFilter:
+  Exclude:
+    - app/controllers/staff/**/*
+
 Rails/SaveBang:
   Enabled: false
 

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -2,6 +2,8 @@
 
 class Staff::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  skip_before_action :require_no_authentication, only: %i[new]
+  before_action :check_signed_in, only: %i[new]
 
   # GET /resource/sign_in
   # def new
@@ -18,10 +20,29 @@ class Staff::SessionsController < Devise::SessionsController
   #   super
   # end
 
+  def after_sign_in_path_for(_resource)
+    if current_staff.manage_referrals?
+      manage_interface_referrals_path
+    elsif current_staff.view_support?
+      support_interface_staff_index_path
+    else
+      flash[:warning] = I18n.t("pundit.unauthorized")
+      root_path
+    end
+  end
+
   # protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  private
+
+  def check_signed_in
+    return unless signed_in?
+
+    redirect_to after_sign_in_path_for(resource)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,10 +26,46 @@ module ApplicationHelper
   end
 
   def navigation
-    govuk_header(service_name: t("service.name")) do |header|
+    govuk_header(service_name:) do |header|
       case current_namespace
       when "manage"
         if current_staff # TODO: replace with case worker user type
+          header.navigation_item(
+            active: current_page?(main_app.manage_interface_referrals_path),
+            href: main_app.manage_interface_referrals_path,
+            text: "Referrals"
+          )
+          if current_staff.view_support?
+            header.navigation_item(
+              active:
+                current_page?(
+                  main_app.support_interface_eligibility_checks_path
+                ),
+              href: main_app.support_interface_eligibility_checks_path,
+              text: "Eligibility Checks"
+            )
+            header.navigation_item(
+              active:
+                current_page?(main_app.support_interface_feature_flags_path),
+              href: main_app.support_interface_feature_flags_path,
+              text: "Features"
+            )
+            header.navigation_item(
+              active: request.path.start_with?("/support/staff"),
+              text: "Staff",
+              href: main_app.support_interface_staff_index_path
+            )
+            if HostingEnvironment.test_environment?
+              header.navigation_item(
+                active:
+                  request.path.start_with?(
+                    main_app.support_interface_test_users_path
+                  ),
+                text: "Test Users",
+                href: main_app.support_interface_test_users_path
+              )
+            end
+          end
           header.navigation_item(
             href: main_app.staff_sign_out_path,
             text: "Sign out"
@@ -100,5 +136,13 @@ module ApplicationHelper
 
   def return_to_session_or(url)
     session[:return_to] || url
+  end
+
+  def service_name
+    if %w[manage support staff].include?(current_namespace)
+      return t("service.manage")
+    end
+
+    t("service.name")
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   service:
     name: Refer serious misconduct by a teacher in England
+    manage: Manage teacher misconduct referrals
     email: misconduct.teacher@education.gov.uk
     phone: 020 7593 5393
     url: https://refer-serious-misconduct.education.gov.uk

--- a/spec/support/system/authorization_steps.rb
+++ b/spec/support/system/authorization_steps.rb
@@ -1,26 +1,39 @@
 module AuthorizationSteps
-  def when_i_am_authorized_as_a_case_worker_with_management_permissions
-    user = create(:staff, :confirmed, :can_view_support, :can_manage_referrals)
+  def when_i_login_as_a_case_worker_with_management_permissions_only
+    create(:staff, :confirmed, :can_manage_referrals)
 
-    sign_in(user)
+    visit new_staff_session_path
+
+    fill_in "Email", with: "test@example.org"
+    fill_in "Password", with: "Example123!"
+
+    click_on "Log in"
   end
 
-  def when_i_am_authorized_as_a_case_worker_without_management_permissions
-    user = create(:staff, :confirmed, :can_view_support)
+  def when_i_login_as_a_case_worker_without_any_permissions_at_all
+    create(:staff, :confirmed)
 
-    sign_in(user)
+    visit new_staff_session_path
+
+    fill_in "Email", with: "test@example.org"
+    fill_in "Password", with: "Example123!"
+
+    click_on "Log in"
   end
 
-  def when_i_am_authorized_as_a_case_worker_with_support_permissions
-    user = create(:staff, :confirmed, :can_view_support)
+  def when_i_login_as_a_case_worker_with_support_permissions_only
+    create(:staff, :confirmed, :can_view_support)
 
-    sign_in(user)
+    visit new_staff_session_path
+
+    fill_in "Email", with: "test@example.org"
+    fill_in "Password", with: "Example123!"
+
+    click_on "Log in"
   end
 
-  def when_i_am_authorized_as_a_case_worker_without_support_permissions
-    user = create(:staff, :confirmed)
-
-    sign_in(user)
+  def when_i_visit_staff_sign_in_page
+    visit new_staff_session_path
   end
 
   def when_i_am_authorized_with_basic_auth_as_a_case_worker
@@ -35,5 +48,14 @@ module AuthorizationSteps
   def then_i_am_unauthorized_and_redirected_to_root_path
     expect(page).to have_current_path("/start")
     expect(page).to have_content("You are not authorized to see this section.")
+  end
+
+  def then_i_see_the_staff_index
+    expect(page).to have_current_path("/support/staff")
+    expect(page).to have_title("Staff")
+  end
+
+  def then_i_see_manage_referrals_page
+    expect(page).to have_current_path("/manage/referrals")
   end
 end

--- a/spec/system/manage/case_worker_with_permissions_views_a_public_referral_spec.rb
+++ b/spec/system/manage/case_worker_with_permissions_views_a_public_referral_spec.rb
@@ -11,7 +11,12 @@ RSpec.feature "Manage referrals" do
     and_the_eligibility_screener_feature_is_active
     and_there_is_an_existing_public_referral
 
-    when_i_am_authorized_as_a_case_worker_with_management_permissions
+    when_i_login_as_a_case_worker_with_management_permissions_only
+    then_i_see_manage_referrals_page
+
+    when_i_visit_staff_sign_in_page
+    then_i_see_manage_referrals_page
+
     and_i_visit_the_referral
     then_i_see_the_referral_summary
     and_i_see_the_personal_details_section

--- a/spec/system/manage/case_worker_with_permissions_views_an_employer_referral_spec.rb
+++ b/spec/system/manage/case_worker_with_permissions_views_an_employer_referral_spec.rb
@@ -9,9 +9,10 @@ RSpec.feature "Manage referrals" do
     given_the_service_is_open
     and_the_referral_form_feature_is_active
     and_the_eligibility_screener_feature_is_active
-    when_i_am_authorized_as_a_case_worker_with_management_permissions
+    when_i_login_as_a_case_worker_with_management_permissions_only
     and_there_is_an_existing_employer_referral
 
+    then_i_see_manage_referrals_page
     when_i_visit_the_referral
     then_i_see_the_referral_summary
     and_i_see_the_personal_details_section

--- a/spec/system/manage/case_worker_with_permissions_views_public_referrals_spec.rb
+++ b/spec/system/manage/case_worker_with_permissions_views_public_referrals_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Manage referrals" do
     and_the_eligibility_screener_feature_is_active
     and_referral_forms_exist
 
-    when_i_am_authorized_as_a_case_worker_with_management_permissions
+    when_i_login_as_a_case_worker_with_management_permissions_only
     when_i_visit_the_referrals_page
 
     then_i_can_see_the_referrals_page

--- a/spec/system/manage/case_worker_without_permissions_is_not_authorized_to_view_a_public_referral_spec.rb
+++ b/spec/system/manage/case_worker_without_permissions_is_not_authorized_to_view_a_public_referral_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Manage referrals" do
     and_the_eligibility_screener_feature_is_active
     and_there_is_an_existing_public_referral
 
-    when_i_am_authorized_as_a_case_worker_without_management_permissions
+    when_i_login_as_a_case_worker_with_support_permissions_only
     and_i_visit_the_referral
     then_i_am_unauthorized_and_redirected_to_root_path
   end

--- a/spec/system/manage/case_worker_without_permissions_is_not_authorized_to_view_an_employer_referral_spec.rb
+++ b/spec/system/manage/case_worker_without_permissions_is_not_authorized_to_view_an_employer_referral_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Manage referrals" do
     and_the_eligibility_screener_feature_is_active
     and_there_is_an_existing_employer_referral
 
-    when_i_am_authorized_as_a_case_worker_without_management_permissions
+    when_i_login_as_a_case_worker_with_support_permissions_only
     and_i_visit_the_referral
     then_i_am_unauthorized_and_redirected_to_root_path
   end

--- a/spec/system/manage/case_worker_without_permissions_is_not_authorized_to_view_public_referrals_spec.rb
+++ b/spec/system/manage/case_worker_without_permissions_is_not_authorized_to_view_public_referrals_spec.rb
@@ -11,15 +11,14 @@ RSpec.feature "Manage referrals" do
     and_the_eligibility_screener_feature_is_active
     and_referral_forms_exist
 
-    when_i_am_authorized_as_a_case_worker_without_management_permissions
-    when_i_visit_the_referrals_page
-
+    when_i_login_as_a_case_worker_with_support_permissions_only
+    and_i_visit_the_referrals_page
     then_i_am_unauthorized_and_redirected_to_root_path
   end
 
   private
 
-  def when_i_visit_the_referrals_page
+  def and_i_visit_the_referrals_page
     visit manage_interface_referrals_path
   end
 end

--- a/spec/system/support/staff_user_with_permissions_can_create_test_users_spec.rb
+++ b/spec/system/support/staff_user_with_permissions_can_create_test_users_spec.rb
@@ -8,7 +8,11 @@ RSpec.feature "Test users" do
     given_the_service_is_open
     and_the_referral_form_feature_is_active
     and_the_eligibility_screener_feature_is_active
-    when_i_am_authorized_as_a_case_worker_with_support_permissions
+    when_i_login_as_a_case_worker_with_support_permissions_only
+    then_i_see_the_staff_index
+
+    when_i_visit_staff_sign_in_page
+    then_i_see_the_staff_index
 
     and_i_visit_the_test_users_section
     and_i_click_test_users_link

--- a/spec/system/support/staff_user_with_permissions_can_visit_the_support_interface_spec.rb
+++ b/spec/system/support/staff_user_with_permissions_can_visit_the_support_interface_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "Support" do
     given_the_service_is_open
     given_an_eligibility_check_exists
     and_the_eligibility_screener_is_enabled
-    when_i_am_authorized_as_a_case_worker_with_support_permissions
+    when_i_login_as_a_case_worker_with_support_permissions_only
+    then_i_see_the_staff_index
     and_i_visit_the_support_page
     then_i_see_the_eligibility_checks_page
     and_i_do_not_see_referrals_link

--- a/spec/system/support/staff_user_with_permissions_sends_account_invitation_spec.rb
+++ b/spec/system/support/staff_user_with_permissions_sends_account_invitation_spec.rb
@@ -9,8 +9,7 @@ RSpec.feature "Staff invitations" do
     given_the_service_is_open
     and_the_eligibility_screener_is_enabled
 
-    when_i_am_authorized_as_a_case_worker_with_support_permissions
-    when_i_visit_the_staff_invitation_page
+    when_i_login_as_a_case_worker_with_support_permissions_only
     then_i_see_the_staff_index
     when_i_click_on_invite
     then_i_see_the_staff_invitation_form
@@ -26,7 +25,6 @@ RSpec.feature "Staff invitations" do
     then_i_am_unauthorized_and_redirected_to_root_path
 
     when_i_login_back_as_a_staff_user
-    and_i_visit_the_staff_invitation_page
     then_i_see_the_staff_index
     and_i_see_the_accepted_staff_user
   end
@@ -49,11 +47,6 @@ RSpec.feature "Staff invitations" do
   end
   alias_method :and_i_visit_the_staff_invitation_page,
                :when_i_visit_the_staff_invitation_page
-
-  def then_i_see_the_staff_index
-    expect(page).to have_current_path("/support/staff")
-    expect(page).to have_title("Staff")
-  end
 
   def when_i_click_on_invite
     click_link "Invite"

--- a/spec/system/support/staff_user_without_permissions_is_not_authorized_to_create_test_users_spec.rb
+++ b/spec/system/support/staff_user_without_permissions_is_not_authorized_to_create_test_users_spec.rb
@@ -9,9 +9,7 @@ RSpec.feature "Test users" do
     given_the_service_is_open
     and_the_referral_form_feature_is_active
     and_the_eligibility_screener_feature_is_active
-    when_i_am_authorized_as_a_case_worker_without_support_permissions
-
-    and_i_visit_the_test_users_section
+    when_i_login_as_a_case_worker_without_any_permissions_at_all
     then_i_am_unauthorized_and_redirected_to_root_path
   end
 

--- a/spec/system/support/staff_user_without_permissions_is_not_authorized_to_see_the_support_interface_spec.rb
+++ b/spec/system/support/staff_user_without_permissions_is_not_authorized_to_see_the_support_interface_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe "Support" do
            type: :system do
     given_the_service_is_open
     and_the_eligibility_screener_is_enabled
-    when_i_am_authorized_as_a_case_worker_without_support_permissions
-    and_i_visit_the_support_page
+    when_i_login_as_a_case_worker_without_any_permissions_at_all
     then_i_am_unauthorized_and_redirected_to_root_path
   end
 

--- a/spec/system/support/staff_user_without_permissions_is_not_authorized_to_send_account_invitation_spec.rb
+++ b/spec/system/support/staff_user_without_permissions_is_not_authorized_to_send_account_invitation_spec.rb
@@ -9,9 +9,7 @@ RSpec.feature "Staff invitations" do
     given_the_service_is_open
     and_the_eligibility_screener_is_enabled
 
-    when_i_am_authorized_as_a_case_worker_without_support_permissions
-    when_i_visit_the_staff_invitation_page
-
+    when_i_login_as_a_case_worker_without_any_permissions_at_all
     then_i_am_unauthorized_and_redirected_to_root_path
   end
 


### PR DESCRIPTION
### Context

Improve user flow for case workers as follows:

- if the case worker has only view_support permission, when logging in one gets directed to Staff section
- if case worker has only manage_referrals permission, when logging in one gets directed to manage referrals section
- if case worker has both permissions, one gets directed to manage referrals section, but sees the support sections as well on the navigation

### Changes proposed in this pull request


https://user-images.githubusercontent.com/1955084/221222944-57b8a6bf-5e96-4d50-a7f2-a26e8a5f9de0.mov


### Link to Trello card

https://trello.com/c/h4RYonlR/1221-staff-login-and-navigation

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
