### PR TITLE
Store declaration content on submit

### DIFF
--- a/app/lib/declaration_renderer.rb
+++ b/app/lib/declaration_renderer.rb
@@ -1,0 +1,15 @@
+class DeclarationRenderer
+  include ActionView::Helpers::SanitizeHelper
+
+  def render
+    strip_tags(rendered_declaration_partial)
+      .lines
+      .reject(&:blank?)
+      .each(&:strip!)
+      .join("\n")
+  end
+
+  def rendered_declaration_partial
+    ApplicationController.renderer.new.render(partial: "shared/declaration")
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -37,6 +37,8 @@ class Referral < ApplicationRecord
   delegate :name, to: :referrer, prefix: true, allow_nil: true
 
   def submit
+    self.declaration = DeclarationRenderer.new.render
+
     update(submitted_at: Time.current) &&
       RenderPdfJob.perform_later(referral: self)
   end

--- a/app/views/public_referrals/review/show.html.erb
+++ b/app/views/public_referrals/review/show.html.erb
@@ -14,15 +14,7 @@
 
           <h2 class="govuk-heading-m govuk-!-font-size-27">Declaration</h2>
 
-          <p>By sending this referral, you agree that:</p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>your allegation will be investigated, which could result in the person you’re referring being stopped from teaching</li>
-            <li>your answers are true to the best of your knowledge and belief</li>
-            <li>your referral, any evidence and supporting information will be shared with the person you’re referring and any employer</li>
-            <li>you have permission from the relevant third parties for any evidence and supporting information to be shared, for example the police or DBS</li>
-            <li>you may need to attend a hearing and give evidence if your allegation reaches that stage</li>
-            <li>your referral will be kept on file for 50 years</li>
-          </ul>
+          <%= render partial: 'shared/declaration' %>
 
           <button class="govuk-button" data-module="govuk-button">
             Agree and send referral

--- a/app/views/referrals/review/show.html.erb
+++ b/app/views/referrals/review/show.html.erb
@@ -14,15 +14,7 @@
 
           <h2 class="govuk-heading-m govuk-!-font-size-27">Declaration</h2>
 
-          <p>By sending this referral, you agree that:</p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>your allegation will be investigated, which could result in the person you’re referring being stopped from teaching</li>
-            <li>your answers are true to the best of your knowledge and belief</li>
-            <li>your referral, any evidence and supporting information will be shared with the person you’re referring and any employer</li>
-            <li>you have permission from the relevant third parties for any evidence and supporting information to be shared, for example the police or DBS</li>
-            <li>you may need to attend a hearing and give evidence if your allegation reaches that stage</li>
-            <li>your referral will be kept on file for 50 years</li>
-          </ul>
+          <%= render partial: 'shared/declaration' %>
 
           <button class="govuk-button" data-module="govuk-button">
             Agree and send referral

--- a/app/views/shared/_declaration.html.erb
+++ b/app/views/shared/_declaration.html.erb
@@ -1,0 +1,10 @@
+<p>By sending this referral, you agree that:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>your allegation will be investigated, which could result in the person you’re referring being stopped from teaching</li>
+  <li>your answers are true to the best of your knowledge and belief</li>
+  <li>your referral, any evidence and supporting information will be shared with the person you’re referring and any employer</li>
+  <li>you have permission from the relevant third parties for any evidence and supporting information to be shared, for example the police or DBS</li>
+  <li>you may need to attend a hearing and give evidence if your allegation reaches that stage</li>
+  <li>your referral will be kept on file for 50 years</li>
+</ul>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -8,3 +8,5 @@
     - confirmation_token
     - unlock_token
     - invitation_token
+  :referrals:
+    - declaration

--- a/db/migrate/20230310125912_add_declaration_to_referrals.rb
+++ b/db/migrate/20230310125912_add_declaration_to_referrals.rb
@@ -1,0 +1,5 @@
+class AddDeclarationToReferrals < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referrals, :declaration, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_03_141955) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_10_125912) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
 
@@ -21,9 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_03_141955) do
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index %w[record_type record_id name blob_id],
-            name: "index_active_storage_attachments_uniqueness",
-            unique: true
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
@@ -41,9 +39,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_03_141955) do
   create_table "active_storage_variant_records", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
-    t.index %w[blob_id variation_digest],
-            name: "index_active_storage_variant_records_uniqueness",
-            unique: true
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "eligibility_checks", force: :cascade do |t|
@@ -150,8 +146,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_03_141955) do
     t.boolean "previous_misconduct_complete"
     t.string "ni_number"
     t.boolean "ni_number_known"
-    t.index ["eligibility_check_id"],
-            name: "index_referrals_on_eligibility_check_id"
+    t.text "declaration"
+    t.index ["eligibility_check_id"], name: "index_referrals_on_eligibility_check_id"
     t.index ["user_id"], name: "index_referrals_on_user_id"
   end
 
@@ -224,12 +220,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_03_141955) do
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
-  add_foreign_key "active_storage_attachments",
-                  "active_storage_blobs",
-                  column: "blob_id"
-  add_foreign_key "active_storage_variant_records",
-                  "active_storage_blobs",
-                  column: "blob_id"
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "organisations", "referrals"
   add_foreign_key "referral_evidences", "referrals"
   add_foreign_key "referrals", "eligibility_checks"


### PR DESCRIPTION
### Context

The declaration could change and we would currently have to review commits and deploy times to figure out which users agreed to which declaration. 

### Changes proposed in this pull request

Separate the declaration into a partial
Render a cleaned version of that partial into a db field on the referral

### Guidance to review

An alternative solution which I did do a spike on is to save the version of the partial - this would have to rely on an ENV var to set the current version which would be vulnerable to configuration error and have problems with rollbacks.

The proposed solution seems the cleanest way to achieve this.

### Link to Trello card

https://trello.com/c/p7FqEU5w/1303-store-the-declaration-content-that-the-user-has-agreed-to-with-the-referral

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
