### PR TITLE
[1259] Add referrer type to manage view

### DIFF
--- a/app/components/manage_interface/referrer_details_component.rb
+++ b/app/components/manage_interface/referrer_details_component.rb
@@ -15,6 +15,7 @@ module ManageInterface
           { key: { text: "Job title" }, value: { text: referrer.job_title } }
         )
       end
+      rows.push({ key: { text: "Type" }, value: { text: referral_type } })
       rows.push({ key: { text: "Email address" }, value: { text: user.email } })
       rows.push(
         { key: { text: "Phone number" }, value: { text: referrer.phone } }
@@ -37,6 +38,10 @@ module ManageInterface
 
     def title
       "Referrer details"
+    end
+
+    def referral_type
+      referral.from_employer? ? "Employer" : "Public"
     end
 
     delegate :referrer, :user, to: :referral


### PR DESCRIPTION


### Context

We need to explicitly show the source of the referral ie Public/Employer

### Changes proposed in this pull request

* Add 'Type: Public/Employer' to the referrer details. This will also appear on the PDF version

### Guidance to review

<img width="1052" alt="Screenshot 2023-03-01 at 11 01 49" src="https://user-images.githubusercontent.com/5216/222121306-01ab977a-5efe-4799-9c47-6646707d20ba.png">

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
