### PR TITLE
Fix work location address visibility

### DIFF
--- a/app/components/their_role_component.rb
+++ b/app/components/their_role_component.rb
@@ -27,7 +27,7 @@ class TheirRoleComponent < ViewComponent::Base
       items << working_somewhere_else_row
 
       items << work_location_known_row if referral.working_somewhere_else?
-      items << work_location_row if referral.work_location_known
+      items << work_location_row if referral.work_location_known?
     end
 
     referral.submitted? ? remove_actions(items) : items

--- a/app/views/manage_interface/referrals/show.html.erb
+++ b/app/views/manage_interface/referrals/show.html.erb
@@ -22,12 +22,12 @@
     <%= render ManageInterface::PersonalDetailsComponent.new(referral: @referral) %>
     <%= render ManageInterface::EmploymentDetailsComponent.new(referral: @referral) %>
 
-    <% if @referral.from_employer? %>
+    <% if @referral.work_location_known? %>
       <%= render ManageInterface::OtherEmploymentDetailsComponent.new(referral: @referral) %>
     <% end %>
 
     <%= render ManageInterface::AllegationDetailsComponent.new(referral: @referral) %>
-    
+
     <%= render ManageInterface::EvidenceComponent.new(referral: @referral) %>
 
     <% if @referral.from_employer? %>

--- a/app/views/referrals/pdf.html.erb
+++ b/app/views/referrals/pdf.html.erb
@@ -26,7 +26,7 @@
         <div class="no-break">
           <%= render ManageInterface::EmploymentDetailsComponent.new(referral:) %>
         </div>
-        <% if referral.from_employer? %>
+        <% if referral.work_location_known? %>
           <div class="no-break">
             <%= render ManageInterface::OtherEmploymentDetailsComponent.new(referral:) %>
           </div>


### PR DESCRIPTION
### Context

Work location address visibility was wrong in manage and on the PDF

### Changes proposed in this pull request

What I found is that the address did show correctly if it is entered. But it would sometimes show as blank if the no radio was checked on work location known so I fixed that

### Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/B37qRbzo/1281-other-employer-details)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
