### PR TITLE
SPIKE incomplete section pattern

### DIFF
--- a/app/assets/stylesheets/_app-govuk-summary-card.scss
+++ b/app/assets/stylesheets/_app-govuk-summary-card.scss
@@ -43,6 +43,16 @@
   .govuk-summary-list {
     margin-bottom: 0;
   }
+
+  &.app-inset-text--incomplete-section {
+    border-left: 5px solid #1d70b8;
+    padding: 15px 0 15px 15px;
+
+    .app-instruction-text {
+      color: #1d70b8;
+      font-weight: bold;
+    }
+  }
 }
 
 .app-govuk-summary-card--large-title .app-govuk-summary-card__title {

--- a/app/components/about_you_component.html.erb
+++ b/app/components/about_you_component.html.erb
@@ -1,1 +1,1 @@
-<%= render(SummaryCardComponent.new(rows:, editable: !referral.submitted?)) %>
+<%= render(SummaryCardComponent.new(rows:, section:, editable: !referral.submitted?)) %>

--- a/app/components/about_you_component.rb
+++ b/app/components/about_you_component.rb
@@ -2,11 +2,16 @@ class AboutYouComponent < ViewComponent::Base
   include ActiveModel::Model
   include ReferralHelper
 
-  attr_accessor :referral, :user
+  attr_accessor :referral, :user, :section
 
   delegate :referrer, to: :referral
 
   def rows
+    complete_rows = section.complete_rows(all_rows)
+    complete_rows.insert(1, summary_row(**email_row))
+  end
+
+  def all_rows
     summary_rows [name_row, email_row, job_title_row, phone_row].compact
   end
 

--- a/app/components/summary_card_component.html.erb
+++ b/app/components/summary_card_component.html.erb
@@ -1,5 +1,10 @@
-<section class="app-govuk-summary-card">
+<%= tag.section class: class_names("app-govuk-summary-card", "app-inset-text--incomplete-section" => show_as_incomplete?) do %>
   <div class="app-govuk-summary-card__body">
     <%= govuk_summary_list(rows:, classes: ["govuk-!-margin-bottom-6"],) %>
   </div>
-</section>
+
+  <% if show_as_incomplete? %>
+    <p class="app-instruction-text">You must complete your details before you can send your referral</p>
+    <%= govuk_button_link_to "Complete your details", section.next_path %>
+  <% end %>
+<% end %>

--- a/app/components/summary_card_component.rb
+++ b/app/components/summary_card_component.rb
@@ -1,8 +1,16 @@
 class SummaryCardComponent < ViewComponent::Base
-  def initialize(rows:, editable: true, ignore_editable: [])
+  attr_reader :section, :review
+
+  def initialize(rows:, section:, review: false, editable: true, ignore_editable: [])
     super
     rows = transform_hash(rows) if rows.is_a?(Hash)
     @rows = rows_including_actions_if_editable(rows, editable, ignore_editable)
+    @section = section
+    @review = review
+  end
+
+  def show_as_incomplete?
+    review ? section.incomplete? : section.questions_incomplete?
   end
 
   private

--- a/app/components/task_list_section_component.html.erb
+++ b/app/components/task_list_section_component.html.erb
@@ -6,9 +6,9 @@
     <% items.each do |item| %>
       <li class="app-task-list__item">
         <span class="app-task-list__task-name">
-          <a href="<%= item.path %>" aria-describedby="<%= item.label.parameterize %>"><%= item.label %></a>
+          <%= link_to item.label, item.path, aria: { describedby: item.label.parameterize } %>
         </span>
-        <% tag_css = item.status != :completed ? " govuk-tag--grey" : "" -%>
+        <% tag_css = item.incomplete? ? " govuk-tag--grey" : "" -%>
         <strong class="govuk-tag app-task-list__tag<%= tag_css %>" id="<%= item.label.parameterize %>">
           <%= I18n.t("referral_form.statuses.#{item.status}") %>
         </strong>

--- a/app/controllers/referrals/referrer/check_answers_controller.rb
+++ b/app/controllers/referrals/referrer/check_answers_controller.rb
@@ -3,7 +3,8 @@ module Referrals
     class CheckAnswersController < BaseController
       def edit
         @referrer = current_referral.referrer
-        @check_answers_form = CheckAnswersForm.new(referrer: @referrer, complete: @referrer.complete)
+        @check_answers_form =
+          CheckAnswersForm.new(referral: current_referral, referrer: @referrer, complete: @referrer.complete)
       end
 
       def update

--- a/app/forms/referral_form.rb
+++ b/app/forms/referral_form.rb
@@ -6,10 +6,6 @@ class ReferralForm
 
   attr_accessor :referral
 
-  # TODO: Replace these with something reading from :referral model fields
-  ReferralSection = Struct.new(:number, :label, :items)
-  ReferralSectionItem = Struct.new(:label, :path, :status)
-
   validate :sections_valid
 
   def save
@@ -22,156 +18,17 @@ class ReferralForm
     referral.submit
   end
 
-  def sections
-    [about_you_section, about_the_person_you_are_referring_section, the_allegation_section]
+  def items
+    [
+      Referrals::SectionGroups::AboutYouSectionGroup.new(referral:)
+      # Referrals::SectionGroups::AboutTheTeacherSectionGroup.new(referral:)
+      # Referrals::SectionGroups::TheAllegationSection.new(referral:)
+    ]
   end
 
   private
 
   def sections_valid
-    errors.add(:base, :all_sections_complete) unless sections.map(&:items).flatten.map(&:status).uniq == [:completed]
-  end
-
-  def about_you_section
-    ReferralSection
-      .new(1, I18n.t("referral_form.about_you"))
-      .tap do |section|
-        section.items = [
-          ReferralSectionItem.new(
-            I18n.t("referral_form.your_details"),
-            path_for_section_status(
-              check_answers?(referral.referrer&.complete),
-              polymorphic_path([:edit, referral.routing_scope, referral, :referrer_name]),
-              polymorphic_path([:edit, referral.routing_scope, referral, :referrer, :check_answers])
-            ),
-            section_status(referral.referrer&.complete)
-          )
-        ]
-
-        if referral.from_employer?
-          section.items.append(
-            ReferralSectionItem.new(
-              I18n.t("referral_form.your_organisation"),
-              path_for_section_status(
-                check_answers?(referral.organisation&.complete),
-                polymorphic_path([:edit, referral.routing_scope, referral, :organisation_address]),
-                polymorphic_path([:edit, referral.routing_scope, referral, :organisation, :check_answers])
-              ),
-              section_status(referral.organisation&.complete)
-            )
-          )
-        end
-      end
-  end
-
-  def about_the_person_you_are_referring_section
-    ReferralSection
-      .new(2, I18n.t("referral_form.about_the_person_you_are_referring"))
-      .tap do |section|
-        section.items = [
-          ReferralSectionItem.new(
-            I18n.t("referral_form.personal_details"),
-            path_for_section_status(
-              check_answers?(referral.personal_details_complete),
-              polymorphic_path([:edit, referral.routing_scope, referral, :personal_details_name]),
-              polymorphic_path([:edit, referral.routing_scope, referral, :personal_details, :check_answers])
-            ),
-            section_status(referral.personal_details_complete)
-          )
-        ]
-
-        if referral.from_employer?
-          section.items.append(
-            ReferralSectionItem.new(
-              I18n.t("referral_form.contact_details"),
-              path_for_section_status(
-                check_answers?(referral.contact_details_complete),
-                polymorphic_path([:edit, referral.routing_scope, referral, :contact_details_email]),
-                polymorphic_path([:edit, referral.routing_scope, referral, :contact_details, :check_answers])
-              ),
-              section_status(referral.contact_details_complete)
-            )
-          )
-        end
-
-        section.items.append(
-          ReferralSectionItem.new(
-            I18n.t("referral_form.about_their_role"),
-            path_for_section_status(
-              check_answers?(referral.teacher_role_complete),
-              polymorphic_path([:edit, referral.routing_scope, referral, :teacher_role, :job_title]),
-              polymorphic_path([:edit, referral.routing_scope, referral, :teacher_role, :check_answers])
-            ),
-            section_status(referral.teacher_role_complete)
-          )
-        )
-      end
-  end
-
-  def the_allegation_section
-    ReferralSection
-      .new(3, I18n.t("referral_form.the_allegation"))
-      .tap do |section|
-        section.items = [
-          ReferralSectionItem.new(
-            I18n.t("referral_form.details_of_the_allegation"),
-            path_for_section_status(
-              check_answers?(referral.allegation_details_complete),
-              polymorphic_path([:edit, referral.routing_scope, referral, :allegation_details]),
-              polymorphic_path([:edit, referral.routing_scope, referral, :allegation, :check_answers])
-            ),
-            section_status(referral.allegation_details_complete)
-          )
-        ]
-
-        if referral.from_employer?
-          section.items.append(
-            ReferralSectionItem.new(
-              I18n.t("referral_form.previous_allegations"),
-              path_for_section_status(
-                check_answers?(referral.previous_misconduct_complete),
-                polymorphic_path([:edit, referral.routing_scope, referral, :previous_misconduct_reported]),
-                polymorphic_path([:edit, referral.routing_scope, referral, :previous_misconduct, :check_answers])
-              ),
-              section_status(referral.previous_misconduct_complete)
-            )
-          )
-        end
-
-        section.items.append(
-          ReferralSectionItem.new(
-            I18n.t("referral_form.evidence_and_supporting_information"),
-            path_for_evidence_section_status(
-              check_answers?(referral.evidence_details_complete),
-              polymorphic_path([:edit, referral.routing_scope, referral, :evidence_start]),
-              polymorphic_path([:edit, referral.routing_scope, referral, :evidence_check_answers]),
-              polymorphic_path([:edit, referral.routing_scope, referral, :evidence_uploaded])
-            ),
-            section_status(referral.evidence_details_complete)
-          )
-        )
-      end
-  end
-
-  def check_answers?(complete)
-    !complete.nil?
-  end
-
-  def section_status(complete)
-    complete ? :completed : :incomplete
-  end
-
-  def path_for_section_status(check_answers, start_path, check_answers_path)
-    check_answers ? check_answers_path : start_path
-  end
-
-  def path_for_evidence_section_status(check_answers, start_path, check_answers_path, evidence_upload_path)
-    if check_answers
-      check_answers_path
-    elsif referral.evidences.any?
-      evidence_upload_path
-    else
-      start_path
-    end
+    errors.add(:base, :all_sections_complete) unless items.all?(&:complete?)
   end
 end

--- a/app/forms/referral_form_section.rb
+++ b/app/forms/referral_form_section.rb
@@ -7,5 +7,29 @@ module ReferralFormSection
     attr_accessor :referral
 
     validates :referral, presence: true
+
+    def complete?
+      valid?
+    end
+
+    def incomplete?
+      !complete?
+    end
+
+    def path
+      [:edit, referral.routing_scope, referral, slug.to_sym]
+    end
+
+    def slug
+      self.class.to_s.split("::")[1..].join.remove("Form").underscore.to_sym
+    end
+
+    def section
+      section_class.new(referral:)
+    end
+
+    def section_class
+      "Referrals::Sections::#{self.class.to_s.split("::").second}Section".constantize
+    end
   end
 end

--- a/app/forms/referrals/section.rb
+++ b/app/forms/referrals/section.rb
@@ -1,0 +1,73 @@
+module Referrals
+  class Section
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include Rails.application.routes.url_helpers
+
+    attribute :referral
+
+    def items
+      raise NotImplementedError, "You must define items in #{self.class}"
+    end
+
+    def complete
+      raise NotImplementedError, "You must define complete in #{self.class}"
+    end
+
+    def view_component(user:)
+      raise NotImplementedError, "You must define view_component in #{self.class}"
+    end
+
+    def label
+      I18n.t("referral_form.#{slug}}")
+    end
+
+    def start_path
+      items.first.path
+    end
+
+    def check_answers_path
+      [:edit, referral.routing_scope, referral, slug, :check_answers]
+    end
+
+    def path
+      started? ? check_answers_path : start_path
+    end
+
+    def next_path
+      items.find(&:incomplete?).path
+    end
+
+    def slug
+      self.class.to_s.demodulize.remove("Section").underscore.to_sym
+    end
+
+    def status
+      complete? ? :completed : :incomplete
+    end
+
+    def complete?
+      !!complete
+    end
+
+    def incomplete?
+      !complete
+    end
+
+    def questions_complete?
+      items[0..-2].all?(&:complete?)
+    end
+
+    def questions_incomplete?
+      !questions_complete?
+    end
+
+    def started?
+      items.first.complete?
+    end
+
+    def complete_rows(rows)
+      rows.select.with_index { |_i, idx| items[idx].complete? }
+    end
+  end
+end

--- a/app/forms/referrals/section_group.rb
+++ b/app/forms/referrals/section_group.rb
@@ -1,0 +1,24 @@
+module Referrals
+  class SectionGroup
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :referral
+
+    def items
+      raise NotImplementedError, "You must define items in #{self.class}"
+    end
+
+    def label
+      I18n.t("referral_form.#{slug}")
+    end
+
+    def slug
+      self.class.to_s.demodulize.remove("SectionGroup").underscore
+    end
+
+    def complete?
+      items.all?(&:complete?)
+    end
+  end
+end

--- a/app/forms/referrals/section_groups/about_you_section_group.rb
+++ b/app/forms/referrals/section_groups/about_you_section_group.rb
@@ -1,0 +1,12 @@
+module Referrals
+  module SectionGroups
+    class AboutYouSectionGroup < SectionGroup
+      def items
+        [
+          Sections::ReferrerSection.new(referral:)
+          # referral.from_employer? && Sections::AboutYouSection::OrganisationSection.new(referral:)
+        ].compact
+      end
+    end
+  end
+end

--- a/app/forms/referrals/sections/referrer_section.rb
+++ b/app/forms/referrals/sections/referrer_section.rb
@@ -1,0 +1,26 @@
+module Referrals
+  module Sections
+    class ReferrerSection < Section
+      def items
+        [
+          Referrer::NameForm.new(referral:),
+          Referrer::JobTitleForm.new(referral:),
+          Referrer::PhoneForm.new(referral:),
+          Referrer::CheckAnswersForm.new(referral:)
+        ]
+      end
+
+      def complete
+        referral.referrer&.complete
+      end
+
+      def label
+        I18n.t("referral_form.your_details")
+      end
+
+      def view_component(user:)
+        AboutYouComponent.new(referral:, user:, section: self)
+      end
+    end
+  end
+end

--- a/app/views/referrals/edit.html.erb
+++ b/app/views/referrals/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l"><%= t("referral_form.heading") %></h1>
-    <%= render TaskListComponent.new(sections: @referral_form.sections) %>
+    <%= render TaskListComponent.new(sections: @referral_form.items) %>
     <%= govuk_button_link_to "Review and send", [current_referral.routing_scope, current_referral, :review] %>
   </div>
 </div>

--- a/app/views/referrals/referrer/check_answers/edit.html.erb
+++ b/app/views/referrals/referrer/check_answers/edit.html.erb
@@ -11,15 +11,18 @@
         Check and confirm your answers
       </h1>
 
-      <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
+      <%= render @check_answers_form.section.view_component user: current_user %>
 
-      <%= f.hidden_field :complete %>
+      <% if @check_answers_form.section.questions_complete? %>
+        <%= f.hidden_field :complete %>
 
-      <%= f.govuk_radio_buttons_fieldset :complete, hint: { text: 'You can still make changes to a completed section' }, legend: { size: 'm', text: 'Have you completed this section?' } do %>
-        <%= f.govuk_radio_button :complete, 'true', label: { text: "Yes, I’ve completed this section" }, link_errors: true %>
-        <%= f.govuk_radio_button :complete, 'false', label: { text: "No, I’ll come back to it later" } %>
+        <%= f.govuk_radio_buttons_fieldset :complete, hint: { text: 'You can still make changes to a completed section' }, legend: { size: 'm', text: 'Have you completed this section?' } do %>
+          <%= f.govuk_radio_button :complete, 'true', label: { text: "Yes, I’ve completed this section" }, link_errors: true %>
+          <%= f.govuk_radio_button :complete, 'false', label: { text: "No, I’ll come back to it later" } %>
+        <% end %>
+
+        <%= f.govuk_submit "Save and continue" %>
       <% end %>
-      <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/referrals/shared/_review.html.erb
+++ b/app/views/referrals/shared/_review.html.erb
@@ -1,35 +1,10 @@
-<div class="app-review-panel">
-  <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
+<% @referral_form.items.each do |section_group| %>
+  <div class="app-review-panel">
+    <h2 class="govuk-heading-m govuk-!-font-size-27"><%= section_group.label %></h2>
 
-  <h3 class="govuk-heading-m">Your details</h3>
-  <%= render AboutYouComponent.new(referral: current_referral, user: current_user) %>
-
-  <h3 class="govuk-heading-m">Your organisation</h3>
-  <%= render OrganisationComponent.new(referral: current_referral) %>
-</div>
-
-<div class="app-review-panel">
-  <h2 class="govuk-heading-m govuk-!-font-size-27">About the teacher</h2>
-
-  <h3 class="govuk-heading-m">Personal details</h3>
-  <%= render PersonalDetailsComponent.new(referral: current_referral) %>
-
-  <h3 class="govuk-heading-m">Contact details</h3>
-  <%= render ContactDetailsComponent.new(referral: current_referral) %>
-
-  <h3 class="govuk-heading-m">About their role</h3>
-  <%= render TheirRoleComponent.new(referral: current_referral) %>
-</div>
-
-<div class="app-review-panel">
-  <h2 class="govuk-heading-m govuk-!-font-size-27">The allegation</h2>
-
-  <h3 class="govuk-heading-m">Allegation details</h3>
-  <%= render WhatHappenedComponent.new(referral: current_referral) %>
-
-  <h3 class="govuk-heading-m">Previous allegation details</h3>
-  <%= render PreviousMisconductComponent.new(referral: current_referral) %>
-
-  <h3 class="govuk-heading-m">Evidence and supporting information</h3>
-  <%= render EvidenceComponent.new(referral: current_referral) %>
-</div>
+    <% section_group.items.each do |section| %>
+      <h3 class="govuk-heading-m"><%= section.label %></h3>
+      <%= render section.view_component user: current_user %>
+    <% end %>
+  </div>
+<% end %>


### PR DESCRIPTION
To make it easier to deal with incomplete sections on the form we show only completed fields and wrap incomplete sections in a blue border.

We add the domain objects `SectionGroup` which contains many `Section` which contains many `Forms` to represent the form structure.

A `Form` is the atomic unit of completion and forms are complete if they are `valid?` so it is relatively easy to see which is the next question. All the state of the form completion is already stored in the referral object, so there's no need to add additional state.

For consistency and for the system to work correctly `Form` objects need to be initialized with a `referral` object rather than specific parameters.

Form consistency is implemented with the `ReferralFormSection` module (needs a rename), and we've also added `Section` and `SectionGroup` base classes which provide default paths and translations (some of these are overridden, but we could go back and homogenise these at a later date)

The ViewComponents for rendering summaries of the sections now require a section object so they know completed they are and whether to render the blue borders around them.

https://trello.com/c/jhcJstSI/1315-spike-incomplete-section-pattern