### PR TITLE
TRN format validation

### DIFF
--- a/app/forms/referrals/personal_details/trn_form.rb
+++ b/app/forms/referrals/personal_details/trn_form.rb
@@ -5,17 +5,25 @@ module Referrals
       include ActiveModel::Model
 
       attr_accessor :referral
-      attr_reader :trn, :trn_known
+      attr_reader :trn_known, :trn
 
       validates :trn_known, inclusion: { in: [true, false] }
-      validates :trn, presence: true, length: { is: 7 }, if: -> { trn_known }
-
-      def trn=(value)
-        @trn = value&.delete("^0-9")
-      end
+      validates :trn,
+                presence: true,
+                length: {
+                  is: 7
+                },
+                numericality: {
+                  only_numeric: true
+                },
+                if: -> { trn_known }
 
       def trn_known=(value)
         @trn_known = ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def trn=(value)
+        @trn = value&.strip
       end
 
       def save

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,8 +115,9 @@ en:
             trn_known:
               inclusion: Select yes if you know their TRN
             trn:
-              blank: Enter their TRN
+              blank: Enter TRN
               wrong_length: TRN must be 7 digits
+              not_a_number: Enter a TRN in the correct format
         "referrals/personal_details/qts_form":
           attributes:
             has_qts:

--- a/spec/forms/referrals/personal_details/trn_form_spec.rb
+++ b/spec/forms/referrals/personal_details/trn_form_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Referrals::PersonalDetails::TrnForm, type: :model do
 
     let(:trn_form) { described_class.new(referral:, trn_known:, trn:) }
     let(:trn_known) { "true" }
-    let(:trn) { "RP99/12345" }
+    let(:trn) { "9912345" }
 
     it { is_expected.to be_truthy }
 
@@ -54,12 +54,12 @@ RSpec.describe Referrals::PersonalDetails::TrnForm, type: :model do
 
       it "adds an error" do
         save
-        expect(trn_form.errors[:trn]).to include("Enter their TRN")
+        expect(trn_form.errors[:trn]).to include("Enter TRN")
       end
     end
 
     context "when a value too short for a TRN is submitted" do
-      let(:trn) { "RP99/123" }
+      let(:trn) { "123" }
 
       it { is_expected.to be_falsey }
 
@@ -70,7 +70,7 @@ RSpec.describe Referrals::PersonalDetails::TrnForm, type: :model do
     end
 
     context "when a value too long for a TRN is submitted" do
-      let(:trn) { "RP99/123456" }
+      let(:trn) { "123456" }
 
       it { is_expected.to be_falsey }
 
@@ -81,12 +81,15 @@ RSpec.describe Referrals::PersonalDetails::TrnForm, type: :model do
     end
 
     context "when a TRN includes non numeric characters" do
-      let(:trn) { "RP/99-123-67" }
+      let(:trn) { "991237A" }
 
-      it { is_expected.to be_truthy }
+      it { is_expected.to be_falsey }
 
-      it "strips all non numeric characters from the TRN" do
-        expect { save }.to change(referral, :trn).from(nil).to("9912367")
+      it "adds an error" do
+        save
+        expect(trn_form.errors[:trn]).to eq(
+          ["Enter a TRN in the correct format"]
+        )
       end
     end
   end

--- a/spec/system/referrals/user_adds_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_personal_details_spec.rb
@@ -149,7 +149,7 @@ RSpec.feature "Personal details", type: :system do
 
   def when_i_fill_out_their_trn
     choose "Yes", visible: false
-    fill_in "TRN", with: "RP99/12345"
+    fill_in "TRN", with: "9912345"
   end
 
   def then_i_am_asked_if_i_know_whether_they_have_qts


### PR DESCRIPTION
### Context

This only validates the format, the TRN can still be an invalid one, but in the correct format.

If blank including trim: `Enter TRN`
If not the right length: `TRN must be 7 digits`
If anything else: `Enter a TRN in the correct format`

<img width="710" alt="Screenshot 2023-03-02 at 13 25 28" src="https://user-images.githubusercontent.com/1636476/222441706-113a0de7-8129-40e6-bc40-a2a2f77bad20.png">
<img width="678" alt="Screenshot 2023-03-02 at 13 25 49" src="https://user-images.githubusercontent.com/1636476/222441716-77aa3481-cb52-4917-85e8-0d5bec63b4d5.png">

### Link to Trello card

https://trello.com/c/rIBExANz/1227-trn-format-validation