### PR TITLE
1237 - Use a custom sign in route for case workers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   )
   devise_scope :staff do
     get "/staff/sign_out", to: "staff/sessions#destroy"
+    get "/manage/sign-in", to: "staff/sessions#new"
   end
 
   devise_for(:user)

--- a/spec/support/system/authorization_steps.rb
+++ b/spec/support/system/authorization_steps.rb
@@ -2,7 +2,7 @@ module AuthorizationSteps
   def when_i_login_as_a_case_worker_with_management_permissions_only
     create(:staff, :confirmed, :can_manage_referrals)
 
-    visit new_staff_session_path
+    visit manage_sign_in_path
 
     fill_in "Email", with: "test@example.org"
     fill_in "Password", with: "Example123!"
@@ -13,7 +13,7 @@ module AuthorizationSteps
   def when_i_login_as_a_case_worker_without_any_permissions_at_all
     create(:staff, :confirmed)
 
-    visit new_staff_session_path
+    visit manage_sign_in_path
 
     fill_in "Email", with: "test@example.org"
     fill_in "Password", with: "Example123!"
@@ -24,7 +24,7 @@ module AuthorizationSteps
   def when_i_login_as_a_case_worker_with_support_permissions_only
     create(:staff, :confirmed, :can_view_support)
 
-    visit new_staff_session_path
+    visit manage_sign_in_path
 
     fill_in "Email", with: "test@example.org"
     fill_in "Password", with: "Example123!"
@@ -33,7 +33,7 @@ module AuthorizationSteps
   end
 
   def when_i_visit_staff_sign_in_page
-    visit new_staff_session_path
+    visit manage_sign_in_path
   end
 
   def when_i_am_authorized_with_basic_auth_as_a_case_worker

--- a/spec/system/support/staff_user_with_permissions_sends_account_invitation_spec.rb
+++ b/spec/system/support/staff_user_with_permissions_sends_account_invitation_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Staff invitations" do
   def when_i_login_back_as_a_staff_user
     Capybara.reset_sessions!
 
-    visit new_staff_session_path
+    visit manage_sign_in_path
 
     fill_in "staff-email-field", with: "test@example.org"
     fill_in "staff-password-field", with: "Example123!"


### PR DESCRIPTION
### Context

Use a custom sign in route for case workers

### Changes proposed in this pull request

Instead of using `/staff/sign_in` users should be able to use `manage/sign-in` as route.

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
