### PR TITLE
Make long text fields all render with simple_format

### DIFF
--- a/app/components/manage_interface/allegation_details_component.rb
+++ b/app/components/manage_interface/allegation_details_component.rb
@@ -32,7 +32,7 @@ module ManageInterface
               text: "Details about how this complaint has been considered"
             },
             value: {
-              text: referral.allegation_consideration_details
+              text: simple_format(referral.allegation_consideration_details)
             }
           }
         )

--- a/app/components/public_allegation_component.rb
+++ b/app/components/public_allegation_component.rb
@@ -85,8 +85,10 @@ class PublicAllegationComponent < ViewComponent::Base
         },
         value: {
           text:
-            nullable_value_to_s(
-              referral.allegation_consideration_details.presence
+            simple_format(
+              nullable_value_to_s(
+                referral.allegation_consideration_details.presence
+              )
             )
         }
       }


### PR DESCRIPTION
### Context

Consistent rendering of user entered textareas

### Changes proposed in this pull request

Ensure simple_format is used throughout the review page, the check answers page and the manage interface.

### Link to Trello card

https://trello.com/c/S8ku33F5/1278-add-line-breaks-for-paragraphs-in-text-fields

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
