### PR TITLE
Turn off SemanticLogger for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,6 @@ gem "puma", "~> 6.1"
 gem "pundit", "~> 2.3"
 gem "rack-attack"
 gem "rails", "~> 7.0.4"
-# Semantic Logger makes logs pretty, also needed for logit integration
-gem "rails_semantic_logger"
 gem "rotp"
 gem "rubyzip"
 gem "sentry-rails"
@@ -63,4 +61,9 @@ group :test do
   gem "cuprite"
   gem "rspec"
   gem "shoulda-matchers"
+end
+
+group :production, :test do
+  # Semantic Logger makes logs pretty, also needed for logit integration
+  gem "rails_semantic_logger"
 end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,3 +1,5 @@
+return if Rails.env.development?
+
 class LogStashFormatter < SemanticLogger::Formatters::Raw
   def format_add_type
     hash[:type] = "rails"


### PR DESCRIPTION
### Context

Turn off SemanticLogger for development

There is a check done on development.rb that is breaking if the logs are formated as a hash:

https://github.com/DFE-Digital/refer-serious-misconduct/blob/main/config/environments/development.rb#L69

This won't work when msg is a hash.

To avoid that it's better to disable SemanticLogger.