### PR TITLE
Fix links in referral PDF

### DIFF
--- a/app/jobs/render_pdf_job.rb
+++ b/app/jobs/render_pdf_job.rb
@@ -28,6 +28,10 @@ class RenderPdfJob < ApplicationJob
     )
   end
 
+  def processed_html
+    html&.gsub(%r{<a.*?>(.*?)</a>}, '\1')
+  end
+
   def html_renderer
     @html_renderer = ApplicationController.renderer.new
   end
@@ -37,7 +41,7 @@ class RenderPdfJob < ApplicationJob
   end
 
   def io
-    StringIO.new(Grover.new(html, format: "A4").to_pdf)
+    StringIO.new(Grover.new(processed_html, format: "A4").to_pdf)
   end
 
   def asset_url(asset_name)

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -51,6 +51,9 @@ FactoryBot.define do
     end
 
     trait :with_attachments do
+      allegation_format { "upload" }
+      duties_format { "upload" }
+
       allegation_upload do
         Rack::Test::UploadedFile.new("spec/fixtures/files/upload1.pdf")
       end

--- a/spec/jobs/render_pdf_job_spec.rb
+++ b/spec/jobs/render_pdf_job_spec.rb
@@ -3,6 +3,17 @@ require "rails_helper"
 RSpec.describe RenderPdfJob do
   let(:referral) { create(:referral, :complete, :with_attachments) }
 
+  describe "generating the HTML" do
+    let(:job) { described_class.new }
+
+    it "renders the html and removes the a tags" do
+      job.perform(referral:)
+
+      expect(job.send(:html)).to match(%r{<dd.*?><a.*?>upload1.pdf</a></dd>})
+      expect(job.send(:processed_html)).to match(%r{<dd.*?>upload1.pdf</dd>})
+    end
+  end
+
   describe "running the job" do
     subject(:perform) { described_class.new.perform(referral:) }
 


### PR DESCRIPTION
### Context

Links in the PDF weren't working and couldn't work as they are expiring URLs so we replaced them with filenames

### Link to Trello card

https://trello.com/c/OGu8lUE6/1242-fix-links-in-the-referral-pdf

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
