### PR TITLE
Fix "You should know" NoMethodError

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,6 +4,8 @@ class PagesController < ApplicationController
   end
 
   def you_should_know
+    return redirect_to(start_path) if eligibility_check.nil?
+
     @continue_path =
       if FeatureFlags::FeatureFlag.active?(:referral_form)
         if !current_user


### PR DESCRIPTION
Accessing the page with a current user but without an eligibility check in the session would trigger a `NoMethodError`.

Fixes: https://dfe-teacher-services.sentry.io/issues/4027898768/?project=4504136292237312&referrer=slack

### Link to Trello card

https://trello.com/c/RBE5WwvX/1327-you-should-know-page-eligibility-bug