### PR TITLE
Send the referral reminder email

### DIFF
--- a/app/jobs/draft_referrals_reminder_job.rb
+++ b/app/jobs/draft_referrals_reminder_job.rb
@@ -1,0 +1,19 @@
+class DraftReferralsReminderJob < ApplicationJob
+  sidekiq_options queue: "low"
+
+  def perform
+    return unless send_reminder_email?
+
+    Referral.stale_drafts_reminder.each do |referral|
+      next unless referral.reminder_emails.recent.none?
+
+      SendReminderEmailJob.perform_later(referral)
+    end
+  end
+
+  private
+
+  def send_reminder_email?
+    FeatureFlags::FeatureFlag.active?(:send_reminder_email)
+  end
+end

--- a/app/jobs/send_reminder_email_job.rb
+++ b/app/jobs/send_reminder_email_job.rb
@@ -1,0 +1,20 @@
+class SendReminderEmailJob < ApplicationJob
+  sidekiq_options queue: "low"
+
+  def perform(referral)
+    Referral.transaction do
+      record_reminder(referral)
+      send_reminder_email(referral)
+    end
+  end
+
+  private
+
+  def send_reminder_email(referral)
+    UserMailer.draft_referral_reminder(referral).deliver_later
+  end
+
+  def record_reminder(referral)
+    referral.reminder_emails.create!
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -22,4 +22,12 @@ class UserMailer < ApplicationMailer
 
     view_mail_refer(mailer_options:)
   end
+
+  def draft_referral_reminder(referral)
+    @link = polymorphic_url([:edit, referral.routing_scope, referral])
+    @user = referral.user
+    mailer_options = { to: @user.email, subject: "Your referral will be deleted in 7 days" }
+
+    view_mail_refer(mailer_options:)
+  end
 end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -10,11 +10,13 @@ class Referral < ApplicationRecord
   has_one_attached :pdf
 
   has_many :evidences, -> { order(:created_at) }, class_name: "ReferralEvidence", dependent: :destroy
+  has_many :reminder_emails
 
   scope :employer, -> { joins(:eligibility_check).where(eligibility_check: { reporting_as: :employer }) }
   scope :member_of_public, -> { joins(:eligibility_check).where(eligibility_check: { reporting_as: :public }) }
   scope :submitted, -> { where.not(submitted_at: nil) }
-  scope :stale_drafts, -> { where(submitted_at: nil).where("created_at < ?", 90.days.ago) }
+  scope :stale_drafts, -> { where(submitted_at: nil).where("updated_at < ?", 90.days.ago) }
+  scope :stale_drafts_reminder, -> { where(submitted_at: nil).where("updated_at <= ?", 83.days.ago) }
 
   delegate :name, to: :referrer, prefix: true, allow_nil: true
 

--- a/app/models/reminder_email.rb
+++ b/app/models/reminder_email.rb
@@ -1,0 +1,5 @@
+class ReminderEmail < ApplicationRecord
+  belongs_to :referral
+
+  scope :recent, -> { where(created_at: 8.days.ago..Time.zone.now) }
+end

--- a/app/views/user_mailer/draft_referral_reminder.erb
+++ b/app/views/user_mailer/draft_referral_reminder.erb
@@ -1,0 +1,11 @@
+Your referral of serious misconduct by a teacher has not been updated in a while.
+
+It’ll be deleted in 7 days on <%= 7.days.from_now.to_fs(:day_month_and_year) %>.
+
+If you would like to keep your referral, you must make changes or complete it.
+
+Complete your referral:
+
+<%= @link %>
+
+<%= render "shared/mailers/get_help" %>

--- a/app/views/users/referrals/show.html.erb
+++ b/app/views/users/referrals/show.html.erb
@@ -7,7 +7,10 @@
       <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l">Your referral</span>
         <h1 class="govuk-heading-l"><%= current_referral.referrer_name %></h1>
-        <p class="govuk-!-margin-bottom-8">You sent this referral on <%= current_referral.submitted_at.to_fs(:day_month_year_time) %>.</p>
+
+        <% if current_referral.submitted? %>
+          <p class="govuk-!-margin-bottom-8">You sent this referral on <%= current_referral.submitted_at.to_fs(:day_month_year_time) %>.</p>
+        <% end %>
 
         <% if current_referral.from_employer? %>
           <%= render "referrals/shared/review" %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -176,3 +176,8 @@ shared:
     - details
     - created_at
     - updated_at
+  :reminder_emails:
+    - id
+    - referral_id
+    - created_at
+    - updated_at

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -21,3 +21,7 @@ feature_flags:
     description: Allow signing in as a staff user using HTTP Basic
       authentication. This is useful before staff users have been created, but
       should otherwise be inactive.
+  send_reminder_email:
+    author: Sebastian Zaremba
+    description: Send the reminder emails 7 days before deletion for unsubmitted
+      referrals that weren't updated in 83 days.

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -7,4 +7,7 @@ Date::DATE_FORMATS[:weekday_day_and_month] = "%A %-d %B"
 Time::DATE_FORMATS[:month_and_year] = "%B %Y"
 Date::DATE_FORMATS[:month_and_year] = "%B %Y"
 
+Time::DATE_FORMATS[:day_month_and_year] = "%d %B %Y"
+Date::DATE_FORMATS[:day_month_and_year] = "%d %B %Y"
+
 Time::DATE_FORMATS[:day_month_year_time] = "%d %B %Y at %-l:%M %P"

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,3 +1,7 @@
 delete_draft_referrals:
   cron: "every day at midnight"
   class: "DeleteDraftReferralsJob"
+
+draft_referral_reminder:
+  cron: "every day at 9 am"
+  class: "DraftReferralsReminderJob"

--- a/db/migrate/20230328092509_create_reminder_emails.rb
+++ b/db/migrate/20230328092509_create_reminder_emails.rb
@@ -1,0 +1,8 @@
+class CreateReminderEmails < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reminder_emails do |t|
+      t.references :referral, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_14_102103) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_28_092509) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
 
@@ -163,6 +163,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_14_102103) do
     t.index ["referral_id"], name: "index_referrers_on_referral_id"
   end
 
+  create_table "reminder_emails", force: :cascade do |t|
+    t.bigint "referral_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["referral_id"], name: "index_reminder_emails_on_referral_id"
+  end
+
   create_table "staff", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -235,4 +242,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_14_102103) do
   add_foreign_key "referrals", "eligibility_checks"
   add_foreign_key "referrals", "users"
   add_foreign_key "referrers", "referrals"
+  add_foreign_key "reminder_emails", "referrals", column: "referral_id"
 end

--- a/spec/factories/reminder_emails.rb
+++ b/spec/factories/reminder_emails.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :reminder_email do
+    referral
+  end
+end

--- a/spec/jobs/delete_draft_referrals_job_spec.rb
+++ b/spec/jobs/delete_draft_referrals_job_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe DeleteDraftReferralsJob, type: :job do
   before do
-    create_list(:referral, 3, created_at: 91.days.ago)
+    create_list(:referral, 3, updated_at: 91.days.ago)
     create_list(:referral, 2)
-    create_list(:referral, 2, :submitted, created_at: 91.days.ago)
+    create_list(:referral, 2, :submitted, updated_at: 91.days.ago)
   end
 
   describe "running the job" do

--- a/spec/jobs/draft_referrals_reminder_job_spec.rb
+++ b/spec/jobs/draft_referrals_reminder_job_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe DraftReferralsReminderJob, type: :job do
+  let!(:referral_to_remind) { create(:referral, updated_at: 83.days.ago) }
+
+  before do
+    create_list(:referral, 2)
+    create_list(:referral, 2, :submitted, updated_at: 83.days.ago)
+  end
+
+  describe "running the job" do
+    subject(:perform) { described_class.new.perform }
+
+    context "when the send_reminder_email feature is active" do
+      before { FeatureFlags::FeatureFlag.activate(:send_reminder_email) }
+
+      it "enqueues 1 job" do
+        expect { perform }.to(have_enqueued_job(SendReminderEmailJob).once)
+      end
+
+      context "when the referral has reminder sent more than 8 days ago" do
+        before { create(:reminder_email, referral: referral_to_remind, created_at: 9.days.ago) }
+
+        after { ReminderEmail.destroy_all }
+
+        it "enqueues 1 jobs" do
+          expect { perform }.to(have_enqueued_job(SendReminderEmailJob).once)
+        end
+      end
+
+      context "when the referral has reminder sent less than 8 days ago" do
+        before { create(:reminder_email, referral: referral_to_remind) }
+
+        after { ReminderEmail.destroy_all }
+
+        it "enqueues 0 jobs" do
+          expect { perform }.not_to(have_enqueued_job(SendReminderEmailJob))
+        end
+      end
+
+      context "when reminders were sent 90 days ago and less than 8 days ago" do
+        before do
+          create(:reminder_email, referral: referral_to_remind, created_at: 90.days.ago)
+          create(:reminder_email, referral: referral_to_remind)
+        end
+
+        after { ReminderEmail.destroy_all }
+
+        it "enqueues 2 jobs" do
+          expect { perform }.not_to(have_enqueued_job(SendReminderEmailJob))
+        end
+      end
+    end
+
+    context "when the send_reminder_email feature is not active" do
+      before { FeatureFlags::FeatureFlag.deactivate(:send_reminder_email) }
+
+      it "enqueues 0 jobs" do
+        expect { perform }.not_to(have_enqueued_job(SendReminderEmailJob))
+      end
+    end
+  end
+end

--- a/spec/jobs/send_reminder_email_job_spec.rb
+++ b/spec/jobs/send_reminder_email_job_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe SendReminderEmailJob, type: :job do
+  before { create(:referral) }
+
+  describe "running the job" do
+    subject(:perform) { described_class.new.perform(Referral.first) }
+
+    it "creates the Sidekiq jobs and sends the reminder email" do
+      expect { perform }.to have_enqueued_mail(UserMailer, :draft_referral_reminder).once.and change(
+                   ReminderEmail,
+                   :count
+                 ).by(1)
+    end
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -74,4 +74,29 @@ RSpec.describe UserMailer, type: :mailer do
       end
     end
   end
+
+  describe ".draft_referral_reminder" do
+    subject(:email) { described_class.draft_referral_reminder(referral) }
+
+    let(:user) { create(:user) }
+    let(:referral) { create(:referral, user_id: user.id) }
+
+    it "sends a referral link to the user" do
+      expect(email.to).to include user.email
+    end
+
+    it "includes the referral link in the email body" do
+      expect(email.body).to include(edit_referral_url(referral))
+    end
+
+    it "includes the correct deletion date" do
+      expect(email.body).to include(7.days.from_now.strftime("%d %B %Y"))
+    end
+
+    it "sets the subject" do
+      expect(email.subject).to eq "Your referral will be deleted in 7 days"
+    end
+
+    it_behaves_like "email with `Get help` section"
+  end
 end


### PR DESCRIPTION
### Context

This job will run every day at 9 am and send emails to the users who have a draft referral 7 days prior to deletion.

### Email preview

<img width="581" alt="Screenshot 2023-03-27 at 12 11 02" src="https://user-images.githubusercontent.com/1636476/227928232-8ae9c5c4-da1d-4c16-a087-cf06cec641ed.png">

### Link to Trello card

https://trello.com/c/ZPmG9xTb/1325-referral-reminder-email