### PR TITLE
1250 - Case workers return to original url after login

### DIFF
--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -20,7 +20,13 @@ class Staff::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  def after_sign_in_path_for(_resource)
+  def after_sign_in_path_for(resource)
+    stored_location = stored_location_for(resource)
+
+    if stored_location.present? && stored_location.exclude?(manage_sign_in_path)
+      return URI.parse(stored_location).path
+    end
+
     if current_staff.manage_referrals?
       manage_interface_referrals_path
     elsif current_staff.view_support?
@@ -43,6 +49,6 @@ class Staff::SessionsController < Devise::SessionsController
   def check_signed_in
     return unless signed_in?
 
-    redirect_to after_sign_in_path_for(resource)
+    redirect_to after_sign_in_path_for(current_staff)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,11 @@ Rails.application.routes.draw do
       passwords: "staff/passwords",
       sessions: "staff/sessions",
       unlocks: "staff/unlocks"
+    },
+    path: "",
+    path_names: {
+      sign_in:  "manage/sign-in",
+      sign_out: "manage/sign-out",
     }
   )
   devise_scope :staff do

--- a/spec/system/manage/case_worker_returns_to_original_url_after_login_spec.rb
+++ b/spec/system/manage/case_worker_returns_to_original_url_after_login_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Manage referrals and staff" do
+  include CommonSteps
+
+  scenario "Case worker returns to the original path after login" do
+    given_the_service_is_open
+    and_the_referral_form_feature_is_active
+    and_the_eligibility_screener_feature_is_active
+    and_there_is_an_existing_public_referral
+    and_there_is_a_case_worker_with_permissions
+    and_i_visit_the_referral
+
+    and_i_login_as_a_case_worker_with_management_permissions_only
+    then_i_see_the_referral_summary
+  end
+
+  private
+
+  def and_there_is_an_existing_public_referral
+    create(:referral, :public_complete)
+  end
+
+  def and_there_is_a_case_worker_with_permissions
+    create(:staff, :confirmed, :can_manage_referrals)
+  end
+
+  def then_i_see_the_referral_summary
+    expect(page).to have_content("Summary")
+    within("#summary") do
+      expect(page).to have_content(Referral.last.id)
+      expect(page).to have_content(
+        Referral.last.created_at.to_fs(:day_month_year_time)
+      )
+    end
+  end
+
+  def when_i_visit_the_referral
+    visit manage_interface_referral_path(Referral.last)
+  end
+  alias_method :and_i_visit_the_referral, :when_i_visit_the_referral
+
+  def and_i_login_as_a_case_worker_with_management_permissions_only
+    fill_in "Email", with: "test@example.org"
+    fill_in "Password", with: "Example123!"
+
+    click_on "Log in"
+  end
+end

--- a/spec/system/support/staff_user_with_permissions_sends_account_invitation_spec.rb
+++ b/spec/system/support/staff_user_with_permissions_sends_account_invitation_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "Staff invitations" do
   end
 
   def then_i_see_the_staff_invitation_form
-    expect(page).to have_current_path("/staff/invitation/new")
+    expect(page).to have_current_path("/invitation/new")
     expect(page).to have_content("Send invitation")
     expect(page).to have_content("Email")
     expect(page).to have_content("Send an invitation")
@@ -89,7 +89,7 @@ RSpec.feature "Staff invitations" do
   def when_i_visit_the_invitation_email
     message = ActionMailer::Base.deliveries.last
     uri = URI.parse(URI.extract(message.body.to_s).second)
-    expect(uri.path).to eq("/staff/invitation/accept")
+    expect(uri.path).to eq("/invitation/accept")
     expect(uri.query).to include("invitation_token=")
     visit "#{uri.path}?#{uri.query}"
   end


### PR DESCRIPTION
### Context

Case workers return to original url after login

### Changes proposed in this pull request

If a case worker accesses any url under `/support/*` or `/manage/*`, but they are not authenticated, they will return to the original url after login.

### Link to Trello card



### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
