### PR TITLE
Add the host domain on the logs

### DIFF
--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -7,6 +7,10 @@ class LogStashFormatter < SemanticLogger::Formatters::Raw
     hash[:hosting_environment] = ENV["HOSTING_ENVIRONMENT_NAME"]
   end
 
+  def format_add_host_domain
+    hash[:host] = ENV["HOSTING_DOMAIN"]
+  end
+
   # Place a more readable version of the exception into the message field.
   def format_exception
     exception_message = hash.dig(:exception, :message)
@@ -31,6 +35,7 @@ class LogStashFormatter < SemanticLogger::Formatters::Raw
 
     format_add_type
     format_add_hosting_env
+    format_add_host_domain
     format_exception
     format_stacktrace
 

--- a/spec/logs/formatters/log_stash_formatter_spec.rb
+++ b/spec/logs/formatters/log_stash_formatter_spec.rb
@@ -121,4 +121,14 @@ RSpec.describe LogStashFormatter do
       expect(formatter.hash[:hosting_environment]).to eq(ENV["HOSTING_ENVIRONMENT_NAME"])
     end
   end
+
+  describe "#format_add_host_domain" do
+    let(:log) { info_level_log }
+
+    it "adds the host domain" do
+      formatter.format_add_host_domain
+
+      expect(formatter.hash[:host]).to eq(ENV["HOSTING_DOMAIN"])
+    end
+  end
 end


### PR DESCRIPTION
### Context

Add the host domain on the logs

### Changes proposed in this pull request

The current host that was sent through the logs was not really helpful, hence why I replaced it with the actual host domain.

#### Before

![Screenshot 2023-03-24 at 17 18 40](https://user-images.githubusercontent.com/1955084/227879998-0540bfe8-7803-45a5-b38a-39f6384e9711.png)

#### After

![Screenshot 2023-03-27 at 08 29 53](https://user-images.githubusercontent.com/1955084/227880045-065edc0c-8460-4cb7-ac5b-4fb76b0d0ad7.png)

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
