### PR TITLE
Show file list if present when returning to evidence section

### DIFF
--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -141,10 +141,11 @@ class ReferralForm
         section.items.append(
           ReferralSectionItem.new(
             I18n.t("referral_form.evidence_and_supporting_information"),
-            path_for_section_status(
+            path_for_evidence_section_status(
               check_answers?(referral.evidence_details_complete),
               polymorphic_path([:edit, referral.routing_scope, referral, :evidence_start]),
-              polymorphic_path([:edit, referral.routing_scope, referral, :evidence_check_answers])
+              polymorphic_path([:edit, referral.routing_scope, referral, :evidence_check_answers]),
+              polymorphic_path([:edit, referral.routing_scope, referral, :evidence_uploaded])
             ),
             section_status(referral.evidence_details_complete)
           )
@@ -162,5 +163,15 @@ class ReferralForm
 
   def path_for_section_status(check_answers, start_path, check_answers_path)
     check_answers ? check_answers_path : start_path
+  end
+
+  def path_for_evidence_section_status(check_answers, start_path, check_answers_path, evidence_upload_path)
+    if check_answers
+      check_answers_path
+    elsif referral.evidences.any?
+      evidence_upload_path
+    else
+      start_path
+    end
   end
 end

--- a/spec/system/public_referrals/user_adds_evidence_spec.rb
+++ b/spec/system/public_referrals/user_adds_evidence_spec.rb
@@ -38,6 +38,10 @@ RSpec.feature "Evidence", type: :system do
     and_i_click_save_and_continue
     then_i_see_a_list_of_the_uploaded_files
 
+    and_i_visit_the_public_referral
+    when_i_edit_the_evidence
+    then_i_see_a_list_of_the_uploaded_files
+
     when_i_have_no_more_evidence_to_upload
     and_i_click_save_and_continue
     then_i_am_asked_to_confirm_the_evidence_details

--- a/spec/system/referrals/user_adds_evidence_spec.rb
+++ b/spec/system/referrals/user_adds_evidence_spec.rb
@@ -41,6 +41,10 @@ RSpec.feature "Evidence", type: :system do
     and_i_click_save_and_continue
     then_i_see_a_list_of_the_uploaded_files
 
+    when_i_visit_the_referral
+    when_i_edit_the_evidence
+    then_i_see_a_list_of_the_uploaded_files
+
     when_i_have_no_more_evidence_to_upload
     and_i_click_save_and_continue
     then_i_am_asked_to_confirm_the_evidence_details
@@ -239,4 +243,8 @@ RSpec.feature "Evidence", type: :system do
     end
   end
   alias_method :then_the_evidence_section_state_is, :and_the_evidence_section_state_is
+
+  def when_i_visit_the_uploaded_evidence_start_page
+    visit edit_referral_evidence_uploaded_path(@referral)
+  end
 end


### PR DESCRIPTION
Previously when uploading a file without completing the evidence section then revisiting that section it would take you to the start of the form.

Now it takes you to the file list if there are files uploaded

See video for demo

https://www.loom.com/share/78299d537900447cabd71bcfb4566e1c

https://trello.com/c/vIMGOLZH/1316-evidence-file-upload-show-list