### PR TITLE
Fix referral submitted at date

### DIFF
--- a/app/views/manage_interface/referrals/index.html.erb
+++ b/app/views/manage_interface/referrals/index.html.erb
@@ -13,7 +13,7 @@
           <%= govuk_summary_list(
             classes: ["govuk-summary-list--no-border"],
             rows: [
-              { key: { text: "Referral date" }, value: { text: referral.created_at.to_fs(:day_month_year_time)} },
+              { key: { text: "Referral date" }, value: { text: referral.submitted_at.to_fs(:day_month_year_time)} },
               { key: { text: "Referrer" }, value: { text: referral.referrer_name } }
             ])
           %>


### PR DESCRIPTION
### Context

We list referrals by date in manage. This should be the submitted_at date as that is the date we are ordering by and is the date that the case workers are sent the referral.

### Changes proposed in this pull request

Display submitted_at date.

### Guidance to review

### Link to Trello card


### Checklist

- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
