### PR TITLE
1309 -  [BUG FIX] Caseworker notification email uses the teacher name

### DIFF
--- a/app/mailers/caseworker_mailer.rb
+++ b/app/mailers/caseworker_mailer.rb
@@ -2,7 +2,7 @@ class CaseworkerMailer < ApplicationMailer
   include Rails.application.routes.url_helpers
 
   def referral_submitted(referral)
-    @name = referral.referrer_name
+    @name = referral.name
     @link = manage_interface_referral_url(referral)
     mailer_options = {
       to: misconduct_notify_mailer_to,

--- a/spec/mailers/caseworker_mailer_spec.rb
+++ b/spec/mailers/caseworker_mailer_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe CaseworkerMailer, type: :mailer do
   describe ".referral_submitted" do
     subject(:email) { described_class.referral_submitted(referral) }
 
-    let(:referral) { create(:referral, :submitted) }
+    let(:referral) { create(:referral, :personal_details_public, :submitted) }
 
     it "includes the required information" do
       expect(
         email.body
-      ).to include "Jane Smith has been referred for serious misconduct by a teacher"
+      ).to include "John Smith has been referred for serious misconduct by a teacher"
     end
 
     it "includes the manage referral URL" do
@@ -17,7 +17,7 @@ RSpec.describe CaseworkerMailer, type: :mailer do
     end
 
     it "sets the subject" do
-      expect(email.subject).to eq "Jane Smith has been referred"
+      expect(email.subject).to eq "John Smith has been referred"
     end
 
     describe "to email address" do


### PR DESCRIPTION
### Context

Caseworker notification email uses the teacher name

### Changes proposed in this pull request

Caseworker notification email was mentioning the referrer name which is incorrect. It has to be the referred teacher name instead.

### Guidance to review

Fill in a referral form and submit it. The caseworker notification email should contain the referred teacher name now.

### Link to Trello card

https://trello.com/c/95uN1pyY

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
