### PR TITLE
Strip spaces in OTP input

### DIFF
--- a/app/controllers/users/otp_controller.rb
+++ b/app/controllers/users/otp_controller.rb
@@ -65,7 +65,7 @@ class Users::OtpController < DeviseController
   end
 
   def user_params
-    params.require(:user).permit(:uuid, :otp, :email)
+    params.require(:user).permit(:uuid, :otp, :email).tap { |p| p[:otp].strip! }
   end
 
   def new_referral

--- a/spec/system/user_auth/user_signs_in_spec.rb
+++ b/spec/system/user_auth/user_signs_in_spec.rb
@@ -23,6 +23,14 @@ RSpec.feature "User accounts" do
     and_i_am_not_prompted_to_sign_in_again
     and_my_otp_state_is_reset
 
+    when_i_am_signed_out
+    when_i_visit_the_root_page
+    and_choose_continue_referral
+    then_i_should_see_the_sign_in_page
+    and_i_submit_my_email
+    when_i_provide_the_expected_otp_with_surrounding_spaces
+    then_i_am_signed_in
+
     when_i_have_a_referral_in_progress
     and_i_sign_out
     when_i_sign_back_in
@@ -93,6 +101,19 @@ RSpec.feature "User accounts" do
     expect(email.body).to include expected_otp
 
     fill_in "Confirmation code", with: expected_otp
+    within("main") { click_on "Continue" }
+  end
+
+  def when_i_provide_the_expected_otp_with_surrounding_spaces
+    perform_enqueued_jobs
+
+    user = User.find_by(email: "test@example.com")
+    expected_otp = Devise::Otp.derive_otp(user.secret_key)
+
+    email = ActionMailer::Base.deliveries.last
+    expect(email.body).to include expected_otp
+
+    fill_in "Confirmation code", with: " #{expected_otp} "
     within("main") { click_on "Continue" }
   end
 


### PR DESCRIPTION
OTPs are copied and pasted from an email. It may be possible to select whitespace while doing that.

The fix here is to strip the otp param in `user_params`

Devise does have a parameter filter which is configured in the initializer with `strip_whitespace_keys` This applies to email addresses when logging in but not to the OTP as it is applied on `save` not to the params themselves. Hence the slightly hacky approach

https://trello.com/c/jhcJstSI/1315-spike-incomplete-section-pattern