### PR TITLE
Update OTP email and expiry time

### DIFF
--- a/app/forms/users/otp_form.rb
+++ b/app/forms/users/otp_form.rb
@@ -1,6 +1,6 @@
 class Users::OtpForm
   MAX_GUESSES = 5
-  EXPIRY_IN_MINUTES = 30.minutes
+  EXPIRY_TIME = 1.hour
 
   include ActiveModel::Model
 
@@ -28,7 +28,7 @@ class Users::OtpForm
   end
 
   def otp_expired?
-    user.otp_created_at.blank? || (EXPIRY_IN_MINUTES.ago >= user.otp_created_at)
+    user.otp_created_at.blank? || (EXPIRY_TIME.ago >= user.otp_created_at)
   end
 
   def secret_key?

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,7 +2,10 @@ class UserMailer < ApplicationMailer
   def otp(user)
     @otp = Devise::Otp.derive_otp(user.secret_key)
     Rails.logger.info "OTP: #{@otp}" if Rails.env.development?
-    mailer_options = { to: user.email, subject: "Confirm your email address" }
+    mailer_options = {
+      to: user.email,
+      subject: "#{@otp} is your confirmation code"
+    }
 
     view_mail(GENERIC_NOTIFY_TEMPLATE, mailer_options)
   end

--- a/app/views/user_mailer/otp.erb
+++ b/app/views/user_mailer/otp.erb
@@ -1,13 +1,13 @@
-Hello
+You requested a confirmation code to continue making a referral of serious misconduct.
 
-You need to confirm your email address to sign in to the Refer serious misconduct by a teacher in England service.
+The code will expire in 1 hour. You can only use the code once.
 
-Use this code:
+Confirmation code: <%= @otp %>
 
-<%= @otp %>
+GET HELP
 
-The code will expire after 15 minutes.
+Email: misconduct.teacher@education.gov.uk
+We aim to respond within 3 working days.
 
-Regards,
-
-Department for Education
+Phone: 020 7593 5393
+Monday to Friday, 9am to 5pm (except public holidays)

--- a/spec/forms/users/otp_form_spec.rb
+++ b/spec/forms/users/otp_form_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe Users::OtpForm do
     before { freeze_time }
     after { travel_back }
 
-    context "when the OTP is 30 minutes old" do
-      let(:otp_created_at) { 30.minutes.ago }
+    context "when the OTP is 60 minutes old" do
+      let(:otp_created_at) { 60.minutes.ago }
 
       it { is_expected.to be_truthy }
     end
 
-    context "when the OTP is 29 minutes old" do
-      let(:otp_created_at) { 29.minutes.ago }
+    context "when the OTP is 59 minutes old" do
+      let(:otp_created_at) { 59.minutes.ago }
 
       it { is_expected.to be_falsey }
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe UserMailer, type: :mailer do
 
     let(:secret_key) { Devise::Otp.generate_key }
     let(:user) { build(:user, secret_key:) }
+    let(:otp) { Devise::Otp.derive_otp(secret_key) }
 
     it "sends a one-time password to the user" do
       expect(email.to).to include user.email
     end
 
     it "includes the one-time password in the email body" do
-      expected_otp = Devise::Otp.derive_otp(secret_key)
-      expect(email.body).to include(expected_otp)
+      expect(email.body).to include(otp)
     end
 
     it "sets the subject" do
-      expect(email.subject).to eq "Confirm your email address"
+      expect(email.subject).to eq "#{otp} is your confirmation code"
     end
   end
 

--- a/spec/system/user_auth/user_tries_signing_in_with_expired_otp_spec.rb
+++ b/spec/system/user_auth/user_tries_signing_in_with_expired_otp_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "User accounts" do
   end
 
   def and_my_otp_has_expired
-    travel_to(Users::OtpForm::EXPIRY_IN_MINUTES.from_now)
+    travel_to(Users::OtpForm::EXPIRY_TIME.from_now)
   end
 
   def when_i_try_to_sign_in


### PR DESCRIPTION
### Context

When updating the sign in flow we missed updating the OTP email content

### Changes proposed in this pull request

Update OTP email content
Increase OTP validity to 1 hour
Make email text consistent with above

### Guidance to review

### Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/NuO5k41S/1251-update-referrer-signin-journey)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
