### PR TITLE
Set Notify API key before sending every email

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,28 +1,28 @@
 # frozen_string_literal: true
 class ApplicationMailer < Mail::Notify::Mailer
-  GENERIC_NOTIFY_TEMPLATE = "04b96c89-77ec-4c07-af01-3c96a4b8b5d7"
-
-  MISCONDUCT_GENERIC_NOTIFY_TEMPLATE = "4f8e7de9-3987-4e75-974f-ac94068c4a62"
+  TRA_NOTIFY_TEMPLATE = "04b96c89-77ec-4c07-af01-3c96a4b8b5d7"
+  MANAGE_NOTIFY_TEMPLATE = "4f8e7de9-3987-4e75-974f-ac94068c4a62"
   MISCONDUCT_NOTIFY_REPLY_TO_ID = "83cac27e-b914-46a3-a1f9-56e5acb07d05"
 
-  private
+  def view_mail_tra(mailer_options:, template_id: TRA_NOTIFY_TEMPLATE)
+    set_action_mailer_refer_key
+    view_mail(template_id, mailer_options)
+  end
 
-  def set_action_mailer_misconduct_key
+  def view_mail_manage(mailer_options:, template_id: MANAGE_NOTIFY_TEMPLATE)
+    set_action_mailer_manage_key
+    view_mail(template_id, mailer_options)
+  end
+
+  def set_action_mailer_manage_key
     ActionMailer::Base.notify_settings[:api_key] = ENV.fetch(
       "GOVUK_NOTIFY_MANAGE_SERIOUS_MISCONDUCT_API_KEY"
     )
   end
 
-  def set_action_mailer_default_key
+  def set_action_mailer_refer_key
     ActionMailer::Base.notify_settings[:api_key] = ENV.fetch(
       "GOVUK_NOTIFY_API_KEY"
     )
-  end
-
-  def deliver_as_manage_misconduct
-    set_action_mailer_misconduct_key
-    yield
-  ensure
-    set_action_mailer_default_key
   end
 end

--- a/app/mailers/caseworker_mailer.rb
+++ b/app/mailers/caseworker_mailer.rb
@@ -10,9 +10,7 @@ class CaseworkerMailer < ApplicationMailer
       subject: "#{@name} has been referred"
     }
 
-    deliver_as_manage_misconduct do
-      view_mail(MISCONDUCT_GENERIC_NOTIFY_TEMPLATE, mailer_options)
-    end
+    view_mail_manage(mailer_options:)
   end
 
   private

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -7,6 +7,7 @@ class DeviseMailer < Devise::Mailer
 
   def devise_mail(record, action, opts = {}, &_block)
     initialize_from_record(record)
+    ApplicationMailer.set_action_mailer_refer_key
     view_mail(GOVUK_NOTIFY_TEMPLATE_ID, headers_for(action, opts))
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -7,7 +7,7 @@ class UserMailer < ApplicationMailer
       subject: "#{@otp} is your confirmation code"
     }
 
-    view_mail(GENERIC_NOTIFY_TEMPLATE, mailer_options)
+    view_mail_tra(mailer_options:)
   end
 
   def referral_link(referral)
@@ -18,7 +18,7 @@ class UserMailer < ApplicationMailer
       subject: "Your referral of serious misconduct by a teacher"
     }
 
-    view_mail(GENERIC_NOTIFY_TEMPLATE, mailer_options)
+    view_mail_tra(mailer_options:)
   end
 
   def referral_submitted(referral)
@@ -29,6 +29,6 @@ class UserMailer < ApplicationMailer
       subject: "Your referral of serious misconduct has been sent"
     }
 
-    view_mail(GENERIC_NOTIFY_TEMPLATE, mailer_options)
+    view_mail_tra(mailer_options:)
   end
 end

--- a/spec/mailers/caseworker_mailer_spec.rb
+++ b/spec/mailers/caseworker_mailer_spec.rb
@@ -58,12 +58,16 @@ RSpec.describe CaseworkerMailer, type: :mailer do
       expect(template_id).to eq "4f8e7de9-3987-4e75-974f-ac94068c4a62"
     end
 
-    it "doesn't change the default Notify API key" do
-      expect { email.deliver_now }.not_to(
-        change { ActionMailer::Base.notify_settings[:api_key] }.from(
-          "govuk_notify_api_key"
+    describe "API keys" do
+      before { ActionMailer::Base.notify_settings[:api_key] = "fake_key" }
+
+      it "uses the manage Notify API key" do
+        expect { email.deliver_now }.to(
+          change { ActionMailer::Base.notify_settings[:api_key] }.from(
+            "fake_key"
+          ).to("govuk_notify_manage_serious_misconduct_api_key")
         )
-      )
+      end
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -67,5 +67,17 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     it_behaves_like "email with `Get help` section"
+
+    describe "API keys" do
+      before { ActionMailer::Base.notify_settings[:api_key] = "fake_key" }
+
+      it "uses the TRA Notify API key" do
+        expect { email.deliver_now }.to(
+          change { ActionMailer::Base.notify_settings[:api_key] }.from(
+            "fake_key"
+          ).to("govuk_notify_api_key")
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

There is still a bug where occasionally email can get sent with an incorrect API key.

### Changes proposed in this pull request

Makes sure view_mail never gets called with an incorrect API key. I'm not 100% happy with this solution. I tried creating a general mailer but I struggled with getting the Devise email working. Suggestions welcome.

### Link to Trello card

https://trello.com/c/yumxV5a3/1311-bug-badrequesterror-template-not-found