### PR TITLE
Send reminder email now instead of later

### DIFF
--- a/app/jobs/send_reminder_email_job.rb
+++ b/app/jobs/send_reminder_email_job.rb
@@ -11,7 +11,7 @@ class SendReminderEmailJob < ApplicationJob
   private
 
   def send_reminder_email(referral)
-    UserMailer.draft_referral_reminder(referral).deliver_later
+    UserMailer.draft_referral_reminder(referral).deliver_now
   end
 
   def record_reminder(referral)

--- a/spec/jobs/send_reminder_email_job_spec.rb
+++ b/spec/jobs/send_reminder_email_job_spec.rb
@@ -7,10 +7,7 @@ RSpec.describe SendReminderEmailJob, type: :job do
     subject(:perform) { described_class.new.perform(Referral.first) }
 
     it "creates the Sidekiq jobs and sends the reminder email" do
-      expect { perform }.to have_enqueued_mail(UserMailer, :draft_referral_reminder).once.and change(
-                   ReminderEmail,
-                   :count
-                 ).by(1)
+      expect { perform }.to change { ActionMailer::Base.deliveries.size }.by(1).and change(ReminderEmail, :count).by(1)
     end
   end
 end


### PR DESCRIPTION
### Context

This makes use of the transaction in the job when the email doesn't get sent and should prevent the update in ReminderEmail.

### Link to Trello card

https://trello.com/c/ZPmG9xTb/1325-referral-reminder-email