### PR TITLE
Update Pundit unauthorised redirect

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -18,4 +18,8 @@ class ErrorsController < ApplicationController
   def internal_server_error
     render "internal_server_error", status: :internal_server_error
   end
+
+  def forbidden
+    render "forbidden", status: :forbidden
+  end
 end

--- a/app/controllers/manage_interface/manage_interface_controller.rb
+++ b/app/controllers/manage_interface/manage_interface_controller.rb
@@ -14,9 +14,7 @@ module ManageInterface
     end
 
     def staff_user_not_authorized
-      flash[:warning] = I18n.t("pundit.unauthorized")
-
-      redirect_to root_path
+      redirect_to forbidden_path
     end
 
     alias_method :pundit_user, :current_staff

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -32,8 +32,7 @@ class Staff::SessionsController < Devise::SessionsController
     elsif current_staff.view_support?
       support_interface_staff_index_path
     else
-      flash[:warning] = I18n.t("pundit.unauthorized")
-      root_path
+      forbidden_path
     end
   end
 

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -12,12 +12,12 @@ module SupportInterface
     private
 
     def staff_user_not_authorized
-      flash[:warning] = I18n.t("pundit.unauthorized")
-
       # FeatureFlags::Engine is a mounted engine and we can't control the
       # behaviour from this level. Attempting to do the redirect
       # here ends up in multiple redirects.
-      redirect_to root_path unless is_a?(FeatureFlags::FeatureFlagsController)
+      unless is_a?(FeatureFlags::FeatureFlagsController)
+        redirect_to forbidden_path
+      end
     end
 
     def authorize_support

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,11 @@
+<%= content_for :page_title, "Forbidden" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('pundit.unauthorized') %></h1>
+    <p class="govuk-body">
+      If you need access to this page, send an email to
+      <a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,4 +369,4 @@ en:
     missing_staff_permission: Select permissions
 
   pundit:
-    unauthorized: You are not authorized to see this section.
+    unauthorized: You do not have permission to view this page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -303,6 +303,7 @@ Rails.application.routes.draw do
   get "/privacy", to: "static#privacy"
 
   scope via: :all do
+    get "/403", to: "errors#forbidden", as: :forbidden
     get "/404", to: "errors#not_found"
     get "/422", to: "errors#unprocessable_entity"
     get "/429", to: "errors#too_many_requests"

--- a/spec/support/system/authorization_steps.rb
+++ b/spec/support/system/authorization_steps.rb
@@ -43,12 +43,12 @@ module AuthorizationSteps
                :when_i_am_authorized_with_basic_auth_as_a_case_worker
 
   def then_i_am_unauthorized
-    expect(page).to have_content("You are not authorized to see this section.")
+    expect(page).to have_content("You do not have permission to view this page")
   end
 
-  def then_i_am_unauthorized_and_redirected_to_root_path
-    expect(page).to have_current_path("/users/registrations/exists")
-    expect(page).to have_content("You are not authorized to see this section.")
+  def then_i_am_unauthorized_and_redirected_to_forbidden_path
+    expect(page).to have_current_path("/403")
+    expect(page).to have_content("You do not have permission to view this page")
   end
 
   def then_i_see_the_staff_index

--- a/spec/system/manage/case_worker_with_basic_auth_is_not_authorized_to_view_a_public_referral_spec.rb
+++ b/spec/system/manage/case_worker_with_basic_auth_is_not_authorized_to_view_a_public_referral_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Manage referrals" do
     and_there_is_an_existing_public_referral
 
     when_i_visit_the_referral
-    then_i_am_unauthorized_and_redirected_to_root_path
+    then_i_am_unauthorized_and_redirected_to_forbidden_path
   end
 
   private

--- a/spec/system/manage/case_worker_with_basic_auth_is_not_authorized_to_view_an_employer_referral_spec.rb
+++ b/spec/system/manage/case_worker_with_basic_auth_is_not_authorized_to_view_an_employer_referral_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Manage referrals" do
     and_there_is_an_existing_employer_referral
 
     when_i_visit_the_referral
-    then_i_am_unauthorized_and_redirected_to_root_path
+    then_i_am_unauthorized_and_redirected_to_forbidden_path
   end
 
   private

--- a/spec/system/manage/case_worker_with_basic_auth_is_not_authorized_to_view_public_referrals_spec.rb
+++ b/spec/system/manage/case_worker_with_basic_auth_is_not_authorized_to_view_public_referrals_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Manage referrals" do
     when_i_am_authorized_with_basic_auth_as_a_case_worker
     when_i_visit_the_referrals_page
 
-    then_i_am_unauthorized_and_redirected_to_root_path
+    then_i_am_unauthorized_and_redirected_to_forbidden_path
   end
 
   private

--- a/spec/system/manage/case_worker_without_permissions_is_not_authorized_to_view_a_public_referral_spec.rb
+++ b/spec/system/manage/case_worker_without_permissions_is_not_authorized_to_view_a_public_referral_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Manage referrals" do
 
     when_i_login_as_a_case_worker_with_support_permissions_only
     and_i_visit_the_referral
-    then_i_am_unauthorized_and_redirected_to_root_path
+    then_i_am_unauthorized_and_redirected_to_forbidden_path
   end
 
   private

--- a/spec/system/manage/case_worker_without_permissions_is_not_authorized_to_view_an_employer_referral_spec.rb
+++ b/spec/system/manage/case_worker_without_permissions_is_not_authorized_to_view_an_employer_referral_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Manage referrals" do
 
     when_i_login_as_a_case_worker_with_support_permissions_only
     and_i_visit_the_referral
-    then_i_am_unauthorized_and_redirected_to_root_path
+    then_i_am_unauthorized_and_redirected_to_forbidden_path
   end
 
   private

--- a/spec/system/manage/case_worker_without_permissions_is_not_authorized_to_view_public_referrals_spec.rb
+++ b/spec/system/manage/case_worker_without_permissions_is_not_authorized_to_view_public_referrals_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Manage referrals" do
 
     when_i_login_as_a_case_worker_with_support_permissions_only
     and_i_visit_the_referrals_page
-    then_i_am_unauthorized_and_redirected_to_root_path
+    then_i_am_unauthorized_and_redirected_to_forbidden_path
   end
 
   private

--- a/spec/system/support/staff_user_with_basic_auth_is_not_authorized_to_create_test_users_spec.rb
+++ b/spec/system/support/staff_user_with_basic_auth_is_not_authorized_to_create_test_users_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Test users" do
     when_i_am_authorized_with_basic_auth_as_a_case_worker
 
     and_i_visit_the_test_users_section
-    then_i_am_unauthorized_and_redirected_to_root_path
+    then_i_am_unauthorized_and_redirected_to_forbidden_path
   end
 
   private


### PR DESCRIPTION
### Context

Replaces the referrer root path redirect with a custom 403 page.

Before:
<img width="836" alt="Screenshot 2023-03-10 at 15 25 02" src="https://user-images.githubusercontent.com/1636476/224679080-3c00d028-d971-4206-b4d9-6b8c3482ead7.png">

After (redirected to a /403 page):
<img width="724" alt="Screenshot 2023-03-13 at 10 42 15" src="https://user-images.githubusercontent.com/1636476/224678990-f12cf83c-6418-4e9a-97b3-c67c414843be.png">

### Link to Trello card

https://trello.com/c/t7b9irHW/1309-bug-manage-support-interface-accessing-a-page-you-dont-have-access-to-redirects-to-the-referrer-login-page