### PR TITLE
TEST ONLY Case workers return to original url after login

### DIFF
--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -21,6 +21,10 @@ class Staff::SessionsController < Devise::SessionsController
   # end
 
   def after_sign_in_path_for(_resource)
+    path = stored_location || request.referer
+
+    return path if path.present? && path.exclude?(manage_sign_in_path)
+
     if current_staff.manage_referrals?
       manage_interface_referrals_path
     elsif current_staff.view_support?
@@ -44,5 +48,11 @@ class Staff::SessionsController < Devise::SessionsController
     return unless signed_in?
 
     redirect_to after_sign_in_path_for(resource)
+  end
+
+  def stored_location
+    return nil if resource.blank?
+
+    stored_location_for(resource)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,11 @@ Rails.application.routes.draw do
       passwords: "staff/passwords",
       sessions: "staff/sessions",
       unlocks: "staff/unlocks"
+    },
+    path: "",
+    path_names: {
+      sign_in:  "manage/sign-in",
+      sign_out: "manage/sign-out",
     }
   )
   devise_scope :staff do

--- a/spec/system/manage/case_worker_returns_to_original_url_after_login_spec.rb
+++ b/spec/system/manage/case_worker_returns_to_original_url_after_login_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Manage referrals and staff" do
     and_the_eligibility_screener_feature_is_active
     and_there_is_an_existing_public_referral
     and_i_visit_the_referral
-    
+
     and_i_login_as_a_case_worker_with_management_permissions_only
     then_i_see_the_referral_summary
     and_i_see_the_personal_details_section
@@ -113,7 +113,6 @@ RSpec.feature "Manage referrals and staff" do
   alias_method :and_i_visit_the_referral, :when_i_visit_the_referral
 
   def and_i_login_as_a_case_worker_with_management_permissions_only
-    binding.pry
     fill_in "Email", with: "test@example.org"
     fill_in "Password", with: "Example123!"
 

--- a/spec/system/manage/case_worker_returns_to_original_url_after_login_spec.rb
+++ b/spec/system/manage/case_worker_returns_to_original_url_after_login_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Manage referrals and staff" do
     and_the_eligibility_screener_feature_is_active
     and_there_is_an_existing_public_referral
     and_i_visit_the_referral
+    
     and_i_login_as_a_case_worker_with_management_permissions_only
     then_i_see_the_referral_summary
     and_i_see_the_personal_details_section

--- a/spec/system/manage/case_worker_returns_to_original_url_after_login_spec.rb
+++ b/spec/system/manage/case_worker_returns_to_original_url_after_login_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Manage referrals and staff" do
+  include CommonSteps
+
+  scenario "Case worker returns to the original path after login",
+           type: :system do
+    given_the_service_is_open
+    and_the_referral_form_feature_is_active
+    and_the_eligibility_screener_feature_is_active
+    and_there_is_an_existing_public_referral
+    and_i_visit_the_referral
+    and_i_login_as_a_case_worker_with_management_permissions_only
+    then_i_see_the_referral_summary
+    and_i_see_the_personal_details_section
+    and_i_see_the_employment_details_section
+    and_i_see_the_allegation_details_section
+    and_i_see_the_evidence_section
+    and_i_see_the_referrer_details_section
+    and_there_are_no_employer_only_sections
+  end
+
+  private
+
+
+  # def follow_redirect &block
+  #   begin
+  #     yield
+  #   ensure
+  #     options[:follow_redirects] = true
+  #   end
+  # end
+
+  def and_there_is_an_existing_public_referral
+    @referral = create(:referral, :public_complete)
+  end
+
+  def then_i_see_the_referral_summary
+    expect(page).to have_content("Summary")
+    within("#summary") do
+      expect(page).to have_content(Referral.last.id)
+      expect(page).to have_content(
+        Referral.last.created_at.to_fs(:day_month_year_time)
+      )
+    end
+  end
+
+  def and_i_see_the_personal_details_section
+    expect(page).to have_content("Personal details")
+    within("#personal_details") do
+      expect(page).to have_content("John")
+      expect(page).to have_content("Smith")
+      expect(page).not_to have_content("Do they have qualified teacher status?")
+    end
+  end
+
+  def and_i_see_the_employment_details_section
+    expect(page).to have_content("Employment details")
+    within("#employment_details") do
+      expect(page).to have_content("Job title")
+      expect(page).to have_content("Teacher")
+      expect(page).to have_content("Main duties")
+      expect(page).not_to have_content("Organisation")
+      expect(page).not_to have_content("Job start date")
+      expect(page).not_to have_content("Job end date")
+      expect(page).not_to have_content("Reason they left the job")
+    end
+  end
+
+  def and_i_see_the_allegation_details_section
+    expect(page).to have_content("Allegation details")
+    within("#allegation_details") do
+      expect(page).to have_content("Allegation details")
+      expect(page).to have_content("They were rude to a child")
+      expect(page).to have_content(
+        "Have you told the Disclosure and Barring Service (DBS)?"
+      )
+      expect(page).to have_content("Yes")
+    end
+  end
+
+  def and_i_see_the_evidence_section
+    expect(page).to have_content("Evidence and supporting information")
+    within("#evidence") { expect(page).to have_link("upload1.pdf") }
+  end
+
+  def and_i_see_the_referrer_details_section
+    expect(page).to have_content("Referrer details")
+    within("#referrer_details") do
+      expect(page).to have_content("First name")
+      expect(page).to have_content("Jane")
+      expect(page).to have_content("Last name")
+      expect(page).to have_content("Smith")
+      expect(page).not_to have_content("Job title")
+      expect(page).to have_content("Email address")
+      expect(page).to have_content(@referral.user.email)
+      expect(page).to have_content("Phone number")
+      expect(page).to have_content("01234567890")
+      expect(page).not_to have_content("Employer")
+    end
+  end
+
+  def and_there_are_no_employer_only_sections
+    expect(page).not_to have_content("Other employment details")
+    expect(page).not_to have_content("Previous allegation details")
+  end
+
+  def when_i_visit_the_referral
+    visit manage_interface_referral_path(Referral.last)
+  end
+  alias_method :and_i_visit_the_referral, :when_i_visit_the_referral
+
+  def and_i_login_as_a_case_worker_with_management_permissions_only
+    binding.pry
+    fill_in "Email", with: "test@example.org"
+    fill_in "Password", with: "Example123!"
+
+    click_on "Log in"
+  end
+end

--- a/spec/system/support/staff_user_with_permissions_sends_account_invitation_spec.rb
+++ b/spec/system/support/staff_user_with_permissions_sends_account_invitation_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "Staff invitations" do
   end
 
   def then_i_see_the_staff_invitation_form
-    expect(page).to have_current_path("/staff/invitation/new")
+    expect(page).to have_current_path("/invitation/new")
     expect(page).to have_content("Send invitation")
     expect(page).to have_content("Email")
     expect(page).to have_content("Send an invitation")
@@ -89,7 +89,7 @@ RSpec.feature "Staff invitations" do
   def when_i_visit_the_invitation_email
     message = ActionMailer::Base.deliveries.last
     uri = URI.parse(URI.extract(message.body.to_s).second)
-    expect(uri.path).to eq("/staff/invitation/accept")
+    expect(uri.path).to eq("/invitation/accept")
     expect(uri.query).to include("invitation_token=")
     visit "#{uri.path}?#{uri.query}"
   end


### PR DESCRIPTION
If a case worker accesses any url under /support/* or /manage/*, but they are not authenticated,
they will return to the original url after login.

### Context

<!-- Why are you making this change? -->

### Changes proposed in this pull request

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
