### PR TITLE
Add job to delete draft referrals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "rotp"
 gem "rubyzip"
 gem "sentry-rails"
 gem "sidekiq", "< 7"
+gem "sidekiq-cron"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "uk_postcode"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
       railties (>= 3.2)
     e2mmap (0.1.0)
     erubi (1.12.0)
+    et-orbi (1.2.7)
+      tzinfo
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -176,6 +178,9 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (>= 0.6, < 0.8)
+    fugit (1.8.1)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     globalid (1.1.0)
       activesupport (>= 5.0)
     google-apis-bigquery_v2 (0.48.0)
@@ -311,6 +316,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.3.0)
       activesupport (>= 3.0.0)
+    raabro (1.4.0)
     racc (1.6.2)
     rack (2.2.6.4)
     rack-attack (6.6.1)
@@ -429,6 +435,10 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    sidekiq-cron (1.10.0)
+      fugit (~> 1.8)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -537,6 +547,7 @@ DEPENDENCIES
   sentry-rails
   shoulda-matchers
   sidekiq (< 7)
+  sidekiq-cron
   solargraph-rails
   syntax_tree
   syntax_tree-haml

--- a/app/jobs/delete_draft_referrals_job.rb
+++ b/app/jobs/delete_draft_referrals_job.rb
@@ -1,0 +1,7 @@
+class DeleteDraftReferralsJob < ApplicationJob
+  sidekiq_options queue: "low"
+
+  def perform
+    Referral.stale_drafts.each { |referral| DeleteReferralJob.perform_later(referral.id) }
+  end
+end

--- a/app/jobs/delete_referral_job.rb
+++ b/app/jobs/delete_referral_job.rb
@@ -1,0 +1,7 @@
+class DeleteReferralJob < ApplicationJob
+  sidekiq_options queue: "low"
+
+  def perform(referral_id)
+    Referral.find(referral_id).destroy
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -12,10 +12,9 @@ class Referral < ApplicationRecord
   has_many :evidences, -> { order(:created_at) }, class_name: "ReferralEvidence", dependent: :destroy
 
   scope :employer, -> { joins(:eligibility_check).where(eligibility_check: { reporting_as: :employer }) }
-
   scope :member_of_public, -> { joins(:eligibility_check).where(eligibility_check: { reporting_as: :public }) }
-
   scope :submitted, -> { where.not(submitted_at: nil) }
+  scope :stale_drafts, -> { where(submitted_at: nil).where("created_at < ?", 90.days.ago) }
 
   delegate :name, to: :referrer, prefix: true, allow_nil: true
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
-Sidekiq.configure_server { |config| config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") } }
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
+
+  config.on(:startup) do
+    schedule_file = "config/schedule.yml"
+    Sidekiq::Cron::Job.load_from_hash(YAML.load_file(schedule_file)) if File.exist?(schedule_file)
+  end
+end
 
 Sidekiq.configure_client { |config| config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") } }

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,0 +1,3 @@
+delete_draft_referrals:
+  cron: "every day at midnight"
+  class: "DeleteDraftReferralsJob"

--- a/spec/jobs/delete_draft_referrals_job_spec.rb
+++ b/spec/jobs/delete_draft_referrals_job_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe DeleteDraftReferralsJob, type: :job do
+  before do
+    create_list(:referral, 3, created_at: 91.days.ago)
+    create_list(:referral, 2)
+    create_list(:referral, 2, :submitted, created_at: 91.days.ago)
+  end
+
+  describe "running the job" do
+    subject(:perform) { described_class.new.perform }
+
+    it "creates the Sidekiq jobs and deletes the referrals" do
+      perform
+      expect { perform_enqueued_jobs }.to change(Referral, :count).by(-3)
+    end
+  end
+end

--- a/spec/jobs/delete_referral_job_spec.rb
+++ b/spec/jobs/delete_referral_job_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe DeleteReferralJob, type: :job do
+  before { create(:referral) }
+
+  describe "running the job" do
+    subject(:perform) { described_class.new.perform(Referral.first.id) }
+
+    it "creates the Sidekiq jobs and deletes the referrals" do
+      expect { perform }.to change(Referral, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
Deletes the draft referrals older than 90 days, and the associated eligibility checks. This is done in a background job scheduled to run every day at midnight. The main job queues up a separate job for each referral to do the deletion.

### Link to Trello card

https://trello.com/c/XGzaIgIr/1324-automatic-deletion-of-draft-referrals-after-90-days

