### PR TITLE
1301 - Allow staff users to be soft deleted

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Rails/ApplicationController:
 Rails/LexicallyScopedActionFilter:
   Exclude:
     - app/controllers/staff/**/*
+    - app/controllers/support_interface/staff_controller.rb
 
 Rails/SaveBang:
   Enabled: false

--- a/app/controllers/support_interface/staff_controller.rb
+++ b/app/controllers/support_interface/staff_controller.rb
@@ -1,7 +1,35 @@
 module SupportInterface
   class StaffController < SupportInterfaceController
+    before_action :can_delete, only: %i[destroy delete]
+
     def index
-      @staff = Staff.order(:email)
+      @staff = Staff.active.order(:email)
+    end
+
+    def destroy
+      staff_user.archive
+
+      flash[:info] = if staff_user.save
+        "User deleted"
+      else
+        "User could not be deleted"
+      end
+
+      redirect_to support_interface_staff_index_path
+    end
+
+    private
+
+    def can_delete
+      if current_staff.id == staff_user.id
+        flash[:info] = "You cannot delete your own user"
+
+        redirect_to support_interface_staff_index_path and return
+      end
+    end
+
+    def staff_user
+      @staff_user ||= Staff.find(params[:id])
     end
   end
 end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -12,8 +12,11 @@ class Staff < ApplicationRecord
     validate_on_invite: true
   )
 
+  validates :email, uniqueness: true
   validate :password_complexity
   validate :permissions_are_valid
+
+  scope :active, -> { where(deleted_at: nil) }
 
   def password_complexity
     if password.blank? ||
@@ -22,6 +25,10 @@ class Staff < ApplicationRecord
     end
 
     errors.add(:password, :password_complexity)
+  end
+
+  def archive
+    self.deleted_at = Time.zone.now
   end
 
   def send_devise_notification(notification, *args)
@@ -35,5 +42,15 @@ class Staff < ApplicationRecord
       :permissions,
       I18n.t("validation_errors.missing_staff_permission")
     )
+  end
+
+  def active_for_authentication?
+    super && active?
+  end
+
+  private
+
+  def active?
+    deleted_at.nil?
   end
 end

--- a/app/policies/support_policy.rb
+++ b/app/policies/support_policy.rb
@@ -23,6 +23,18 @@ class SupportPolicy < ApplicationPolicy
     super
   end
 
+  def delete?
+    return user.view_support? if user.is_a?(Staff)
+
+    false
+  end
+
+  def destroy?
+    return user.view_support? if user.is_a?(Staff)
+
+    super
+  end
+
   def authenticate?
     return user.view_support? if user.is_a?(Staff)
 

--- a/app/views/support_interface/staff/delete.html.erb
+++ b/app/views/support_interface/staff/delete.html.erb
@@ -1,0 +1,13 @@
+<% content_for :back_link_url, support_interface_staff_index_path %>
+<% content_for :page_title, "Delete #{@staff_user.email}" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @staff_user.email %></span>
+    <h1 class="govuk-heading-l">Confirm that you want to delete this user</h1>
+
+    <p class="govuk-body">
+      <%= govuk_button_to "Delete user", support_interface_staff_path, method: :delete, class: "govuk-button govuk-button--warning" %>
+      <%= govuk_link_to "Cancel", support_interface_staff_index_path %>
+    </p>
+</div>

--- a/app/views/support_interface/staff/index.html.erb
+++ b/app/views/support_interface/staff/index.html.erb
@@ -14,6 +14,7 @@
     <% if staff.created_by_invite? && !staff.invitation_accepted? %>
       <%= govuk_link_to "Resend invitation", edit_support_interface_staff_invitation_path(staff) %>
     <% end %>
+    <%= govuk_link_to "Delete user", delete_support_interface_staff_path(staff) unless staff.id == current_staff.id %>
   </div>
 
   <%= govuk_summary_list do |summary_list|

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -169,3 +169,4 @@ shared:
     - invitations_count
     - view_support
     - manage_referrals
+    - deleted_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,7 +276,9 @@ Rails.application.routes.draw do
 
   namespace :support_interface, path: "/support" do
     root to: redirect("/support/eligibility-checks")
-    resources :staff, only: %i[index]
+    resources :staff, only: %i[index destroy] do
+      get '/delete', on: :member, to: "staff#delete"
+    end
     resources :staff_permissions, only: %i[edit update]
     resources :staff_invitations, only: %i[edit update]
     resources :test_users, only: %i[index create] do

--- a/db/migrate/20230313112021_add_deleted_at_field_to_staff_user.rb
+++ b/db/migrate/20230313112021_add_deleted_at_field_to_staff_user.rb
@@ -1,0 +1,7 @@
+class AddDeletedAtFieldToStaffUser < ActiveRecord::Migration[7.0]
+  def change
+    change_table :staff, bulk: true do |t|
+      t.timestamp :deleted_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_10_125912) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_13_112021) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
 
@@ -193,6 +193,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_10_125912) do
     t.integer "invitations_count", default: 0
     t.boolean "view_support", default: false
     t.boolean "manage_referrals", default: false
+    t.datetime "deleted_at", precision: nil
     t.index ["confirmation_token"], name: "index_staff_on_confirmation_token", unique: true
     t.index ["email"], name: "index_staff_on_email", unique: true
     t.index ["invitation_token"], name: "index_staff_on_invitation_token", unique: true

--- a/spec/factories/staffs.rb
+++ b/spec/factories/staffs.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
     confirmed_at { Time.zone.now }
   end
 
+  trait :deleted do
+    deleted_at { Time.zone.now }
+  end
+
   trait :can_view_support do
     view_support { true }
   end

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -42,10 +42,28 @@ RSpec.describe Staff, type: :model do
       end
     end
 
+    context "when the email address is already taken" do
+      before { create(:staff) }
+
+      let(:staff) { build(:staff) }
+
+      it { is_expected.to be_falsey }
+    end
+
     context "when the permissions are invalid" do
       let(:staff) { build(:staff, view_support: nil, manage_referrals: nil) }
 
       it { is_expected.to be_falsey }
+    end
+  end
+
+  describe "#archive" do
+    let(:staff) { create(:staff) }
+
+    it "marks the user as deleted" do
+      staff.archive
+
+      expect(staff.deleted_at).to be_within(1).of(Time.zone.now)
     end
   end
 end

--- a/spec/policies/support_policy_spec.rb
+++ b/spec/policies/support_policy_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe SupportPolicy do
     it_behaves_like "staff policy with permission", :can_view_support
   end
 
+  describe "#delete?" do
+    subject(:delete?) { policy.delete? }
+
+    it_behaves_like "staff policy with permission", :can_view_support
+  end
+
+  describe "#destroy?" do
+    subject(:destroy?) { policy.destroy? }
+
+    it_behaves_like "staff policy with permission", :can_view_support
+  end
+
   describe "#activate?" do
     subject(:activate?) { policy.authenticate? }
 

--- a/spec/system/manage/case_workers_cannot_self_delete_spec.rb
+++ b/spec/system/manage/case_workers_cannot_self_delete_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Staff actions" do
+  include CommonSteps
+
+  scenario "Staff users with permissions cannot self delete", type: :system do
+    given_the_service_is_open
+    and_the_eligibility_screener_is_enabled
+
+    when_i_login_as_a_case_worker_with_support_permissions_only
+    and_i_try_to_delete_my_user
+    then_i_get_redirected_to_staff_index_page
+    and_i_see_the_notification_message
+    and_i_am_not_marked_as_deleted
+  end
+
+  private
+
+  def and_i_try_to_delete_my_user
+    @current_staff = Staff.last
+
+    visit delete_support_interface_staff_path(@current_staff)
+  end
+
+  def then_i_get_redirected_to_staff_index_page
+    expect(page).to have_current_path(support_interface_staff_index_path)
+  end
+
+  def and_i_see_the_notification_message
+    expect(page).to have_content("You cannot delete your own user")
+  end
+
+  def and_i_am_not_marked_as_deleted
+    expect(@current_staff.deleted_at).to be_nil
+  end
+end

--- a/spec/system/manage/case_workers_with_permissions_can_soft_delete_staff_users_spec.rb
+++ b/spec/system/manage/case_workers_with_permissions_can_soft_delete_staff_users_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Staff actions" do
+  include CommonSteps
+
+  scenario "Staff users with permissions can soft delete other staff user",
+           type: :system do
+    given_the_service_is_open
+    and_the_eligibility_screener_is_enabled
+    and_there_are_staff_users
+
+    when_i_login_as_a_case_worker_with_support_permissions_only
+    then_i_see_the_staff_index
+
+    when_i_choose_to_delete_other_staff_user
+    then_i_see_the_warning_message
+    and_i_click_continue
+    then_i_no_longer_see_the_deleted_staff_user
+    and_i_see_the_notification_message
+    and_staff_user_is_marked_as_deleted
+  end
+
+  private
+
+  def when_i_choose_to_delete_other_staff_user
+    visit delete_support_interface_staff_path(@user)
+  end
+
+  def and_there_are_staff_users
+    @user =
+      create(:staff, :confirmed, :can_view_support, email: "another@test.com")
+  end
+
+  def then_i_see_the_warning_message
+    expect(page).to have_content(@user.email)
+    expect(page).to have_content("Confirm that you want to delete this user")
+  end
+
+  def then_i_no_longer_see_the_deleted_staff_user
+    expect(page).not_to have_content(@user.email)
+  end
+
+  def and_i_click_continue
+    click_on "Delete user"
+  end
+
+  def and_i_see_the_notification_message
+    expect(page).to have_content("User deleted")
+    expect(page).to have_current_path(support_interface_staff_index_path)
+  end
+
+  def and_staff_user_is_marked_as_deleted
+    expect(@user.reload.deleted_at).not_to be_nil
+  end
+end

--- a/spec/system/manage/deleted_case_workers_can_no_longer_login_spec.rb
+++ b/spec/system/manage/deleted_case_workers_can_no_longer_login_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Staff actions" do
+  include CommonSteps
+
+  scenario "Deleted staff users can no longer login", type: :system do
+    given_the_service_is_open
+    and_the_eligibility_screener_is_enabled
+    and_i_have_been_soft_deleted
+
+    when_i_login
+    then_i_get_redirected_to_manage_sign_in_page
+    and_i_see_the_notification_message
+  end
+
+  private
+
+  def and_i_have_been_soft_deleted
+    @user = create(:staff, :confirmed, :can_view_support, :deleted)
+  end
+
+  def when_i_login
+    visit manage_sign_in_path
+
+    fill_in "Email", with: "test@example.org"
+    fill_in "Password", with: "Example123!"
+
+    click_on "Log in"
+  end
+
+  def and_i_see_the_notification_message
+    expect(page).to have_content("Your account is not activated yet.")
+  end
+
+  def then_i_get_redirected_to_manage_sign_in_page
+    expect(page).to have_current_path(manage_sign_in_path)
+  end
+end


### PR DESCRIPTION
### Context

Caseworkers can now soft delete other users

We decided to soft delete users for auditing purposes.

### Changes proposed in this pull request

- allow staff users to soft delete other staff users
- do not show deleted staff users in the UI

![Screenshot 2023-03-15 at 08 50 35](https://user-images.githubusercontent.com/1955084/225256532-803e178d-0948-41d7-a322-35665c5b0e9f.png)

![Screenshot 2023-03-15 at 09 09 38](https://user-images.githubusercontent.com/1955084/225261192-2d85a284-d07a-4cb3-bdc9-584d46ad2fe7.png)

### Link to Trello card

https://trello.com/c/ZCQHoPWy

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
