### PR TITLE
Manage referrals - Previous Allegation Details

### DIFF
--- a/app/components/manage_interface/previous_allegation_details_component.rb
+++ b/app/components/manage_interface/previous_allegation_details_component.rb
@@ -19,6 +19,14 @@ module ManageInterface
         },
         {
           key: {
+            text: "How do you want to give details about previous allegations?"
+          },
+          value: {
+            text: detail_type
+          }
+        },
+        {
+          key: {
             text: "Previous allegation details"
           },
           value: {
@@ -30,6 +38,12 @@ module ManageInterface
 
     def title
       "Previous allegation details"
+    end
+
+    def detail_type
+      return "Upload file" if referral.previous_misconduct_upload.attached?
+
+      "Describe the allegation"
     end
   end
 end


### PR DESCRIPTION
### Context

Add missing fields on the form visible inside the
manage referrals - Previous allegation details section.

### Changes proposed in this pull request

This is only available for employer referrals.

<img width="1210" alt="Screenshot 2023-03-03 at 12 41 45" src="https://user-images.githubusercontent.com/1955084/222723864-7e05bd82-a260-4f5b-9107-d766f33f4324.png">


### Link to Trello card

https://trello.com/c/xGHLYcN3

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
