### PR TITLE
Use Pundit to prevent staff user self-deletion

### DIFF
--- a/app/controllers/support_interface/staff_controller.rb
+++ b/app/controllers/support_interface/staff_controller.rb
@@ -1,31 +1,27 @@
 module SupportInterface
   class StaffController < SupportInterfaceController
-    before_action :can_delete, only: %i[destroy delete]
-
     def index
       @staff = Staff.active.order(:email)
     end
 
-    def destroy
-      staff_user.archive
+    def delete
+      authorize staff
+    end
 
-      flash[:info] = (staff_user.save ? "User deleted" : "User could not be deleted")
+    def destroy
+      authorize staff
+
+      staff.archive
+
+      flash[:info] = (staff.save ? "User deleted" : "User could not be deleted")
 
       redirect_to support_interface_staff_index_path
     end
 
     private
 
-    def can_delete
-      if current_staff.id == staff_user.id
-        flash[:info] = "You cannot delete your own user"
-
-        redirect_to support_interface_staff_index_path and return
-      end
-    end
-
-    def staff_user
-      @staff_user ||= Staff.find(params[:id])
+    def staff
+      @staff ||= Staff.find(params[:id])
     end
   end
 end

--- a/app/lib/anonymous_support_user.rb
+++ b/app/lib/anonymous_support_user.rb
@@ -6,4 +6,12 @@ class AnonymousSupportUser
   def devise_scope
     :staff
   end
+
+  def view_support?
+    false
+  end
+
+  def manage_referrals?
+    false
+  end
 end

--- a/app/policies/management_policy.rb
+++ b/app/policies/management_policy.rb
@@ -1,13 +1,9 @@
 class ManagementPolicy < ApplicationPolicy
   def index?
-    return user.manage_referrals? if user.is_a?(Staff)
-
-    super
+    user.manage_referrals?
   end
 
   def show?
-    return user.manage_referrals? if user.is_a?(Staff)
-
-    super
+    user.manage_referrals?
   end
 end

--- a/app/policies/staff_policy.rb
+++ b/app/policies/staff_policy.rb
@@ -1,0 +1,9 @@
+class StaffPolicy < ApplicationPolicy
+  def delete?
+    user.id != record.id
+  end
+
+  def destroy?
+    user.id != record.id
+  end
+end

--- a/app/policies/support_policy.rb
+++ b/app/policies/support_policy.rb
@@ -1,55 +1,37 @@
 class SupportPolicy < ApplicationPolicy
   def index?
-    return user.view_support? if user.is_a?(Staff)
-
-    super
+    user.view_support?
   end
 
   def create?
-    return user.view_support? if user.is_a?(Staff)
-
-    super
+    user.view_support?
   end
 
   def edit?
-    return user.view_support? if user.is_a?(Staff)
-
-    super
+    user.view_support?
   end
 
   def update?
-    return user.view_support? if user.is_a?(Staff)
-
-    super
+    user.view_support?
   end
 
   def delete?
-    return user.view_support? if user.is_a?(Staff)
-
-    false
+    user.view_support?
   end
 
   def destroy?
-    return user.view_support? if user.is_a?(Staff)
-
-    super
+    user.view_support?
   end
 
   def authenticate?
-    return user.view_support? if user.is_a?(Staff)
-
-    false
+    user.view_support?
   end
 
   def activate?
-    return user.view_support? if user.is_a?(Staff)
-
-    false
+    user.view_support?
   end
 
   def deactivate?
-    return user.view_support? if user.is_a?(Staff)
-
-    false
+    user.view_support?
   end
 end

--- a/app/views/support_interface/staff/delete.html.erb
+++ b/app/views/support_interface/staff/delete.html.erb
@@ -1,9 +1,9 @@
 <% content_for :back_link_url, support_interface_staff_index_path %>
-<% content_for :page_title, "Delete #{@staff_user.email}" %>
+<% content_for :page_title, "Delete #{@staff.email}" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l"><%= @staff_user.email %></span>
+    <span class="govuk-caption-l"><%= @staff.email %></span>
     <h1 class="govuk-heading-l">Confirm that you want to delete this user</h1>
 
     <p class="govuk-body">

--- a/spec/policies/staff_policy_spec.rb
+++ b/spec/policies/staff_policy_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StaffPolicy do
+  subject(:policy) { described_class.new(current_staff, staff_user) }
+
+  let(:current_staff) { create(:staff, :confirmed, :can_view_support) }
+  let(:staff_user) { nil }
+
+  describe "#delete?" do
+    subject(:delete?) { policy.delete? }
+
+    it_behaves_like "staff policy deletion"
+  end
+
+  describe "#destroy?" do
+    subject(:destroy?) { policy.destroy? }
+
+    it_behaves_like "staff policy deletion"
+  end
+end

--- a/spec/support/shared_examples/staff_policy_deletion.rb
+++ b/spec/support/shared_examples/staff_policy_deletion.rb
@@ -1,0 +1,13 @@
+RSpec.shared_examples "staff policy deletion" do
+  context "when deleting a staff user that is not the current staff user" do
+    let(:staff_user) { create(:staff, :confirmed, :can_view_support, email: "test@test.com") }
+
+    it { is_expected.to be true }
+  end
+
+  context "when deleting a staff user that is also the current staff user" do
+    let(:staff_user) { current_staff }
+
+    it { is_expected.to be false }
+  end
+end

--- a/spec/system/manage/case_workers_cannot_self_delete_spec.rb
+++ b/spec/system/manage/case_workers_cannot_self_delete_spec.rb
@@ -10,8 +10,7 @@ RSpec.feature "Staff actions" do
 
     when_i_login_as_a_case_worker_with_support_permissions_only
     and_i_try_to_delete_my_user
-    then_i_get_redirected_to_staff_index_page
-    and_i_see_the_notification_message
+    then_i_get_redirected_to_forbidden_page
     and_i_am_not_marked_as_deleted
   end
 
@@ -23,12 +22,8 @@ RSpec.feature "Staff actions" do
     visit delete_support_interface_staff_path(@current_staff)
   end
 
-  def then_i_get_redirected_to_staff_index_page
-    expect(page).to have_current_path(support_interface_staff_index_path)
-  end
-
-  def and_i_see_the_notification_message
-    expect(page).to have_content("You cannot delete your own user")
+  def then_i_get_redirected_to_forbidden_page
+    expect(page).to have_current_path(forbidden_path)
   end
 
   def and_i_am_not_marked_as_deleted


### PR DESCRIPTION
### Context

Refactor our support policy and use that to prevent staff user self deletion.

### Changes proposed in this pull request

Make use of Pundit policies to also prevent staff user self deletion.

### Link to Trello card

https://trello.com/c/W9IgNSc0

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
