### PR TITLE
Add upload file size hint and tidy file sizes throughout

### DIFF
--- a/app/forms/referrals/allegation/details_form.rb
+++ b/app/forms/referrals/allegation/details_form.rb
@@ -10,11 +10,13 @@ module Referrals
                 if: -> { allegation_format == "details" }
       validates :allegation_upload,
                 presence: true,
-                file_upload: true,
                 if: -> {
                   allegation_format == "upload" &&
                     !referral.allegation_upload.attached?
                 }
+      validates :allegation_upload,
+                file_upload: true,
+                if: -> { allegation_format == "upload" }
 
       attr_accessor :referral,
                     :allegation_details,

--- a/app/forms/referrals/previous_misconduct/detailed_account_form.rb
+++ b/app/forms/referrals/previous_misconduct/detailed_account_form.rb
@@ -18,11 +18,13 @@ module Referrals
                 if: -> { previous_misconduct_format == "details" }
       validates :previous_misconduct_upload,
                 presence: true,
-                file_upload: true,
                 if: -> {
                   previous_misconduct_format == "upload" &&
                     !referral.previous_misconduct_upload.attached?
                 }
+      validates :previous_misconduct_upload,
+                file_upload: true,
+                if: -> { previous_misconduct_format == "upload" }
 
       def save
         return false unless valid?

--- a/app/forms/referrals/teacher_role/duties_form.rb
+++ b/app/forms/referrals/teacher_role/duties_form.rb
@@ -12,10 +12,12 @@ module Referrals
                 if: -> { duties_format == "details" }
       validates :duties_upload,
                 presence: true,
-                file_upload: true,
                 if: -> {
                   duties_format == "upload" && !referral.duties_upload.attached?
                 }
+      validates :duties_upload,
+                file_upload: true,
+                if: -> { duties_format == "upload" }
 
       def save
         return false if invalid?

--- a/app/helpers/file_size_helper.rb
+++ b/app/helpers/file_size_helper.rb
@@ -1,0 +1,13 @@
+module FileSizeHelper
+  def file_size(attachment)
+    ActiveSupport::NumberHelper.number_to_human_size(
+      attachment.byte_size
+    ).delete(" ")
+  end
+
+  def max_allowed_file_size
+    ActiveSupport::NumberHelper.number_to_human_size(
+      FileUploadValidator::MAX_FILE_SIZE
+    ).delete(" ")
+  end
+end

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -1,4 +1,6 @@
 module ReferralHelper
+  include FileSizeHelper
+
   def duties_format(referral)
     return "Describe their main duties" if referral.duties_format == "details"
 
@@ -58,9 +60,5 @@ module ReferralHelper
     else
       "Incomplete"
     end
-  end
-
-  def file_size(attachment)
-    attachment.byte_size.to_fs(:human_size)
   end
 end

--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -1,5 +1,5 @@
 class FileUploadValidator < ActiveModel::EachValidator
-  include ActionView::Helpers::NumberHelper
+  include FileSizeHelper
 
   MAX_FILE_SIZE = 50.megabytes
   MAX_FILES = 10
@@ -36,11 +36,7 @@ class FileUploadValidator < ActiveModel::EachValidator
       next if uploaded_file.nil?
 
       if uploaded_file.size > MAX_FILE_SIZE
-        record.errors.add(
-          attribute,
-          :file_size_too_big,
-          max_file_size: number_to_human_size(MAX_FILE_SIZE)
-        )
+        record.errors.add(attribute, :file_size_too_big, max_allowed_file_size:)
         break
       end
 

--- a/app/views/public_referrals/evidence/upload/edit.html.erb
+++ b/app/views/public_referrals/evidence/upload/edit.html.erb
@@ -5,12 +5,12 @@
   <div class="govuk-grid-column-two-thirds-from-desktop ">
     <%= form_with model: @evidence_upload_form, url: public_referral_evidence_upload_path(current_referral), method: :put do |f| %>
       <%= f.govuk_error_summary %>
-    
+
       <span class="govuk-caption-l">Evidence and supporting information</span>
       <h1 class="govuk-heading-l">Upload evidence</h1>
-    
+
       <p>For example:</p>
-    
+
       <ul class="govuk-list govuk-list--bullet">
         <li>complaint made to the school</li>
         <li>correspondence with the school</li>
@@ -19,9 +19,9 @@
         <li>complaint made to the local authority or any other agency or body</li>
         <li>signed witness statements</li>
       </ul>
-    
+
       <p>Make sure the file names describe the content, for example ‘signed witness statement’.</p>
-    
+
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
@@ -29,13 +29,14 @@
           Do not include explicit content, for example indecent photos. You’ll be asked for these separately if needed.
         </strong>
       </div>
-    
+
       <%= f.govuk_file_field(
           :evidence_uploads,
           multiple: true,
-          label: { text: "Upload files", size: "m" }
+          label: { text: "Upload files", size: "m" },
+          hint: { text: "Must be smaller than #{max_allowed_file_size}" }
       ) %>
-  
+
       <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>

--- a/app/views/referrals/allegation/details/edit.html.erb
+++ b/app/views/referrals/allegation/details/edit.html.erb
@@ -22,10 +22,16 @@
                     )
                   %>
                 </p>
-                <%= f.govuk_file_field :allegation_upload, label: { text: "Upload new file", size: "s" } %>
+                <%= f.govuk_file_field :allegation_upload,
+                  label: { text: "Upload new file", size: "s" },
+                  hint: { text: "Must be smaller than #{max_allowed_file_size}" }
+                %>
               </div>
             <% else %>
-              <%= f.govuk_file_field :allegation_upload, label: { text: "Upload file", size: "s" } %>
+              <%= f.govuk_file_field :allegation_upload,
+                label: { text: "Upload file", size: "s" },
+                hint: { text: "Must be smaller than #{max_allowed_file_size}" }
+              %>
             <% end %>
           <% end %>
           <%= f.govuk_radio_button :allegation_format, "details", label: { text: "Describe the allegation" } do %>

--- a/app/views/referrals/evidence/upload/edit.html.erb
+++ b/app/views/referrals/evidence/upload/edit.html.erb
@@ -43,7 +43,8 @@
       <%= f.govuk_file_field(
           :evidence_uploads,
           multiple: true,
-          label: { text: "Upload files", size: "m" }
+          label: { text: "Upload files", size: "m" },
+          hint: { text: "Must be smaller than #{max_allowed_file_size}" }
       ) %>
 
       <%= f.govuk_submit "Save and continue" %>

--- a/app/views/referrals/previous_misconduct/detailed_account/edit.html.erb
+++ b/app/views/referrals/previous_misconduct/detailed_account/edit.html.erb
@@ -29,10 +29,16 @@
                     )
                   %>
                 </p>
-                <%= f.govuk_file_field :previous_misconduct_upload, label: { text: "Upload new file", size: "s" } %>
+                <%= f.govuk_file_field :previous_misconduct_upload,
+                  label: { text: "Upload new file", size: "s" },
+                  hint: { text: "Must be smaller than #{max_allowed_file_size}" }
+                %>
               </div>
             <% else %>
-              <%= f.govuk_file_field :previous_misconduct_upload, label: { text: "Upload file", size: "s" } %>
+              <%= f.govuk_file_field :previous_misconduct_upload,
+                label: { text: "Upload file", size: "s" },
+                hint: { text: "Must be smaller than #{max_allowed_file_size}" }
+              %>
             <% end %>
           <% end %>
           <%= f.govuk_radio_button :previous_misconduct_format, "details", label: { text: "Describe the previous allegations" } do %>

--- a/app/views/referrals/teacher_role/duties/edit.html.erb
+++ b/app/views/referrals/teacher_role/duties/edit.html.erb
@@ -24,11 +24,14 @@
                 </p>
                 <%= f.govuk_file_field :duties_upload,
                   label: { text: "Upload new file", size: "s" },
-                  hint: { text: "For example, a job description"  }
+                  hint: { text: "For example, a job description. Must be smaller than #{max_allowed_file_size}" }
                 %>
               </div>
             <% else %>
-              <%= f.govuk_file_field :duties_upload, label: { text: "Upload file", size: "s" } %>
+              <%= f.govuk_file_field :duties_upload,
+                label: { text: "Upload file", size: "s" },
+                hint: { text: "For example, a job description. Must be smaller than #{max_allowed_file_size}" }
+              %>
             <% end %>
           <% end %>
           <%= f.govuk_radio_button :duties_format, "details", label: { text: "Describe their main duties" } do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,7 +191,7 @@ en:
               blank: Select a file containing a description of their main duties
               invalid_content_type: The selected file must be of type (%{valid_types})
               mismatch_content_type: The selected file does not match its contents
-              file_size_too_big: The selected file must be smaller than 25MB
+              file_size_too_big: The selected file must be smaller than %{max_allowed_file_size}
         "referrals/teacher_role/working_somewhere_else_form":
           attributes:
             working_somewhere_else:
@@ -291,7 +291,7 @@ en:
               blank: Select a file containing details of previous allegations
               invalid_content_type: The selected file must be of type (%{valid_types})
               mismatch_content_type: The selected file does not match its contents
-              file_size_too_big: The selected file must be smaller than %{max_file_size}
+              file_size_too_big: The selected file must be smaller than %{max_allowed_file_size}
         "referrals/previous_misconduct/reported_form":
           attributes:
             previous_misconduct_reported:
@@ -310,7 +310,7 @@ en:
               blank: Select a file containing details of your allegation
               invalid_content_type: The selected file must be of type (%{valid_types})
               mismatch_content_type: The selected file does not match its contents
-              file_size_too_big: The selected file must be smaller than %{max_file_size}
+              file_size_too_big: The selected file must be smaller than %{max_allowed_file_size}
         "referrals/allegation/dbs_form":
           attributes:
             dbs_notified:
@@ -330,7 +330,7 @@ en:
               blank: Select evidence to upload
               invalid_content_type: The selected file must be of valid type (%{valid_types})
               mismatch_content_type: The selected file does not match its contents
-              file_size_too_big: The selected file must be smaller than %{max_file_size}
+              file_size_too_big: The selected file must be smaller than %{max_allowed_file_size}
               file_count: You can only upload %{max_files} files
         "referrals/evidence/uploaded_form":
           attributes:

--- a/spec/helpers/file_size_helper_spec.rb
+++ b/spec/helpers/file_size_helper_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe FileSizeHelper, type: :helper do
+  describe "#file_size" do
+    subject { file_size(attachment) }
+
+    context "when called with an attachment" do
+      let(:attachment) do
+        instance_double("ActiveStorage::Blob", byte_size: 33.6.kilobytes)
+      end
+
+      it { is_expected.to eq "33.6KB" }
+    end
+  end
+
+  describe "#max_allowed_file_size" do
+    subject { max_allowed_file_size }
+
+    context "when called returns the max allowed file size human formatted with space removed" do
+      it { is_expected.to eq "50MB" }
+    end
+  end
+end

--- a/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
+++ b/spec/system/public_referrals/user_adds_details_of_the_allegation_spec.rb
@@ -176,6 +176,6 @@ RSpec.feature "Details of the allegation", type: :system do
   end
 
   def then_i_can_see_the_allegation_file
-    expect(page).to have_content("upload1.pdf (4.98 KB)")
+    expect(page).to have_content("upload1.pdf (4.98KB)")
   end
 end

--- a/spec/system/public_referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_teacher_role_details_spec.rb
@@ -297,11 +297,11 @@ RSpec.feature "Teacher role", type: :system do
   # Page content
 
   def and_i_see_the_uploaded_filename
-    expect(page).to have_content("upload1.pdf (4.98 KB)")
+    expect(page).to have_content("upload1.pdf (4.98KB)")
   end
 
   def and_i_see_the_second_uploaded_filename
-    expect(page).to have_content("upload2.pdf (5.11 KB)")
+    expect(page).to have_content("upload2.pdf (5.11KB)")
   end
 
   def and_i_see_the_status_section_in_the_referral_summary(status: "COMPLETED")

--- a/spec/system/referrals/user_adds_previous_misconduct_spec.rb
+++ b/spec/system/referrals/user_adds_previous_misconduct_spec.rb
@@ -200,6 +200,6 @@ RSpec.feature "Employer Referral: Previous Misconduct", type: :system do
   end
 
   def then_i_can_see_the_previous_misconduct_file
-    expect(page).to have_content("upload.txt (15 Bytes)")
+    expect(page).to have_content("upload.txt (15Bytes)")
   end
 end

--- a/spec/system/referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_details_spec.rb
@@ -572,11 +572,11 @@ RSpec.feature "Teacher role", type: :system do
   # Page content
 
   def and_i_see_the_uploaded_filename
-    expect(page).to have_content("upload1.pdf (4.98 KB)")
+    expect(page).to have_content("upload1.pdf (4.98KB)")
   end
 
   def and_i_see_the_second_uploaded_filename
-    expect(page).to have_content("upload2.pdf (5.11 KB)")
+    expect(page).to have_content("upload2.pdf (5.11KB)")
   end
 
   def and_i_see_the_status_section_in_the_referral_summary(status: "COMPLETED")


### PR DESCRIPTION
### Context

To make it clearer that there is a filesize limit before the user uploads

### Changes proposed in this pull request

Show a hint to the users with all file upload fields. The text needs to say "50MB" not "50 MB" as returned by the rails helper so had to create our own. 

Took the liberty of tidying up the file sizes throughout by adding a `FileSizeHelper`

Also fixed a bug where uploading a file on top of an existing file ignored file size validation

### Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/yLd8A4Ti/1243-referrals-design-history-change-adding-hint-text-to-file-uploads)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
