### PR TITLE
Add Resend invitation function for staff invites

### DIFF
--- a/app/controllers/support_interface/staff_invitations_controller.rb
+++ b/app/controllers/support_interface/staff_invitations_controller.rb
@@ -1,0 +1,28 @@
+module SupportInterface
+  class StaffInvitationsController < SupportInterfaceController
+    def edit
+      @staff = Staff.find(params[:id])
+    end
+
+    def update
+      @staff = Staff.find(params[:id])
+
+      if @staff.invite!(current_staff)
+        flash[:success] = "Invitation sent"
+        redirect_to support_interface_staff_index_path
+      else
+        flash[:warning] = "Invitation failed to send"
+        render :edit
+      end
+    end
+
+    private
+
+    def staff_params
+      params.require(:support_interface_staff_permissions_form).permit(
+        :manage_referrals,
+        :view_support
+      )
+    end
+  end
+end

--- a/app/views/support_interface/staff/index.html.erb
+++ b/app/views/support_interface/staff/index.html.erb
@@ -8,9 +8,13 @@
 
 <% @staff.each do |staff| %>
   <h2 class="govuk-heading-m"><%= staff.email %></h2>
-  <p>
+
+  <div class="govuk-button-group">
     <%= govuk_link_to "Change permissions", edit_support_interface_staff_permission_path(staff) %>
-  </p>
+    <% if staff.created_by_invite? && !staff.invitation_accepted? %>
+      <%= govuk_link_to "Resend invitation", edit_support_interface_staff_invitation_path(staff) %>
+    <% end %>
+  </div>
 
   <%= govuk_summary_list do |summary_list|
     summary_list.row do |row|

--- a/app/views/support_interface/staff_invitations/edit.html.erb
+++ b/app/views/support_interface/staff_invitations/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :back_link_url, support_interface_staff_index_path %>
+<% content_for :page_title, "Resend invitation for #{@staff.email}" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @staff.email %></span>
+    <h1 class="govuk-heading-l">Confirm that you want to resend the invitation</h1>
+
+    <p class="govuk-body">
+      <%= govuk_button_to "Resend invitation", support_interface_staff_invitation_path(@staff), method: :patch %>
+      <%= govuk_link_to "Cancel", support_interface_staff_index_path %>
+    </p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,6 +278,7 @@ Rails.application.routes.draw do
     root to: redirect("/support/eligibility-checks")
     resources :staff, only: %i[index]
     resources :staff_permissions, only: %i[edit update]
+    resources :staff_invitations, only: %i[edit update]
     resources :test_users, only: %i[index create] do
       put "/authenticate", on: :member, to: "test_users#authenticate"
     end

--- a/spec/system/support/staff_user_with_permissions_sends_account_invitation_spec.rb
+++ b/spec/system/support/staff_user_with_permissions_sends_account_invitation_spec.rb
@@ -22,6 +22,10 @@ RSpec.feature "Staff invitations" do
     then_i_see_an_invitation_email
     then_i_see_the_invited_staff_user
 
+    when_i_resend_invitation
+    then_i_see_an_invitation_email
+    then_i_see_the_invited_staff_user
+
     when_i_am_not_authorized_as_a_staff_user
     when_i_visit_the_invitation_email
     when_i_fill_password
@@ -72,6 +76,12 @@ RSpec.feature "Staff invitations" do
     perform_enqueued_jobs
   end
   alias_method :when_i_send_invitation, :and_i_send_invitation
+
+  def when_i_resend_invitation
+    click_link "Resend invitation"
+    click_button "Resend invitation"
+    perform_enqueued_jobs
+  end
 
   def then_i_see_an_invitation_email
     message = ActionMailer::Base.deliveries.last


### PR DESCRIPTION
### Context

To allow resending invites to staff users

### Link to Trello card

https://trello.com/c/taAGeS9j/1300-resend-invite

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
