### PR TITLE
Validate dates before 1920

### DIFF
--- a/app/forms/referrals/personal_details/age_form.rb
+++ b/app/forms/referrals/personal_details/age_form.rb
@@ -10,7 +10,9 @@ module Referrals
       validates :age_known, inclusion: { in: [true, false] }
       validates :date_of_birth,
                 date: {
-                  date_of_birth: true
+                  above_16: true,
+                  not_future: true,
+                  past_century: true
                 },
                 if: -> { age_known }
 

--- a/app/forms/referrals/teacher_role/end_date_form.rb
+++ b/app/forms/referrals/teacher_role/end_date_form.rb
@@ -11,7 +11,8 @@ module Referrals
       validates :role_end_date_known, inclusion: { in: [true, false] }
       validates :role_end_date,
                 date: {
-                  in_the_future: false
+                  not_future: false,
+                  past_century: true
                 },
                 if: -> { role_end_date_known }
 

--- a/app/forms/referrals/teacher_role/start_date_form.rb
+++ b/app/forms/referrals/teacher_role/start_date_form.rb
@@ -11,7 +11,8 @@ module Referrals
       validates :role_start_date_known, inclusion: { in: [true, false] }
       validates :role_start_date,
                 date: {
-                  in_the_future: false
+                  not_future: true,
+                  past_century: true
                 },
                 if: -> { role_start_date_known }
 

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -78,27 +78,25 @@ class DateValidator < ActiveModel::EachValidator
       return false
     end
 
-    return true unless options[:date_of_birth] || !options[:in_the_future]
-
-    if year > Time.zone.today.year
-      record.errors.add(attribute, :in_the_future)
+    if options[:not_future] && Date.new(year, month, day) > Time.zone.today
+      record.errors.add(attribute, :not_future)
       return false
     end
 
-    return true unless options[:date_of_birth]
-
-    if year < 1900
-      record.errors.add(attribute, :born_after_1900)
+    if options[:past_century] && !year.between?(1920, Time.zone.today.year)
+      record.errors.add(attribute, :past_century)
       return false
     end
 
-    if record.send(attribute) > 16.years.ago
-      record.errors.add(attribute, :inclusion)
+    if options[:above_16] && record.send(attribute) > 16.years.ago
+      record.errors.add(attribute, :above_16)
       return false
     end
 
     true
   end
+
+  private
 
   def word_to_number(field)
     return field if field.is_a? Integer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,9 +84,9 @@ en:
           attributes:
             date_of_birth:
               blank: Enter their date of birth
-              born_after_1900: Enter a year later than 1900
-              inclusion: You must be 16 or over to use this service
-              in_the_future: Their date of birth must be in the past
+              past_century: Their date of birth must be the same as or after 1 January 1920
+              above_16: You must be 16 or over to use this service
+              not_future: Their date of birth must be in the past
               invalid: Enter their date of birth in the correct format
               missing_day: Date of birth must include a day
               missing_month: Date of birth must include a month
@@ -165,7 +165,8 @@ en:
               inclusion: Select yes if you know when they started the job
             role_start_date:
               blank: Enter the job start date
-              in_the_future: Job start date must be in the past
+              not_future: Job start date must be in the past
+              past_century: Job start date must be the same as or after 1 January 1920
               invalid: Job start date must be a real date
               missing_day: Job start date must include a day
               missing_month: Job start date must include a month
@@ -234,7 +235,8 @@ en:
               inclusion: Select yes if you know when they left the job
             role_end_date:
               blank: Enter the job end date
-              in_the_future: Job end date must be in the past
+              not_future: Job end date must be in the past
+              past_century: Job end date must be the same as or after 1 January 1920
               invalid: Job end date must be a real date
               missing_day: Job end date must include a day
               missing_month: Job end date must include a month

--- a/spec/support/shared_examples/validating_date.rb
+++ b/spec/support/shared_examples/validating_date.rb
@@ -201,7 +201,9 @@ RSpec.shared_examples "form with a date of birth validator" do |field|
     it { is_expected.to be_falsy }
 
     it "adds an error" do
-      expect(form.errors[field.to_s]).to eq(["Enter a year later than 1900"])
+      expect(form.errors[field.to_s]).to eq(
+        ["Their date of birth must be the same as or after 1 January 1920"]
+      )
     end
   end
 end

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe DateValidator do
     it { is_expected.to be_valid }
   end
 
-  context "with date_of_birth option" do
+  context "with above_16 option" do
     subject(:model) do
-      stub_validatable_class("DobValidatable", options: { date_of_birth: true })
-      DobValidatable.new
+      stub_validatable_class("MinAgeValidatable", options: { above_16: true })
+      MinAgeValidatable.new
     end
 
     context "with valid date params" do
@@ -73,18 +73,6 @@ RSpec.describe DateValidator do
       it { is_expected.to be_valid }
     end
 
-    context "with date of birth params in future" do
-      let(:date_params) do
-        {
-          "the_date(1i)" => 1.year.since.year,
-          "the_date(2i)" => "12",
-          "the_date(3i)" => "25"
-        }
-      end
-
-      it { is_expected.to be_invalid }
-    end
-
     context "with min age date of birth params" do
       let(:date_params) do
         {
@@ -96,8 +84,44 @@ RSpec.describe DateValidator do
 
       it { is_expected.to be_invalid }
     end
+  end
 
-    context "with max age date of birth params" do
+  context "with past_century option" do
+    subject(:model) do
+      stub_validatable_class(
+        "CenturyValidatable",
+        options: {
+          past_century: true
+        }
+      )
+      CenturyValidatable.new
+    end
+
+    context "with valid date params" do
+      let(:date_params) do
+        {
+          "the_date(1i)" => "1990",
+          "the_date(2i)" => "12",
+          "the_date(3i)" => "25"
+        }
+      end
+
+      it { is_expected.to be_valid }
+    end
+
+    context "with date params in future" do
+      let(:date_params) do
+        {
+          "the_date(1i)" => 1.year.since.year,
+          "the_date(2i)" => "12",
+          "the_date(3i)" => "25"
+        }
+      end
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "with year before 1920" do
       let(:date_params) do
         {
           "the_date(1i)" => "1899",


### PR DESCRIPTION
### Context
Added to date of birth, job start date, job end date pages.

<img width="691" alt="Screenshot 2023-03-03 at 14 14 17" src="https://user-images.githubusercontent.com/1636476/222743019-2cd7f8be-3ec4-473d-8e33-5c70b4efcf78.png">

### Link to Trello card

https://trello.com/c/uZAhKWwY/1231-employer-form-validate-dates-before-1920