### PR TITLE
1306 - Use the email templates from the new Notify service

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 class ApplicationMailer < Mail::Notify::Mailer
-  TRA_NOTIFY_TEMPLATE = "04b96c89-77ec-4c07-af01-3c96a4b8b5d7"
+  REFER_NOTIFY_TEMPLATE = "8a10a1c1-9cc3-4234-af86-c54cedb7ce09"
   MANAGE_NOTIFY_TEMPLATE = "4f8e7de9-3987-4e75-974f-ac94068c4a62"
   MISCONDUCT_NOTIFY_REPLY_TO_ID = "83cac27e-b914-46a3-a1f9-56e5acb07d05"
 
-  def view_mail_tra(mailer_options:, template_id: TRA_NOTIFY_TEMPLATE)
+  def view_mail_refer(mailer_options:, template_id: REFER_NOTIFY_TEMPLATE)
     set_action_mailer_refer_key
     view_mail(template_id, mailer_options)
   end

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,5 +1,5 @@
 class DeviseMailer < Devise::Mailer
-  GOVUK_NOTIFY_TEMPLATE_ID = ENV.fetch("GOVUK_NOTIFY_TEMPLATE_ID_DEVISE", "f1a31a19-a161-45b9-8450-1f0e10daeaf3")
+  GOVUK_NOTIFY_TEMPLATE_ID = ENV.fetch("GOVUK_NOTIFY_TEMPLATE_ID_DEVISE", "3441548d-bd6b-46b5-b986-8860f824cae8")
 
   def devise_mail(record, action, opts = {}, &_block)
     initialize_from_record(record)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,7 +4,7 @@ class UserMailer < ApplicationMailer
     Rails.logger.info "OTP: #{@otp}" if Rails.env.development?
     mailer_options = { to: user.email, subject: "#{@otp} is your confirmation code" }
 
-    view_mail_tra(mailer_options:)
+    view_mail_refer(mailer_options:)
   end
 
   def referral_link(referral)
@@ -12,7 +12,7 @@ class UserMailer < ApplicationMailer
     @user = referral.user
     mailer_options = { to: @user.email, subject: "Your referral of serious misconduct by a teacher" }
 
-    view_mail_tra(mailer_options:)
+    view_mail_refer(mailer_options:)
   end
 
   def referral_submitted(referral)
@@ -20,6 +20,6 @@ class UserMailer < ApplicationMailer
     @user = referral.user
     mailer_options = { to: @user.email, subject: "Your referral of serious misconduct has been sent" }
 
-    view_mail_tra(mailer_options:)
+    view_mail_refer(mailer_options:)
   end
 end


### PR DESCRIPTION
### Context

Move Mailer and Devise Notify templates

### Changes proposed in this pull request

Move the existing Mailer and Devise templates from Teaching Regulation Agency
to Refer serious misconduct by a teacher in England service
in Notify.

### Guidance to review

We need to do a full regression testing for any notification that we send to ensure everything is working as expected.

### NOTES

I will need to work with either @vassyz or @gpeng because I don't have Azure access (still) and once the API keys are generated in Notify (you can't see them again) so they have to be added in the vaults as we go.

### Link to Trello card

https://trello.com/c/O36wjl4w

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
