### PR TITLE
Remove the sign up functionality

### DIFF
--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -5,7 +5,6 @@ class Staff < ApplicationRecord
     :invitable,
     :lockable,
     :recoverable,
-    :registerable,
     :rememberable,
     :timeoutable,
     :trackable,

--- a/app/views/staff/shared/_links.html.erb
+++ b/app/views/staff/shared/_links.html.erb
@@ -3,10 +3,6 @@
     <%= govuk_link_to "Log in", new_session_path(resource_name) %><br />
   <% end %>
 
-  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-    <%= govuk_link_to "Sign up", new_registration_path(resource_name) %><br />
-  <% end %>
-
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
     <%= govuk_link_to "Forgot your password?", new_password_path(resource_name) %><br />
   <% end %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -14,7 +14,7 @@ en:
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
       timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
+      unauthenticated: "You need to sign in before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
       user:
         otp_invalid: "Invalid code"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     path: "",
     path_names: {
       sign_in:  "manage/sign-in",
-      sign_out: "manage/sign-out",
+      sign_out: "manage/sign-out"
     }
   )
   devise_scope :staff do


### PR DESCRIPTION
### Context

Staff users can’t sign up, they have to be invited.

### Changes proposed in this pull request

The signup page is removed

The signup link is removed from the login page

The ‘signin’ flash message no longer mentions signing up

### Link to Trello card

https://trello.com/c/lSXzgqrX/1280-remove-sign-up-functionality