### PR TITLE
[1285] Add another heading to the PDF

### DIFF
--- a/app/views/referrals/pdf.html.erb
+++ b/app/views/referrals/pdf.html.erb
@@ -16,6 +16,7 @@
     <img src="<%= @logo %>" class="logo"/>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
+        <span class="govuk-heading-l">Teacher misconduct referral form</span>
         <h1 class="govuk-heading-l"><%= referral.name %></h1>
         <div class="no-break">
           <%= render ManageInterface::ReferralSummaryComponent.new(referral:) %>


### PR DESCRIPTION
### Context

Add another heading to the PDF to make it clear that the document represents a teacher misconduct referral form.

### Changes proposed in this pull request

* Add 'Teacher misconduct referral form' to the PDF

### Guidance to review


### Link to Trello card


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
