### PR TITLE
Prevent user from updating submitter referrals

### DIFF
--- a/app/controllers/concerns/redirect_if_referral_submitted.rb
+++ b/app/controllers/concerns/redirect_if_referral_submitted.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module RedirectIfReferralSubmitted
+  extend ActiveSupport::Concern
+
+  included { before_action { redirect_if_referral_submitted(current_referral) if current_referral } }
+
+  def redirect_if_referral_submitted(referral)
+    return unless referral.submitted? && controller_name != "confirmation"
+
+    redirect_to(users_referral_path(referral))
+  end
+end

--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -3,6 +3,7 @@ module Referrals
     include AuthenticateUser
     include StoreUserLocation
     include RedirectIfFeatureFlagInactive
+    include RedirectIfReferralSubmitted
 
     before_action { redirect_if_feature_flag_inactive(:referral_form) }
     before_action :set_return_to_url, only: :edit
@@ -14,6 +15,9 @@ module Referrals
 
     def current_referral
       id = params[:id] || params[:referral_id] || params[:public_referral_id]
+
+      return nil if id.blank?
+
       @current_referral ||= current_user.referrals.find(id)
     end
     helper_method :current_referral

--- a/app/controllers/users/referrals_controller.rb
+++ b/app/controllers/users/referrals_controller.rb
@@ -1,12 +1,19 @@
 module Users
-  class ReferralsController < Referrals::BaseController
+  class ReferralsController < ApplicationController
+    include AuthenticateUser
+    include StoreUserLocation
+
     def index
       @referrals_submitted = current_user.referrals.submitted.order(submitted_at: :desc)
       @referral_in_progress = current_user.referral_in_progress
     end
 
     def show
-      @referral = current_user.referrals.find(params[:id])
     end
+
+    def current_referral
+      @current_referral ||= current_user.referrals.find(params[:id])
+    end
+    helper_method :current_referral
   end
 end

--- a/spec/system/referrals/user_cannot_edit_referral_if_it_has_been_submitted_spec.rb
+++ b/spec/system/referrals/user_cannot_edit_referral_if_it_has_been_submitted_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Submitted referral", type: :system do
+  include CommonSteps
+
+  scenario "User tries to edit the referral" do
+    given_the_service_is_open
+    and_the_referral_form_feature_is_active
+    and_i_am_signed_in
+    and_i_have_submitted_referrals
+
+    when_i_access_a_public_submitted_referral_edit_page
+    then_i_get_redirected_to_the_public_referral_page
+
+    when_i_access_an_employer_submitted_referral_edit_page
+    then_i_get_redirected_to_the_employer_referral_page
+  end
+
+  private
+
+  def and_i_have_submitted_referrals
+    @employer_referral = create(:referral, :submitted, :public, user: @user)
+    @public_referral = create(:referral, :submitted, :employer, user: @user)
+  end
+
+  def when_i_access_a_public_submitted_referral_edit_page
+    visit edit_referral_personal_details_name_path(@public_referral)
+  end
+
+  def then_i_get_redirected_to_the_public_referral_page
+    expect(page).to have_content("Your referral")
+    expect(page).to have_current_path("/users/referrals/#{@public_referral.id}")
+  end
+
+  def when_i_access_an_employer_submitted_referral_edit_page
+    visit edit_public_referral_personal_details_name_path(@employer_referral)
+  end
+
+  def then_i_get_redirected_to_the_employer_referral_page
+    expect(page).to have_content("Your referral")
+    expect(page).to have_current_path("/users/referrals/#{@employer_referral.id}")
+  end
+end


### PR DESCRIPTION
It redirects the user to the referral show page if the referral has been submitted.

### Link to Trello card

https://trello.com/c/4qpIxiR3/1307-stop-submitted-referrals-being-edited-by-the-user
