### PR TITLE
1274 - Use the correct devise method for staff user

### DIFF
--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -47,7 +47,7 @@ class Staff::SessionsController < Devise::SessionsController
   private
 
   def check_signed_in
-    return unless signed_in?
+    return unless staff_signed_in?
 
     redirect_to after_sign_in_path_for(current_staff)
   end


### PR DESCRIPTION
### Context

As we currently have two types of users that can be on the session: User and Staff,
we want to make sure that while accessing the manage section we check
if the right user is logged in. In this case this must be a Staff user.

### Link to Trello card

https://trello.com/c/eJ1q7am5

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
