### PR TITLE
Update email templates to use new get help partial

### DIFF
--- a/app/views/shared/mailers/_get_help.erb
+++ b/app/views/shared/mailers/_get_help.erb
@@ -1,0 +1,7 @@
+# Get help
+
+Email: misconduct.teacher@education.gov.uk
+We aim to respond within 3 working days.
+
+Phone: 020 7593 5393
+Monday to Friday, 9am to 5pm (except public holidays)

--- a/app/views/user_mailer/otp.erb
+++ b/app/views/user_mailer/otp.erb
@@ -4,10 +4,4 @@ The code will expire in 1 hour. You can only use the code once.
 
 Confirmation code: <%= @otp %>
 
-GET HELP
-
-Email: misconduct.teacher@education.gov.uk
-We aim to respond within 3 working days.
-
-Phone: 020 7593 5393
-Monday to Friday, 9am to 5pm (except public holidays)
+<%= render "shared/mailers/get_help" %>

--- a/app/views/user_mailer/referral_link.erb
+++ b/app/views/user_mailer/referral_link.erb
@@ -4,10 +4,4 @@ Complete your referral:
 
 <%= polymorphic_url([:edit, @referral.routing_scope, @referral]) %>
 
-GET HELP
-
-Email: misconduct.teacher@education.gov.uk
-We aim to respond within 3 working days.
-
-Phone: 020 7593 5393
-Monday to Friday, 9am to 5pm (except public holidays)
+<%= render "shared/mailers/get_help" %>

--- a/app/views/user_mailer/referral_submitted.erb
+++ b/app/views/user_mailer/referral_submitted.erb
@@ -4,7 +4,7 @@ View your referral:
 
 <%= @link %>
 
-WHAT HAPPENS NEXT
+# What happens next
 
 Your referral will usually be reviewed within 3 working days. It may be longer if more information is needed.
 
@@ -15,10 +15,4 @@ It could be decided that:
 
 You’ll be sent an email with the decision.
 
-GET HELP
-
-Email: misconduct.teacher@education.gov.uk
-We aim to respond within 3 working days.
-
-Phone: 020 7593 5393
-Monday to Friday, 9am to 5pm (except public holidays)
+<%= render "shared/mailers/get_help" %>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe UserMailer, type: :mailer do
     it "sets the subject" do
       expect(email.subject).to eq "#{otp} is your confirmation code"
     end
+
+    it_behaves_like "email with `Get help` section"
   end
 
   describe ".referral_link" do
@@ -40,6 +42,8 @@ RSpec.describe UserMailer, type: :mailer do
         email.subject
       ).to eq "Your referral of serious misconduct by a teacher"
     end
+
+    it_behaves_like "email with `Get help` section"
   end
 
   describe ".referral_submitted" do
@@ -61,5 +65,7 @@ RSpec.describe UserMailer, type: :mailer do
         email.subject
       ).to eq "Your referral of serious misconduct has been sent"
     end
+
+    it_behaves_like "email with `Get help` section"
   end
 end

--- a/spec/support/shared_examples/mailers_get_help.rb
+++ b/spec/support/shared_examples/mailers_get_help.rb
@@ -1,0 +1,13 @@
+RSpec.shared_examples "email with `Get help` section" do
+  it "includes the header" do
+    expect(email.body).to include("Get help")
+  end
+
+  it "includes the contact email" do
+    expect(email.body).to include("misconduct.teacher@education.gov.uk")
+  end
+
+  it "includes the contact phone number" do
+    expect(email.body).to include("020 7593 5393")
+  end
+end


### PR DESCRIPTION
### Context

Formatting was required for uppercase headers in mailers. I have added a new partial to be used in all mailers to keep the formatting consistent.

Before
<img width="610" alt="Screenshot 2023-03-08 at 15 50 01" src="https://user-images.githubusercontent.com/1636476/223761638-fff16020-f114-4e33-94f0-2f72aec6ab97.png">

After
<img width="607" alt="Screenshot 2023-03-08 at 15 50 05" src="https://user-images.githubusercontent.com/1636476/223761662-46c6b300-11f8-42c7-914a-6cb44592a7ca.png">

### Link to Trello card

https://trello.com/c/l9sRYPmh/1288-format-of-confirmation-code-requested-email