### PR TITLE
1254 Manage referrals - Allegation Details

### DIFF
--- a/app/components/manage_interface/allegation_details_component.rb
+++ b/app/components/manage_interface/allegation_details_component.rb
@@ -6,7 +6,15 @@ module ManageInterface
     attr_accessor :referral
 
     def rows
-      [
+      rows = [
+        {
+          key: {
+            text: "How do you want to give details about the allegation?"
+          },
+          value: {
+            text: details_format
+          }
+        },
         {
           key: {
             text: "Allegation details"
@@ -14,7 +22,25 @@ module ManageInterface
           value: {
             text: allegation_details(referral)
           }
-        },
+        }
+      ]
+
+      if referral.from_member_of_public?
+        rows.push(
+          {
+            key: {
+              text: "Details about how this complaint has been considered"
+            },
+            value: {
+              text: referral.allegation_consideration_details
+            }
+          }
+        )
+      end
+
+      return rows unless referral.from_employer?
+
+      rows.push(
         {
           key: {
             text: "Have you told the Disclosure and Barring Service (DBS)?"
@@ -23,11 +49,22 @@ module ManageInterface
             text: referral.dbs_notified ? "Yes" : "No"
           }
         }
-      ]
+      )
+
+      rows
     end
 
     def title
       "Allegation details"
+    end
+
+    def details_format
+      case referral.allegation_format
+      when "details"
+        "Describe the allegation"
+      when "upload"
+        "File upload"
+      end
     end
   end
 end

--- a/app/components/manage_interface/employment_details_component.rb
+++ b/app/components/manage_interface/employment_details_component.rb
@@ -170,20 +170,6 @@ module ManageInterface
             }
           }
         )
-
-        if referral.work_location_known
-          rows.push(
-            {
-              key: {
-                text:
-                  "Name and address of the organisation where they’re employed"
-              },
-              value: {
-                text: teaching_address(referral)
-              }
-            }
-          )
-        end
       end
 
       rows

--- a/spec/system/manage/case_worker_with_permissions_views_a_public_referral_spec.rb
+++ b/spec/system/manage/case_worker_with_permissions_views_a_public_referral_spec.rb
@@ -70,10 +70,6 @@ RSpec.feature "Manage referrals" do
     within("#allegation_details") do
       expect(page).to have_content("Allegation details")
       expect(page).to have_content("They were rude to a child")
-      expect(page).to have_content(
-        "Have you told the Disclosure and Barring Service (DBS)?"
-      )
-      expect(page).to have_content("Yes")
     end
   end
 


### PR DESCRIPTION
### Context

Add missing fields on the form visible inside the
manage referrals - Allegation details section.

### Changes proposed in this pull request

#### Public referral (public facing service)

<img width="578" alt="Screenshot 2023-03-03 at 11 46 44" src="https://user-images.githubusercontent.com/1955084/222712671-562bc898-9c9a-44ae-a6f7-7d44aa79e876.png">

#### Employer referral  (public facing service)

<img width="709" alt="Screenshot 2023-03-03 at 11 47 20" src="https://user-images.githubusercontent.com/1955084/222712772-8ec3375a-1609-40dc-8931-2ba1bbe098da.png">

#### Manage referral (caseworker facing service)

#### Public referral


<img width="672" alt="Screenshot 2023-03-03 at 11 49 50" src="https://user-images.githubusercontent.com/1955084/222713285-d11676e2-8f10-40d5-b112-8ca63ec52609.png">


#### Employer referral 

<img width="695" alt="Screenshot 2023-03-03 at 11 50 40" src="https://user-images.githubusercontent.com/1955084/222713419-61ab87f1-9c20-406c-8f63-74cd6360d257.png">


### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/xGHLYcN3

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
