### PR TITLE
Update user/staff email validation to match Notify

### DIFF
--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -12,7 +12,7 @@ class Staff < ApplicationRecord
     validate_on_invite: true
   )
 
-  validates :email, uniqueness: true
+  validates :email, uniqueness: true, valid_for_notify: true
   validate :password_complexity
   validate :permissions_are_valid
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
 
   after_commit :reload_uuid, on: :create
 
+  validates :email, valid_for_notify: true
+
   def reload_uuid
     self[:uuid] = self.class.where(id:).pick(:uuid)
   end

--- a/spec/system/user_registration/user_registers_spec.rb
+++ b/spec/system/user_registration/user_registers_spec.rb
@@ -14,6 +14,9 @@ RSpec.feature "User registration" do
     and_i_complete_the_eligibility_screener
     then_i_should_see_sign_up_page
 
+    when_i_submit_an_invalid_email_address
+    then_i_should_see_the_sign_up_page_with_an_error
+
     when_i_submit_my_email
     then_i_should_see_the_otp_page
     and_event_tracking_is_working
@@ -62,8 +65,18 @@ RSpec.feature "User registration" do
     expect(page).to have_current_path(new_user_session_path(new_referral: true))
   end
 
+  def when_i_submit_an_invalid_email_address
+    fill_in "Your email address", with: "test@email"
+    click_on "Continue"
+  end
+
+  def then_i_should_see_the_sign_up_page_with_an_error
+    expect(page).to have_content "Your email address"
+    expect(page).to have_content "Enter an email address in the correct format, like name@example.com"
+  end
+
   def when_i_submit_my_email
-    fill_in "user-email-field", with: "test@example.com"
+    fill_in "Your email address", with: "test@example.com"
     click_on "Continue"
   end
 


### PR DESCRIPTION
### Context

Without this validation users can register using an invalid email address (like email@example). This would raise a `Notifications::Client::BadRequestError` with Notify.

Before:
<img width="564" alt="Screenshot 2023-03-27 at 14 53 27" src="https://user-images.githubusercontent.com/1636476/227959797-f57dfd92-5db1-44c5-a19b-f53dcaff88ba.png">

After:
<img width="721" alt="Screenshot 2023-03-27 at 14 09 21" src="https://user-images.githubusercontent.com/1636476/227959859-0d5c2ed3-811f-4a67-955b-6dda95d552f1.png">

### Link to Trello card

https://trello.com/c/hu0tdn8D/1339-match-email-validation-with-notify
