### PR TITLE
Hide show user referral page before submission

### DIFF
--- a/app/controllers/users/referrals_controller.rb
+++ b/app/controllers/users/referrals_controller.rb
@@ -9,6 +9,7 @@ module Users
     end
 
     def show
+      redirect_to :not_found unless current_referral.submitted?
     end
 
     def current_referral

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,7 +250,7 @@ Rails.application.routes.draw do
 
   scope via: :all do
     get "/403", to: "errors#forbidden", as: :forbidden
-    get "/404", to: "errors#not_found"
+    get "/404", to: "errors#not_found", as: :not_found
     get "/422", to: "errors#unprocessable_entity"
     get "/429", to: "errors#too_many_requests"
     get "/500", to: "errors#internal_server_error"

--- a/spec/system/user_auth/user_with_completed_referral_signs_in_spec.rb
+++ b/spec/system/user_auth/user_with_completed_referral_signs_in_spec.rb
@@ -26,6 +26,9 @@ RSpec.feature "User accounts" do
     then_i_am_signed_in
     and_i_see_the_referrals_page
     and_i_can_continue_the_referral_in_progress
+
+    when_i_access_the_unsubmitted_referral_page_directly
+    then_i_am_redirected_to_the_404_page
   end
 
   private
@@ -105,5 +108,13 @@ RSpec.feature "User accounts" do
   def and_i_can_continue_the_referral_in_progress
     click_on "Complete referral"
     expect(page).to have_current_path(edit_referral_path(@user.referral_in_progress))
+  end
+
+  def when_i_access_the_unsubmitted_referral_page_directly
+    visit users_referral_path(@user.referral_in_progress)
+  end
+
+  def then_i_am_redirected_to_the_404_page
+    expect(page).to have_content "Page not found"
   end
 end


### PR DESCRIPTION
### Context

The `users/referrals/:id` page should not be accessible before the referral gets submitted.

Before:
<img width="720" alt="Screenshot 2023-03-27 at 10 15 58" src="https://user-images.githubusercontent.com/1636476/227972623-a6b498f6-5171-4634-8f18-e90ccc95f3f0.png">

After:
<img width="756" alt="Screenshot 2023-03-27 at 15 34 57" src="https://user-images.githubusercontent.com/1636476/227972640-5ea19b39-f887-4773-8f6c-2da1ab3a6914.png">

### Link to Trello card

https://trello.com/c/L7kl0DFc/1340-hide-show-user-referral-page-for-unsubmitted-referrals
