### PR TITLE
Change textarea fields column type to text

### DIFF
--- a/db/migrate/20230303141955_change_string_descriptions_to_text.rb
+++ b/db/migrate/20230303141955_change_string_descriptions_to_text.rb
@@ -1,0 +1,15 @@
+class ChangeStringDescriptionsToText < ActiveRecord::Migration[7.0]
+  def up
+    change_table :referrals, bulk: true do |t|
+      t.change :duties_details, :text
+      t.change :allegation_details, :text
+    end
+  end
+
+  def down
+    change_table :referrals, bulk: true do |t|
+      t.change :duties_details, :string
+      t.change :allegation_details, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_17_122304) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_03_141955) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
 
@@ -112,7 +112,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_17_122304) do
     t.boolean "contact_details_complete"
     t.bigint "user_id", null: false
     t.string "allegation_format"
-    t.string "allegation_details"
+    t.text "allegation_details"
     t.boolean "dbs_notified"
     t.boolean "allegation_details_complete"
     t.boolean "has_evidence"
@@ -126,7 +126,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_17_122304) do
     t.string "job_title"
     t.boolean "same_organisation"
     t.string "duties_format"
-    t.string "duties_details"
+    t.text "duties_details"
     t.boolean "teacher_role_complete"
     t.text "previous_misconduct_details"
     t.datetime "submitted_at", precision: nil


### PR DESCRIPTION
### Context

Change made because the string data type only allows for 255 characters.

### Link to Trello card

https://trello.com/c/OEwa5yP3/1277-create-a-migration-to-increase-the-length-of-the-textarea-inputs