### PR TITLE
1254 - Manage referrals - Teacher Personal Details

### DIFF
--- a/app/components/manage_interface/personal_details_component.rb
+++ b/app/components/manage_interface/personal_details_component.rb
@@ -9,7 +9,80 @@ module ManageInterface
         { key: { text: "First name" }, value: { text: referral.first_name } },
         { key: { text: "Last name" }, value: { text: referral.last_name } }
       ]
+
+      rows.push(
+        {
+          key: {
+            text: "Are they known by other name?"
+          },
+          value: {
+            text: referral.name_has_changed
+          }
+        }
+      )
+
+      if referral.previous_name.present?
+        rows.push(
+          {
+            key: {
+              text: "Other name"
+            },
+            value: {
+              text: referral.previous_name
+            }
+          }
+        )
+      end
+
       return rows unless referral.from_employer?
+
+      rows.push(
+        {
+          key: {
+            text: "Is their date of birth known?"
+          },
+          value: {
+            text: referral.age_known ? "yes" : "no"
+          }
+        }
+      )
+
+      if referral.date_of_birth.present?
+        rows.push(
+          {
+            key: {
+              text: "Date of birth"
+            },
+            value: {
+              text: referral.date_of_birth&.to_fs(:long_ordinal_uk)
+            }
+          }
+        )
+      end
+
+      rows.push(
+        {
+          key: {
+            text: "Is their National Insurance number known?"
+          },
+          value: {
+            text: referral.ni_number_known ? "yes" : "no"
+          }
+        }
+      )
+
+      if referral.ni_number.present?
+        rows.push(
+          {
+            key: {
+              text: "National Insurance number"
+            },
+            value: {
+              text: referral.ni_number
+            }
+          }
+        )
+      end
 
       rows.push(
         {


### PR DESCRIPTION
Add missing fields on the form visible inside the
manage referrals - Personal details section.

### Context

Add missing fields on the form visible inside the
manage referrals - Personal details section.

### Changes proposed in this pull request

Add missing fields on the form visible on manage referrals - personal details section

#### Public facing service

##### Public referral

<img width="490" alt="Screenshot 2023-03-02 at 16 08 03" src="https://user-images.githubusercontent.com/1955084/222484555-f4efc62d-efb6-4c5b-b1df-a72a3e9f4fab.png">


##### Employer Referral

<img width="575" alt="Screenshot 2023-03-02 at 16 08 16" src="https://user-images.githubusercontent.com/1955084/222484597-48f98423-a45d-4eae-8875-f67df003a1f9.png">

#### Caseworkers manage referrals section

##### Public referral

![Screenshot 2023-03-02 at 16 09 37](https://user-images.githubusercontent.com/1955084/222484852-ae97af8d-b1ac-490d-9786-54ca1d2ad0d5.png)

##### Employer referral

![Screenshot 2023-03-02 at 16 09 25](https://user-images.githubusercontent.com/1955084/222484936-f9f5d8df-a972-41dd-a8c3-39756327e8bf.png)

### Link to Trello card

https://trello.com/c/xGHLYcN3

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
