### PR TITLE
Use Pundit to prevent staff user self-deletion

### DIFF
--- a/app/controllers/support_interface/staff_controller.rb
+++ b/app/controllers/support_interface/staff_controller.rb
@@ -1,31 +1,27 @@
 module SupportInterface
   class StaffController < SupportInterfaceController
-    before_action :can_delete, only: %i[destroy delete]
-
     def index
       @staff = Staff.active.order(:email)
     end
 
-    def destroy
-      staff_user.archive
+    def delete
+      authorize staff, policy_class: SupportPolicy
+    end
 
-      flash[:info] = (staff_user.save ? "User deleted" : "User could not be deleted")
+    def destroy
+      authorize staff, policy_class: SupportPolicy
+
+      staff.archive
+
+      flash[:info] = (staff.save ? "User deleted" : "User could not be deleted")
 
       redirect_to support_interface_staff_index_path
     end
 
     private
 
-    def can_delete
-      if current_staff.id == staff_user.id
-        flash[:info] = "You cannot delete your own user"
-
-        redirect_to support_interface_staff_index_path and return
-      end
-    end
-
-    def staff_user
-      @staff_user ||= Staff.find(params[:id])
+    def staff
+      @staff ||= Staff.find(params[:id])
     end
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 class ApplicationMailer < Mail::Notify::Mailer
-  TRA_NOTIFY_TEMPLATE = "04b96c89-77ec-4c07-af01-3c96a4b8b5d7"
+  REFER_NOTIFY_TEMPLATE = "8a10a1c1-9cc3-4234-af86-c54cedb7ce09"
   MANAGE_NOTIFY_TEMPLATE = "4f8e7de9-3987-4e75-974f-ac94068c4a62"
   MISCONDUCT_NOTIFY_REPLY_TO_ID = "83cac27e-b914-46a3-a1f9-56e5acb07d05"
 
-  def view_mail_tra(mailer_options:, template_id: TRA_NOTIFY_TEMPLATE)
+  def view_mail_refer(mailer_options:, template_id: REFER_NOTIFY_TEMPLATE)
     set_action_mailer_refer_key
     view_mail(template_id, mailer_options)
   end

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,5 +1,5 @@
 class DeviseMailer < Devise::Mailer
-  GOVUK_NOTIFY_TEMPLATE_ID = ENV.fetch("GOVUK_NOTIFY_TEMPLATE_ID_DEVISE", "f1a31a19-a161-45b9-8450-1f0e10daeaf3")
+  GOVUK_NOTIFY_TEMPLATE_ID = ENV.fetch("GOVUK_NOTIFY_TEMPLATE_ID_DEVISE", "3441548d-bd6b-46b5-b986-8860f824cae8")
 
   def devise_mail(record, action, opts = {}, &_block)
     initialize_from_record(record)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,7 +4,7 @@ class UserMailer < ApplicationMailer
     Rails.logger.info "OTP: #{@otp}" if Rails.env.development?
     mailer_options = { to: user.email, subject: "#{@otp} is your confirmation code" }
 
-    view_mail_tra(mailer_options:)
+    view_mail_refer(mailer_options:)
   end
 
   def referral_link(referral)
@@ -12,7 +12,7 @@ class UserMailer < ApplicationMailer
     @user = referral.user
     mailer_options = { to: @user.email, subject: "Your referral of serious misconduct by a teacher" }
 
-    view_mail_tra(mailer_options:)
+    view_mail_refer(mailer_options:)
   end
 
   def referral_submitted(referral)
@@ -20,6 +20,6 @@ class UserMailer < ApplicationMailer
     @user = referral.user
     mailer_options = { to: @user.email, subject: "Your referral of serious misconduct has been sent" }
 
-    view_mail_tra(mailer_options:)
+    view_mail_refer(mailer_options:)
   end
 end

--- a/app/policies/management_policy.rb
+++ b/app/policies/management_policy.rb
@@ -1,13 +1,13 @@
 class ManagementPolicy < ApplicationPolicy
   def index?
-    return user.manage_referrals? if user.is_a?(Staff)
+    return false if user.is_a?(AnonymousSupportUser)
 
-    super
+    user.manage_referrals?
   end
 
   def show?
-    return user.manage_referrals? if user.is_a?(Staff)
+    return false if user.is_a?(AnonymousSupportUser)
 
-    super
+    user.manage_referrals?
   end
 end

--- a/app/policies/support_policy.rb
+++ b/app/policies/support_policy.rb
@@ -1,55 +1,59 @@
 class SupportPolicy < ApplicationPolicy
   def index?
-    return user.view_support? if user.is_a?(Staff)
+    return false if user.is_a?(AnonymousSupportUser)
 
-    super
+    user.view_support?
   end
 
   def create?
-    return user.view_support? if user.is_a?(Staff)
+    return false if user.is_a?(AnonymousSupportUser)
 
-    super
+    user.view_support?
   end
 
   def edit?
-    return user.view_support? if user.is_a?(Staff)
+    return false if user.is_a?(AnonymousSupportUser)
 
-    super
+    user.view_support?
   end
 
   def update?
-    return user.view_support? if user.is_a?(Staff)
+    return false if user.is_a?(AnonymousSupportUser)
 
-    super
+    user.view_support?
   end
 
   def delete?
-    return user.view_support? if user.is_a?(Staff)
+    return false if user.is_a?(AnonymousSupportUser)
 
-    false
+    return user.view_support? unless record.is_a?(Staff)
+
+    user.id != record.id
   end
 
   def destroy?
-    return user.view_support? if user.is_a?(Staff)
+    return false if user.is_a?(AnonymousSupportUser)
 
-    super
+    return user.view_support? unless record.is_a?(Staff)
+
+    user.id != record.id
   end
 
   def authenticate?
-    return user.view_support? if user.is_a?(Staff)
+    return false if user.is_a?(AnonymousSupportUser)
 
-    false
+    user.view_support?
   end
 
   def activate?
-    return user.view_support? if user.is_a?(Staff)
+    return false if user.is_a?(AnonymousSupportUser)
 
-    false
+    user.view_support?
   end
 
   def deactivate?
-    return user.view_support? if user.is_a?(Staff)
+    return false if user.is_a?(AnonymousSupportUser)
 
-    false
+    user.view_support?
   end
 end

--- a/app/views/support_interface/staff/delete.html.erb
+++ b/app/views/support_interface/staff/delete.html.erb
@@ -1,9 +1,9 @@
 <% content_for :back_link_url, support_interface_staff_index_path %>
-<% content_for :page_title, "Delete #{@staff_user.email}" %>
+<% content_for :page_title, "Delete #{@staff.email}" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l"><%= @staff_user.email %></span>
+    <span class="govuk-caption-l"><%= @staff.email %></span>
     <h1 class="govuk-heading-l">Confirm that you want to delete this user</h1>
 
     <p class="govuk-body">

--- a/spec/system/manage/case_workers_cannot_self_delete_spec.rb
+++ b/spec/system/manage/case_workers_cannot_self_delete_spec.rb
@@ -10,8 +10,7 @@ RSpec.feature "Staff actions" do
 
     when_i_login_as_a_case_worker_with_support_permissions_only
     and_i_try_to_delete_my_user
-    then_i_get_redirected_to_staff_index_page
-    and_i_see_the_notification_message
+    then_i_get_redirected_to_forbidden_page
     and_i_am_not_marked_as_deleted
   end
 
@@ -23,12 +22,8 @@ RSpec.feature "Staff actions" do
     visit delete_support_interface_staff_path(@current_staff)
   end
 
-  def then_i_get_redirected_to_staff_index_page
-    expect(page).to have_current_path(support_interface_staff_index_path)
-  end
-
-  def and_i_see_the_notification_message
-    expect(page).to have_content("You cannot delete your own user")
+  def then_i_get_redirected_to_forbidden_page
+    expect(page).to have_current_path(forbidden_path)
   end
 
   def and_i_am_not_marked_as_deleted


### PR DESCRIPTION
### Context

Refactor our support policy and use that to prevent staff user self deletion.

### Changes proposed in this pull request

Make use of Pundit policies to also prevent staff user self deletion.

### Link to Trello card

https://trello.com/c/W9IgNSc0

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
