### PR TITLE
Change summary_row_actions from array

### DIFF
--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -123,12 +123,12 @@ module ReferralHelper
   end
 
   def summary_row_actions(path:, label:, visually_hidden_text: nil)
-    return [] unless path
+    return {} unless path
 
     visually_hidden_text = label.downcase if visually_hidden_text.blank?
     expanded_path = path.is_a?(Symbol) ? [:edit, referral.routing_scope, referral, path] : path
     href = polymorphic_path(expanded_path, return_to: return_to_path)
 
-    [{ text: "Change", href:, visually_hidden_text: }]
+    { text: "Change", href:, visually_hidden_text: }
   end
 end

--- a/spec/helpers/referral_helper_spec.rb
+++ b/spec/helpers/referral_helper_spec.rb
@@ -18,13 +18,11 @@ RSpec.describe ReferralHelper, type: :helper do
       it "returns a hash with the correct values" do
         expect(helper_method).to eq(
           {
-            actions: [
-              {
-                text: "Change",
-                href: "/referrals/#{referral.id}/referrer/name/edit?return_to=",
-                visually_hidden_text: "label"
-              }
-            ],
+            actions: {
+              text: "Change",
+              href: "/referrals/#{referral.id}/referrer/name/edit?return_to=",
+              visually_hidden_text: "label"
+            },
             key: {
               text: "label"
             },
@@ -44,7 +42,7 @@ RSpec.describe ReferralHelper, type: :helper do
       end
 
       it "returns a hash with the correct values" do
-        expect(helper_method).to eq({ actions: [], key: { text: "label" }, value: { text: "value" } })
+        expect(helper_method).to eq({ actions: {}, key: { text: "label" }, value: { text: "value" } })
       end
     end
   end


### PR DESCRIPTION
The method doesn't allow returning multiple values in the array, making the array wrapping redundant. Removing it benefits when writing component specs.