### PR TITLE
Validate NINO format

### DIFF
--- a/app/forms/referrals/personal_details/ni_number_form.rb
+++ b/app/forms/referrals/personal_details/ni_number_form.rb
@@ -4,14 +4,23 @@ module Referrals
     class NiNumberForm
       include ActiveModel::Model
 
-      attr_accessor :referral, :ni_number
-      attr_reader :ni_number_known
+      attr_accessor :referral
+      attr_reader :ni_number_known, :ni_number
 
-      validates :ni_number, presence: true, if: -> { ni_number_known }
+      validates :ni_number,
+                presence: true,
+                format: {
+                  with: /\A[a-z]{2}[0-9]{6}[a-d]{1}\Z/i
+                },
+                if: -> { ni_number_known }
       validates :ni_number_known, inclusion: { in: [true, false] }
 
       def ni_number_known=(value)
         @ni_number_known = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def ni_number=(value)
+        @ni_number = value&.gsub(/\s|-/, "")
       end
 
       def save

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,7 @@ en:
               inclusion: Select yes if you know their National Insurance number
             ni_number:
               blank: Enter their National Insurance number
+              invalid: Enter a National Insurance number in the correct format
         "referrals/personal_details/name_form":
           attributes:
             first_name:

--- a/spec/forms/referrals/personal_details/ni_number_form_spec.rb
+++ b/spec/forms/referrals/personal_details/ni_number_form_spec.rb
@@ -25,5 +25,21 @@ RSpec.describe Referrals::PersonalDetails::NiNumberForm, type: :model do
       save
       expect(referral.ni_number).to eq(ni_number)
     end
+
+    context "with an invalid NI number" do
+      let(:ni_number) { "AB1234566" }
+
+      before { save }
+
+      it "does not update the ni_number" do
+        expect(referral.ni_number).to be_nil
+      end
+
+      it "adds an error to the form" do
+        expect(form.errors[:ni_number]).to eq(
+          ["Enter a National Insurance number in the correct format"]
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

This only validates the format, the NINO can still be an invalid one, but in the correct format.

<img width="668" alt="Screenshot 2023-03-02 at 10 07 49" src="https://user-images.githubusercontent.com/1636476/222400180-7466df2d-97c6-41e6-af85-22cd946ecd6f.png">

### Link to Trello card

https://trello.com/c/MNKLpuuE/1226-validate-nino-format