### PR TITLE
Fix sign out bug

### DIFF
--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -37,6 +37,10 @@ class Staff::SessionsController < Devise::SessionsController
     end
   end
 
+  def after_sign_out_path_for(_resource)
+    manage_sign_in_path
+  end
+
   # protected
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/spec/system/manage/case_worker_returns_to_original_url_after_login_spec.rb
+++ b/spec/system/manage/case_worker_returns_to_original_url_after_login_spec.rb
@@ -14,6 +14,10 @@ RSpec.feature "Manage referrals and staff" do
 
     and_i_login_as_a_case_worker_with_management_permissions_only
     then_i_see_the_referral_summary
+
+    when_i_sign_out
+    and_i_login_as_a_case_worker_with_management_permissions_only
+    then_i_see_manage_referrals_page
   end
 
   private
@@ -46,5 +50,9 @@ RSpec.feature "Manage referrals and staff" do
     fill_in "Password", with: "Example123!"
 
     click_on "Log in"
+  end
+
+  def when_i_sign_out
+    within(".govuk-header") { click_on "Sign out" }
   end
 end


### PR DESCRIPTION
Clicking the sign out link in the manage interface header was not working properly. It was redirecting to the user sign in page instead of the staff sign in page.

Before
<img width="547" alt="Screenshot 2023-03-08 at 15 00 00" src="https://user-images.githubusercontent.com/1636476/223748846-efaca047-6eba-4442-a19e-a05a0bd59cf6.png">

After
<img width="729" alt="Screenshot 2023-03-08 at 14 59 52" src="https://user-images.githubusercontent.com/1636476/223748866-24fbbcaf-8bca-4a6d-b441-3258e8733101.png">
