### PR TITLE
Send confirmation email

### DIFF
--- a/app/controllers/referrals/review_controller.rb
+++ b/app/controllers/referrals/review_controller.rb
@@ -9,6 +9,7 @@ module Referrals
 
       if @referral_form.submit
         CaseworkerMailer.referral_submitted(current_referral).deliver_later
+        UserMailer.referral_submitted(current_referral).deliver_later
         redirect_to [
                       current_referral.routing_scope,
                       current_referral,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -20,4 +20,15 @@ class UserMailer < ApplicationMailer
 
     view_mail(GENERIC_NOTIFY_TEMPLATE, mailer_options)
   end
+
+  def referral_submitted(referral)
+    @link = users_referral_url(referral)
+    @user = referral.user
+    mailer_options = {
+      to: @user.email,
+      subject: "Your referral of serious misconduct has been sent"
+    }
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE, mailer_options)
+  end
 end

--- a/app/views/user_mailer/referral_submitted.erb
+++ b/app/views/user_mailer/referral_submitted.erb
@@ -1,0 +1,24 @@
+You’ve sent a referral of serious misconduct.
+
+View your referral:
+
+<%= @link %>
+
+WHAT HAPPENS NEXT
+
+Your referral will usually be reviewed within 3 working days. It may be longer if more information is needed.
+
+It could be decided that:
+
+* the case will not be investigated, for example because it’s unlikely the teacher will be stopped from teaching
+* a formal investigation will be launched
+
+You’ll be sent an email with the decision.
+
+GET HELP
+
+Email: misconduct.teacher@education.gov.uk
+We aim to respond within 3 working days.
+
+Phone: 020 7593 5393
+Monday to Friday, 9am to 5pm (except public holidays)

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -41,4 +41,25 @@ RSpec.describe UserMailer, type: :mailer do
       ).to eq "Your referral of serious misconduct by a teacher"
     end
   end
+
+  describe ".referral_submitted" do
+    subject(:email) { described_class.referral_submitted(referral) }
+
+    let(:user) { create(:user) }
+    let(:referral) { create(:referral, :submitted, user_id: user.id) }
+
+    it "sends a referral link to the user" do
+      expect(email.to).to include user.email
+    end
+
+    it "includes the referral link in the email body" do
+      expect(email.body).to include(users_referral_url(referral))
+    end
+
+    it "sets the subject" do
+      expect(
+        email.subject
+      ).to eq "Your referral of serious misconduct has been sent"
+    end
+  end
 end

--- a/spec/system/public_referrals/user_submits_referral_spec.rb
+++ b/spec/system/public_referrals/user_submits_referral_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature "A member of the public submits a referral", type: :system do
     then_i_see_the_check_answers_page
     and_i_click_send_referral
     then_i_see_the_confirmation_page
+    then_i_see_a_referral_submitted_email
   end
 
   private
@@ -69,5 +70,15 @@ RSpec.feature "A member of the public submits a referral", type: :system do
     @referral.update(attributes_for(:referral, :complete))
     create(:organisation, complete: true, referral: @referral)
     create(:referrer, complete: true, referral: @referral)
+  end
+
+  def then_i_see_a_referral_submitted_email
+    perform_enqueued_jobs
+    message = ActionMailer::Base.deliveries.last
+    expect(message.subject).to eq(
+      "Your referral of serious misconduct has been sent"
+    )
+    expect(message.to).to include(@referral.user.email)
+    expect(message.body).to include(users_referral_path(@referral))
   end
 end


### PR DESCRIPTION
### Context

When a user submits a referral they will receive a confirmation email.

### Link to Trello card

https://trello.com/c/7M27fCB9/1282-send-confirmation-email
