### PR TITLE
Make all unanswered questions on review page show as not answered

### DIFF
--- a/app/components/about_you_component.rb
+++ b/app/components/about_you_component.rb
@@ -25,7 +25,10 @@ class AboutYouComponent < ViewComponent::Base
           text: "Your name"
         },
         value: {
-          text: "#{referrer&.first_name} #{referrer&.last_name}"
+          text:
+            nullable_value_to_s(
+              "#{referrer&.first_name} #{referrer&.last_name}".presence
+            )
         }
       },
       {
@@ -62,7 +65,7 @@ class AboutYouComponent < ViewComponent::Base
             text: "Your job title"
           },
           value: {
-            text: referrer&.job_title
+            text: nullable_value_to_s(referrer&.job_title)
           }
         }
       )
@@ -85,7 +88,7 @@ class AboutYouComponent < ViewComponent::Base
           text: "Your phone number"
         },
         value: {
-          text: referrer&.phone
+          text: nullable_value_to_s(referrer&.phone)
         }
       }
     )

--- a/app/components/contact_details_component.rb
+++ b/app/components/contact_details_component.rb
@@ -2,6 +2,7 @@ class ContactDetailsComponent < ViewComponent::Base
   include ActiveModel::Model
   include AddressHelper
   include ComponentHelper
+  include ReferralHelper
 
   attr_accessor :referral
 
@@ -45,7 +46,7 @@ class ContactDetailsComponent < ViewComponent::Base
         text: "Do you know their email address?"
       },
       value: {
-        text: referral.email_known ? "Yes" : "No"
+        text: nullable_boolean_to_s(referral.email_known)
       }
     }
   end
@@ -81,7 +82,7 @@ class ContactDetailsComponent < ViewComponent::Base
         text: "Do you know their phone number?"
       },
       value: {
-        text: referral.phone_known ? "Yes" : "No"
+        text: nullable_boolean_to_s(referral.phone_known)
       }
     }
   end
@@ -117,7 +118,7 @@ class ContactDetailsComponent < ViewComponent::Base
         text: "Do you know their home address?"
       },
       value: {
-        text: referral.address_known ? "Yes" : "No"
+        text: nullable_boolean_to_s(referral.address_known)
       }
     }
   end
@@ -135,7 +136,7 @@ class ContactDetailsComponent < ViewComponent::Base
         text: "Home address"
       },
       value: {
-        text: address(referral)
+        text: nullable_value_to_s(address(referral).presence)
       }
     }
   end

--- a/app/components/evidence_component.rb
+++ b/app/components/evidence_component.rb
@@ -29,13 +29,13 @@ class EvidenceComponent < ViewComponent::Base
         text: "Do you have anything to upload?"
       },
       value: {
-        text: referral.has_evidence ? "Yes" : "No"
+        text: nullable_boolean_to_s(referral.has_evidence)
       }
     }
   end
 
   def evidence_row
-    return unless referral.evidences.any?
+    return unless referral.has_evidence?
 
     {
       actions: [
@@ -59,6 +59,8 @@ class EvidenceComponent < ViewComponent::Base
   end
 
   def evidence_text
+    return "Not answered" if referral.evidences.empty?
+
     tag.ul(class: "govuk-list govuk-list--bullet govuk-!-margin-bottom-0") do
       referral.evidences.map do |evidence|
         concat(

--- a/app/components/organisation_component.rb
+++ b/app/components/organisation_component.rb
@@ -2,6 +2,7 @@ class OrganisationComponent < ViewComponent::Base
   include ActiveModel::Model
   include AddressHelper
   include ComponentHelper
+  include ReferralHelper
 
   attr_accessor :referral
 
@@ -28,7 +29,7 @@ class OrganisationComponent < ViewComponent::Base
           text: "Your organisation"
         },
         value: {
-          text: organisation_address(organisation)
+          text: nullable_value_to_s(organisation_address(organisation).presence)
         }
       }
     ]

--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -40,7 +40,7 @@ class PersonalDetailsComponent < ViewComponent::Base
         text: "Do you know them by any other name?"
       },
       value: {
-        text: referral.name_has_changed&.humanize
+        text: nullable_value_to_s(referral.name_has_changed&.humanize)
       }
     }
   end
@@ -62,7 +62,10 @@ class PersonalDetailsComponent < ViewComponent::Base
         text: "Their name"
       },
       value: {
-        text: "#{referral.first_name} #{referral.last_name}"
+        text:
+          nullable_value_to_s(
+            "#{referral.first_name} #{referral.last_name}".presence
+          )
       }
     }
   end
@@ -128,7 +131,7 @@ class PersonalDetailsComponent < ViewComponent::Base
         text: "Do you know their date of birth"
       },
       value: {
-        text: referral.age_known? ? "Yes" : "No"
+        text: nullable_boolean_to_s(referral.age_known)
       }
     }
   end
@@ -151,7 +154,7 @@ class PersonalDetailsComponent < ViewComponent::Base
         text: "Do you know their teacher reference number (TRN)?"
       },
       value: {
-        text: referral.trn.present? ? "Yes" : "No"
+        text: nullable_boolean_to_s(referral.trn_known)
       }
     }
   end
@@ -195,7 +198,7 @@ class PersonalDetailsComponent < ViewComponent::Base
         text: "Do they have qualified teacher status (QTS)?"
       },
       value: {
-        text: referral.has_qts&.humanize
+        text: nullable_value_to_s(referral.has_qts&.humanize)
       }
     }
   end
@@ -222,7 +225,7 @@ class PersonalDetailsComponent < ViewComponent::Base
         text: "Do you know their National Insurance number?"
       },
       value: {
-        text: referral.ni_number_known? ? "Yes" : "No"
+        text: nullable_boolean_to_s(referral.ni_number_known)
       }
     }
   end

--- a/app/components/previous_misconduct_component.rb
+++ b/app/components/previous_misconduct_component.rb
@@ -2,6 +2,7 @@ class PreviousMisconductComponent < ViewComponent::Base
   include ActiveModel::Model
   include ApplicationHelper
   include ComponentHelper
+  include ReferralHelper
 
   attr_accessor :referral
 
@@ -26,7 +27,10 @@ class PreviousMisconductComponent < ViewComponent::Base
           text: "Has there been any previous misconduct?"
         },
         value: {
-          text: humanize_three_way_choice(referral.previous_misconduct_reported)
+          text:
+            nullable_value_to_s(
+              humanize_three_way_choice(referral.previous_misconduct_reported)
+            )
         }
       }
     ]
@@ -98,7 +102,7 @@ class PreviousMisconductComponent < ViewComponent::Base
       return simple_format(referral.previous_misconduct_details)
     end
 
-    "Not answered yet"
+    "Not answered"
   end
 
   def return_to
@@ -113,8 +117,21 @@ class PreviousMisconductComponent < ViewComponent::Base
   end
 
   def detail_type
-    return "Upload file" if referral.previous_misconduct_upload.attached?
-
-    "Describe the allegation"
+    case referral.previous_misconduct_format
+    when "details"
+      if referral.previous_misconduct_details.present?
+        "Describe the allegation"
+      else
+        "Incomplete"
+      end
+    when "upload"
+      if referral.previous_misconduct_upload.attached?
+        "Upload file"
+      else
+        "Incomplete"
+      end
+    else
+      "Not answered"
+    end
   end
 end

--- a/app/components/public_allegation_component.rb
+++ b/app/components/public_allegation_component.rb
@@ -1,6 +1,7 @@
 class PublicAllegationComponent < ViewComponent::Base
   include ActiveModel::Model
   include ComponentHelper
+  include ReferralHelper
 
   attr_accessor :referral
 
@@ -9,30 +10,12 @@ class PublicAllegationComponent < ViewComponent::Base
       Referrals::Allegation::CheckAnswersForm.new(referral:)
   end
 
-  def details_format
-    case referral.allegation_format
-    when "details"
-      "Describe the allegation"
-    when "upload"
-      "File upload"
-    else
-      "Incomplete"
-    end
-  end
-
   def file_upload?
     referral.allegation_format == "upload"
   end
 
   def details_described?
     referral.allegation_format == "details"
-  end
-
-  def details_text
-    return file_link if file_upload?
-    return referral.allegation_details if details_described?
-
-    "Incomplete"
   end
 
   def file_link
@@ -62,7 +45,7 @@ class PublicAllegationComponent < ViewComponent::Base
           text: "How do you want to give details about the allegation?"
         },
         value: {
-          text: details_format
+          text: allegation_details_format(referral)
         }
       },
       {
@@ -81,7 +64,7 @@ class PublicAllegationComponent < ViewComponent::Base
           text: "Description of the allegation"
         },
         value: {
-          text: details_text
+          text: allegation_details(referral)
         }
       },
       {
@@ -101,7 +84,10 @@ class PublicAllegationComponent < ViewComponent::Base
           text: "Details about how this complaint has been considered"
         },
         value: {
-          text: referral.allegation_consideration_details || "Incomplete"
+          text:
+            nullable_value_to_s(
+              referral.allegation_consideration_details.presence
+            )
         }
       }
     ]

--- a/app/components/their_role_component.rb
+++ b/app/components/their_role_component.rb
@@ -48,7 +48,7 @@ class TheirRoleComponent < ViewComponent::Base
         text: "Their job title"
       },
       value: {
-        text: referral.job_title || "Not known"
+        text: nullable_value_to_s(referral.job_title)
       }
     }
   end
@@ -105,7 +105,7 @@ class TheirRoleComponent < ViewComponent::Base
           "Were they employed at the same organisation as you at the time of the alleged misconduct?"
       },
       value: {
-        text: referral.same_organisation ? "Yes" : "No"
+        text: nullable_boolean_to_s(referral.same_organisation)
       }
     }
   end
@@ -125,7 +125,7 @@ class TheirRoleComponent < ViewComponent::Base
           "Do you know the name and address of the organisation where the alleged misconduct took place?"
       },
       value: {
-        text: referral.organisation_address_known ? "Yes" : "No"
+        text: nullable_boolean_to_s(referral.organisation_address_known)
       }
     }
   end
@@ -163,7 +163,7 @@ class TheirRoleComponent < ViewComponent::Base
         text: "Do you know when they started the job?"
       },
       value: {
-        text: referral.role_start_date_known ? "Yes" : "No"
+        text: nullable_boolean_to_s(referral.role_start_date_known)
       }
     }
   end
@@ -219,7 +219,7 @@ class TheirRoleComponent < ViewComponent::Base
         text: "Do you know when they left the job?"
       },
       value: {
-        text: referral.role_end_date_known ? "Yes" : "No"
+        text: nullable_boolean_to_s(referral.role_end_date_known)
       }
     }
   end
@@ -293,7 +293,7 @@ class TheirRoleComponent < ViewComponent::Base
           "Do you know the name and address of the organisation where they’re employed?"
       },
       value: {
-        text: referral.work_location_known ? "Yes" : "No"
+        text: nullable_boolean_to_s(referral.work_location_known)
       }
     }
   end
@@ -312,7 +312,7 @@ class TheirRoleComponent < ViewComponent::Base
         text: "Name and address of the organisation where they’re employed"
       },
       value: {
-        text: teaching_address(referral)
+        text: nullable_value_to_s(teaching_address(referral).presence)
       }
     }
   end
@@ -335,14 +335,16 @@ class TheirRoleComponent < ViewComponent::Base
   end
 
   def reason_leaving_role
-    return "I'm not sure" if referral.reason_leaving_role.to_sym == :unknown
+    return "I'm not sure" if referral.reason_leaving_role&.to_sym == :unknown
 
-    referral.reason_leaving_role&.humanize
+    referral.reason_leaving_role&.humanize.presence || "Not answered"
   end
 
   def working_somewhere_else
-    return "I'm not sure" if referral.working_somewhere_else.to_sym == :not_sure
+    if referral.working_somewhere_else&.to_sym == :not_sure
+      return "I'm not sure"
+    end
 
-    referral.working_somewhere_else&.humanize
+    referral.working_somewhere_else&.humanize.presence || "Not answered"
   end
 end

--- a/app/components/what_happened_component.rb
+++ b/app/components/what_happened_component.rb
@@ -26,7 +26,7 @@ class WhatHappenedComponent < ViewComponent::Base
           text: "How do you want to give details about the allegation?"
         },
         value: {
-          text: allegation_details_type
+          text: allegation_details_format(referral)
         }
       },
       {
@@ -70,7 +70,7 @@ class WhatHappenedComponent < ViewComponent::Base
           text: "Have you told DBS?"
         },
         value: {
-          text: referral.dbs_notified ? "Yes" : "No"
+          text: nullable_boolean_to_s(referral.dbs_notified)
         }
       }
     ]
@@ -82,14 +82,5 @@ class WhatHappenedComponent < ViewComponent::Base
     polymorphic_path(
       [:edit, referral.routing_scope, referral, :allegation, :check_answers]
     )
-  end
-
-  private
-
-  def allegation_details_type
-    return "Upload file" if referral.allegation_upload.attached?
-    return "Describe the allegation" if referral.allegation_details.present?
-
-    "Incomplete"
   end
 end

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -2,21 +2,39 @@ module ReferralHelper
   include FileSizeHelper
 
   def duties_format(referral)
-    return "Describe their main duties" if referral.duties_format == "details"
-
-    "Upload file"
+    case referral.duties_format
+    when "details"
+      if referral.duties_details.present?
+        "Describe their main duties"
+      else
+        "Incomplete"
+      end
+    when "upload"
+      referral.duties_upload.attached? ? "Upload file" : "Incomplete"
+    else
+      "Not answered"
+    end
   end
 
   def duties_details(referral)
-    if referral.duties_upload.attached?
-      govuk_link_to(
-        referral.duties_upload.filename,
-        rails_blob_path(referral.duties_upload, disposition: "attachment")
-      )
-    elsif referral.duties_details.present?
-      referral.duties_details.truncate(150)
+    case referral.duties_format
+    when "details"
+      if referral.duties_details.present?
+        simple_format(referral.duties_details)
+      else
+        "Incomplete"
+      end
+    when "upload"
+      if referral.duties_upload.attached?
+        govuk_link_to(
+          referral.duties_upload.filename,
+          rails_blob_path(referral.duties_upload, disposition: "attachment")
+        )
+      else
+        "Incomplete"
+      end
     else
-      "Incomplete"
+      "Not answered"
     end
   end
 
@@ -29,20 +47,44 @@ module ReferralHelper
     when "left_role"
       "No"
     else
-      "Incomplete"
+      "Not answered"
+    end
+  end
+
+  def allegation_details_format(referral)
+    case referral.allegation_format
+    when "details"
+      if referral.allegation_details.present?
+        "Describe the allegation"
+      else
+        "Incomplete"
+      end
+    when "upload"
+      referral.allegation_upload.attached? ? "Upload file" : "Incomplete"
+    else
+      "Not answered"
     end
   end
 
   def allegation_details(referral)
-    if referral.allegation_upload.attached?
-      govuk_link_to(
-        referral.allegation_upload.filename,
-        rails_blob_path(referral.allegation_upload, disposition: "attachment")
-      )
-    elsif referral.allegation_details.present?
-      simple_format(referral.allegation_details)
+    case referral.allegation_format
+    when "details"
+      if referral.allegation_details.present?
+        simple_format(referral.allegation_details)
+      else
+        "Incomplete"
+      end
+    when "upload"
+      if referral.allegation_upload.attached?
+        govuk_link_to(
+          referral.allegation_upload.filename,
+          rails_blob_path(referral.allegation_upload, disposition: "attachment")
+        )
+      else
+        "Incomplete"
+      end
     else
-      "Incomplete"
+      "Not answered"
     end
   end
 
@@ -60,5 +102,18 @@ module ReferralHelper
     else
       "Incomplete"
     end
+  end
+
+  def nullable_boolean_to_s(
+    value,
+    yes = "Yes",
+    noo = "No",
+    not_answered = "Not answered"
+  )
+    value.nil? && not_answered || value && yes || noo
+  end
+
+  def nullable_value_to_s(value, not_answered = "Not answered")
+    value.nil? && not_answered || value
   end
 end

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -116,6 +116,7 @@ FactoryBot.define do
 
     trait :allegation_details do
       allegation_details_complete { true }
+      allegation_format { "details" }
       allegation_details { "They were rude to a child" }
       dbs_notified { true }
     end


### PR DESCRIPTION
### Context

To make it clear when on the review page which answers have been completed.

### Changes proposed in this pull request

**Employer referral before:**
![employer_referral_old](https://user-images.githubusercontent.com/29513/223060583-c9c7581d-b8fa-47d7-beab-612a4d1c6ae9.png)

**Employer referral after:**
![employer_referral_new](https://user-images.githubusercontent.com/29513/223060619-85b6e61d-80c4-4b00-9ae0-0a7067891f0b.png)

**Public referral before:** 
![public_referral_old](https://user-images.githubusercontent.com/29513/223060727-490a8357-5b6a-4347-a32b-01489263a47f.png)

**Public referral after:**
![public_referral_new](https://user-images.githubusercontent.com/29513/223060790-1656b004-0bcb-4765-b625-40ea94ef928b.png)

### Link to Trello card

https://trello.com/c/xSN27sN4/1229-not-answered-on-referral-show-page 

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
