### PR TITLE
Manage referrals - Teacher Employment Details

### DIFF
--- a/app/components/manage_interface/employment_details_component.rb
+++ b/app/components/manage_interface/employment_details_component.rb
@@ -18,6 +18,14 @@ module ManageInterface
         },
         {
           key: {
+            text: "How where details about their main duties given?"
+          },
+          value: {
+            text: duties_format(referral)
+          }
+        },
+        {
+          key: {
             text: "Main duties"
           },
           value: {
@@ -26,9 +34,59 @@ module ManageInterface
         }
       ]
 
+      if referral.from_member_of_public?
+        rows.push(
+          {
+            key: {
+              text:
+                "Is name and address of the organisation where the alleged misconduct took place known?"
+            },
+            value: {
+              text: referral.organisation_address_known ? "Yes" : "No"
+            }
+          }
+        )
+
+        rows.push(
+          {
+            key: {
+              text:
+                "Name and address of the organisation where the alleged misconduct took place"
+            },
+            value: {
+              text: referral_organisation_address(referral)
+            }
+          }
+        )
+      end
+
       return rows unless referral.from_employer?
 
+      rows.push(
+        {
+          key: {
+            text:
+              "Were they employed at the same organisation as you at the time of the alleged misconduct?"
+          },
+          value: {
+            text: referral.same_organisation ? "Yes" : "No"
+          }
+        }
+      )
+
       rows.push(organisation_row)
+
+      rows.push(
+        {
+          key: {
+            text: "Is it known when they started the job?"
+          },
+          value: {
+            text: referral.role_start_date_known ? "Yes" : "No"
+          }
+        }
+      )
+
       if referral.role_start_date_known
         rows.push(
           {
@@ -40,29 +98,93 @@ module ManageInterface
             }
           }
         )
-      end
-      if referral.role_end_date_known
+
         rows.push(
           {
             key: {
-              text: "Job end date"
+              text:
+                "Are they still employed at the organisation where the alleged misconduct took place?"
             },
             value: {
-              text: referral.role_end_date&.to_fs(:long_ordinal_uk)
+              text: employment_status(referral)
             }
           }
         )
       end
-      rows.push(
-        {
-          key: {
-            text: "Reason they left the job"
-          },
-          value: {
-            text: referral.reason_leaving_role&.humanize
+
+      if employment_status(referral) == "No"
+        rows.push(
+          {
+            key: {
+              text: "Is it known when they left the job?"
+            },
+            value: {
+              text: referral.role_end_date_known ? "Yes" : "No"
+            }
           }
-        }
-      )
+        )
+
+        if referral.role_end_date_known
+          rows.push(
+            {
+              key: {
+                text: "Job end date"
+              },
+              value: {
+                text: referral.role_end_date&.to_fs(:long_ordinal_uk)
+              }
+            }
+          )
+        end
+
+        rows.push(
+          {
+            key: {
+              text: "Reason they left the job"
+            },
+            value: {
+              text: referral.reason_leaving_role&.humanize
+            }
+          }
+        )
+
+        rows.push(
+          {
+            key: {
+              text: "Are they employed somewhere else?"
+            },
+            value: {
+              text: working_somewhere_else
+            }
+          }
+        )
+
+        rows.push(
+          {
+            key: {
+              text:
+                "Is the name and address of the organisation where they’re employed known?"
+            },
+            value: {
+              text: referral.work_location_known ? "Yes" : "No"
+            }
+          }
+        )
+
+        if referral.work_location_known
+          rows.push(
+            {
+              key: {
+                text:
+                  "Name and address of the organisation where they’re employed"
+              },
+              value: {
+                text: teaching_address(referral)
+              }
+            }
+          )
+        end
+      end
 
       rows
     end
@@ -89,6 +211,14 @@ module ManageInterface
             )
         }
       }
+    end
+
+    def working_somewhere_else
+      if referral.working_somewhere_else.to_sym == :not_sure
+        return "I'm not sure"
+      end
+
+      referral.working_somewhere_else&.humanize
     end
   end
 end

--- a/app/components/manage_interface/personal_details_component.rb
+++ b/app/components/manage_interface/personal_details_component.rb
@@ -42,7 +42,7 @@ module ManageInterface
             text: "Is their date of birth known?"
           },
           value: {
-            text: referral.age_known ? "yes" : "no"
+            text: referral.age_known ? "Yes" : "No"
           }
         }
       )
@@ -66,7 +66,7 @@ module ManageInterface
             text: "Is their National Insurance number known?"
           },
           value: {
-            text: referral.ni_number_known ? "yes" : "no"
+            text: referral.ni_number_known ? "Yes" : "No"
           }
         }
       )


### PR DESCRIPTION
### Context

Add missing fields on the form visible inside the
manage referrals - Employment details section.

### Changes proposed in this pull request

Add missing fields on the form visible inside the
manage referrals - Employment details section.

#### Public referral (public facing service)

<img width="604" alt="Screenshot 2023-03-03 at 09 17 16" src="https://user-images.githubusercontent.com/1955084/222681591-aac12615-7c52-4cb7-9a5b-cecd1902a456.png">


#### Employer referral with teacher still employed (public facing service)

<img width="563" alt="Screenshot 2023-03-03 at 09 18 14" src="https://user-images.githubusercontent.com/1955084/222681378-13570d60-16d2-4d11-87f9-8e08c1f62333.png">


#### Employer referral with teacher not employed anymore (public facing service)

<img width="632" alt="Screenshot 2023-03-03 at 09 18 50" src="https://user-images.githubusercontent.com/1955084/222681521-adedfb1f-dcb9-4286-9df3-d51d3b5e0204.png">

#### Manage referral (caseworker facing service)

#### Public referral

![Screenshot 2023-03-03 at 09 20 59](https://user-images.githubusercontent.com/1955084/222682025-43613e78-1a96-4e32-8004-62c586027bda.png)

#### Employer referral with teacher still employed 

![Screenshot 2023-03-03 at 09 23 19](https://user-images.githubusercontent.com/1955084/222682565-393398c3-133f-425d-985f-858ebc9166bf.png)

#### Employer referral with teacher not employed 

![Screenshot 2023-03-03 at 09 24 31](https://user-images.githubusercontent.com/1955084/222682887-7dd00aed-d984-4191-807a-ed3d893e0a12.png)


### Link to Trello card

https://trello.com/c/xGHLYcN3

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
