### PR TITLE
Strip action links when the referral is submitted

### DIFF
--- a/app/components/about_you_component.rb
+++ b/app/components/about_you_component.rb
@@ -1,13 +1,16 @@
 class AboutYouComponent < ViewComponent::Base
   include ActiveModel::Model
   include ReferralHelper
+  include ComponentHelper
 
   attr_accessor :referral, :user
 
   delegate :referrer, to: :referral
 
   def rows
-    summary_rows [name_row, email_row, job_title_row, phone_row].compact
+    items = summary_rows [name_row, email_row, job_title_row, phone_row].compact
+
+    referral.submitted? ? remove_actions(items) : items
   end
 
   private

--- a/app/components/contact_details_component.rb
+++ b/app/components/contact_details_component.rb
@@ -7,14 +7,17 @@ class ContactDetailsComponent < ViewComponent::Base
   attr_accessor :referral
 
   def rows
-    summary_rows [
-                   email_known_row,
-                   email_row,
-                   phone_number_known_row,
-                   phone_number_row,
-                   address_known_row,
-                   address_row
-                 ].compact
+    items =
+      summary_rows [
+                     email_known_row,
+                     email_row,
+                     phone_number_known_row,
+                     phone_number_row,
+                     address_known_row,
+                     address_row
+                   ].compact
+
+    referral.submitted? ? remove_actions(items) : items
   end
 
   private

--- a/app/components/evidence_component.rb
+++ b/app/components/evidence_component.rb
@@ -1,11 +1,14 @@
 class EvidenceComponent < ViewComponent::Base
   include ActiveModel::Model
   include ReferralHelper
+  include ComponentHelper
 
   attr_accessor :referral
 
   def rows
-    summary_rows [anything_to_upload_row, evidence_row].compact
+    items = summary_rows [anything_to_upload_row, evidence_row].compact
+
+    referral.submitted? ? remove_actions(items) : items
   end
 
   private

--- a/app/components/organisation_component.rb
+++ b/app/components/organisation_component.rb
@@ -2,13 +2,16 @@ class OrganisationComponent < ViewComponent::Base
   include ActiveModel::Model
   include AddressHelper
   include ReferralHelper
+  include ComponentHelper
 
   attr_accessor :referral
 
   delegate :organisation, to: :referral
 
   def rows
-    summary_rows [organisation_row].compact
+    items = summary_rows [organisation_row].compact
+
+    referral.submitted? ? remove_actions(items) : items
   end
 
   private

--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -6,18 +6,21 @@ class PersonalDetailsComponent < ViewComponent::Base
   attr_accessor :referral
 
   def rows
-    summary_rows [
-                   name_row,
-                   known_by_other_name_row,
-                   other_name_row,
-                   date_of_birth_known_row,
-                   date_of_birth_row,
-                   ni_number_known_row,
-                   ni_number_row,
-                   trn_known_row,
-                   trn_row,
-                   qts_row
-                 ].compact
+    items =
+      summary_rows [
+                     name_row,
+                     known_by_other_name_row,
+                     other_name_row,
+                     date_of_birth_known_row,
+                     date_of_birth_row,
+                     ni_number_known_row,
+                     ni_number_row,
+                     trn_known_row,
+                     trn_row,
+                     qts_row
+                   ].compact
+
+    referral.submitted? ? remove_actions(items) : items
   end
 
   def known_by_other_name_row

--- a/app/components/previous_misconduct_component.rb
+++ b/app/components/previous_misconduct_component.rb
@@ -2,15 +2,19 @@ class PreviousMisconductComponent < ViewComponent::Base
   include ActiveModel::Model
   include ApplicationHelper
   include ReferralHelper
+  include ComponentHelper
 
   attr_accessor :referral
 
   def rows
-    summary_rows [
-                   previous_misconduct_reported_row,
-                   detailed_account_type_row,
-                   detailed_account_report_row
-                 ].compact
+    items =
+      summary_rows [
+                     previous_misconduct_reported_row,
+                     detailed_account_type_row,
+                     detailed_account_report_row
+                   ].compact
+
+    referral.submitted? ? remove_actions(items) : items
   end
 
   def previous_misconduct_reported_row

--- a/app/components/public_allegation_component.rb
+++ b/app/components/public_allegation_component.rb
@@ -1,15 +1,19 @@
 class PublicAllegationComponent < ViewComponent::Base
   include ActiveModel::Model
   include ReferralHelper
+  include ComponentHelper
 
   attr_accessor :referral
 
   def rows
-    summary_rows [
-                   allegation_details_format_row,
-                   allegation_details_description_row,
-                   allegation_details_considerations_row
-                 ].compact
+    items =
+      summary_rows [
+                     allegation_details_format_row,
+                     allegation_details_description_row,
+                     allegation_details_considerations_row
+                   ].compact
+
+    referral.submitted? ? remove_actions(items) : items
   end
 
   def allegation_details_format_row

--- a/app/components/what_happened_component.rb
+++ b/app/components/what_happened_component.rb
@@ -6,11 +6,14 @@ class WhatHappenedComponent < ViewComponent::Base
   attr_accessor :referral
 
   def rows
-    summary_rows [
-                   details_about_allegation_format_row,
-                   details_about_allegation_row,
-                   dbs_notified_row
-                 ].compact
+    items =
+      summary_rows [
+                     details_about_allegation_format_row,
+                     details_about_allegation_row,
+                     dbs_notified_row
+                   ].compact
+
+    referral.submitted? ? remove_actions(items) : items
   end
 
   private

--- a/spec/components/about_you_component_spec.rb
+++ b/spec/components/about_you_component_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe AboutYouComponent, type: :component do
   let(:user) { referral.user }
   let(:referrer) { referral.referrer }
   let(:row_labels) { component.rows.map { |row| row.dig(:key, :text) } }
+  let(:row_links) { component.rows.map { |row| row.dig(:actions, :href) } }
 
   before { render_inline(component) }
 
@@ -52,6 +53,14 @@ RSpec.describe AboutYouComponent, type: :component do
       expect(page).not_to have_css("dd", text: referrer.job_title)
       expect(page).not_to have_link "Change",
                 href: "/referrals/#{referral.id}/referrer/job-title/edit?return_to=%2F"
+    end
+  end
+
+  context "when referral is submitted" do
+    let(:referral) { create(:referral, :submitted) }
+
+    it "does not have any action links" do
+      expect(row_links.compact).to be_empty
     end
   end
 end

--- a/spec/components/contact_details_component_spec.rb
+++ b/spec/components/contact_details_component_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ContactDetailsComponent, type: :component do
 
   let(:referral) { create(:referral, :contact_details_employer) }
   let(:row_labels) { component.rows.map { |row| row.dig(:key, :text) } }
+  let(:row_links) { component.rows.map { |row| row.dig(:actions, :href) } }
 
   before { render_inline(component) }
 
@@ -99,6 +100,14 @@ RSpec.describe ContactDetailsComponent, type: :component do
     it "renders the home address not known row" do
       expect(page).to have_css("dt", text: "Do you know their home address?")
       expect(page).to have_css("dd", text: "No")
+    end
+  end
+
+  context "when referral is submitted" do
+    let(:referral) { create(:referral, :submitted) }
+
+    it "does not have any action links" do
+      expect(row_links.compact).to be_empty
     end
   end
 end

--- a/spec/components/evidence_component_spec.rb
+++ b/spec/components/evidence_component_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe EvidenceComponent, type: :component do
   subject(:component) { described_class.new(referral:) }
 
   let(:row_labels) { component.rows.map { |row| row.dig(:key, :text) } }
+  let(:row_links) { component.rows.map { |row| row.dig(:actions, :href) } }
 
   before { render_inline(component) }
 
@@ -36,6 +37,14 @@ RSpec.describe EvidenceComponent, type: :component do
       expect(page).to have_css("dd", text: "Yes")
       expect(page).to have_link "Change",
                 href: "/referrals/#{referral.id}/evidence/uploaded/edit?return_to=%2F"
+    end
+  end
+
+  context "when referral is submitted" do
+    let(:referral) { create(:referral, :submitted) }
+
+    it "does not have any action links" do
+      expect(row_links.compact).to be_empty
     end
   end
 end

--- a/spec/components/organisation_component_spec.rb
+++ b/spec/components/organisation_component_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe OrganisationComponent, type: :component do
   subject(:component) { described_class.new(referral:) }
 
+  let(:row_links) { component.rows.map { |row| row.dig(:actions, :href) } }
+
   let(:organisation) { referral.organisation }
 
   before { render_inline(component) }
@@ -21,6 +23,14 @@ RSpec.describe OrganisationComponent, type: :component do
 
       expect(page).to have_link "Change",
                 href: "/referrals/#{referral.id}/organisation/address/edit?return_to=%2F"
+    end
+  end
+
+  context "when referral is submitted" do
+    let(:referral) { create(:referral, :submitted) }
+
+    it "does not have any action links" do
+      expect(row_links.compact).to be_empty
     end
   end
 end

--- a/spec/components/personal_details_component_spec.rb
+++ b/spec/components/personal_details_component_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe PersonalDetailsComponent, type: :component do
   subject(:component) { described_class.new(referral:) }
 
-  let(:referral) { create(:referral, :employer_complete) }
+  let(:referral) { create(:referral, :employer, :personal_details_employer) }
 
   let(:row_labels) { component.rows.map { |row| row.dig(:key, :text) } }
   let(:row_values) { component.rows.map { |row| row.dig(:value, :text) }.map(&:strip) }
@@ -34,7 +34,7 @@ RSpec.describe PersonalDetailsComponent, type: :component do
   end
 
   context "when not known by other name" do
-    let(:referral) { create(:referral, :employer_complete, name_has_changed: "no") }
+    let(:referral) { create(:referral, :employer, name_has_changed: "no") }
 
     it "renders the known name row" do
       expect(row_labels[1]).to eq("Do you know them by any other name?")
@@ -50,9 +50,7 @@ RSpec.describe PersonalDetailsComponent, type: :component do
   end
 
   context "when known by other name" do
-    let(:referral) do
-      create(:referral, :employer_complete, name_has_changed: "yes", previous_name: "T")
-    end
+    let(:referral) { create(:referral, :employer, name_has_changed: "yes", previous_name: "T") }
 
     it "renders the known name row" do
       expect(row_labels[1]).to eq("Do you know them by any other name?")
@@ -73,12 +71,7 @@ RSpec.describe PersonalDetailsComponent, type: :component do
 
   context "when date of birth is known" do
     let(:referral) do
-      create(
-        :referral,
-        :contact_details_employer,
-        age_known: true,
-        date_of_birth: Date.new(1990, 1, 1)
-      )
+      create(:referral, :employer, age_known: true, date_of_birth: Date.new(1990, 1, 1))
     end
 
     it "renders the date of birth known row" do
@@ -99,7 +92,7 @@ RSpec.describe PersonalDetailsComponent, type: :component do
   end
 
   context "when date of birth is not known" do
-    let(:referral) { create(:referral, :contact_details_employer, age_known: false) }
+    let(:referral) { create(:referral, :employer, age_known: false) }
 
     it "renders the date of birth known row" do
       expect(row_labels[2]).to eq("Do you know their date of birth?")
@@ -115,7 +108,7 @@ RSpec.describe PersonalDetailsComponent, type: :component do
   end
 
   context "when trn is known" do
-    let(:referral) { create(:referral, :contact_details_employer, trn_known: true, trn: "4567814") }
+    let(:referral) { create(:referral, :employer, trn_known: true, trn: "4567814") }
 
     it "renders the trn known row" do
       expect(row_labels[4]).to eq("Do you know their teacher reference number (TRN)?")
@@ -135,7 +128,7 @@ RSpec.describe PersonalDetailsComponent, type: :component do
   end
 
   context "when trn is not known" do
-    let(:referral) { create(:referral, :contact_details_employer, trn_known: false) }
+    let(:referral) { create(:referral, :employer, trn_known: false) }
 
     it "renders the trn known row" do
       expect(row_labels[4]).to eq("Do you know their teacher reference number (TRN)?")
@@ -151,9 +144,7 @@ RSpec.describe PersonalDetailsComponent, type: :component do
   end
 
   context "when national insurance number is known" do
-    let(:referral) do
-      create(:referral, :contact_details_employer, ni_number_known: true, ni_number: "SC234568")
-    end
+    let(:referral) { create(:referral, :employer, ni_number_known: true, ni_number: "SC234568") }
 
     it "renders the national insurance number known row" do
       expect(row_labels[3]).to eq("Do you know their National Insurance number?")
@@ -173,7 +164,7 @@ RSpec.describe PersonalDetailsComponent, type: :component do
   end
 
   context "when national insurance number is not known" do
-    let(:referral) { create(:referral, :contact_details_employer, ni_number_known: false) }
+    let(:referral) { create(:referral, :employer, ni_number_known: false) }
 
     it "renders the national insurance number known row" do
       expect(row_labels[3]).to eq("Do you know their National Insurance number?")
@@ -195,10 +186,18 @@ RSpec.describe PersonalDetailsComponent, type: :component do
   end
 
   context "when the referral is a public one" do
-    let(:referral) { create(:referral, :public_complete) }
+    let(:referral) { create(:referral, :public) }
 
     it "renders a limited number of questions" do
       expect(row_labels).to eq(["Their name", "Do you know them by any other name?"])
+    end
+  end
+
+  context "when referral is submitted" do
+    let(:referral) { create(:referral, :submitted) }
+
+    it "does not have any action links" do
+      expect(row_links.compact).to be_empty
     end
   end
 end

--- a/spec/components/previous_misconduct_component_spec.rb
+++ b/spec/components/previous_misconduct_component_spec.rb
@@ -87,5 +87,13 @@ RSpec.describe PreviousMisconductComponent, type: :component do
         )
       end
     end
+
+    context "when referral is submitted" do
+      let(:referral) { create(:referral, :submitted) }
+
+      it "does not have any action links" do
+        expect(row_links.compact).to be_empty
+      end
+    end
   end
 end

--- a/spec/components/public_allegation_component_spec.rb
+++ b/spec/components/public_allegation_component_spec.rb
@@ -89,4 +89,23 @@ RSpec.describe PublicAllegationComponent, type: :component do
       )
     end
   end
+
+  context "when referral is submitted" do
+    let(:referral) do
+      create(
+        :referral,
+        :complete,
+        :submitted,
+        :public,
+        allegation_format:,
+        allegation_details:,
+        allegation_upload:,
+        allegation_consideration_details:
+      )
+    end
+
+    it "does not have any action links" do
+      expect(row_links.compact).to be_empty
+    end
+  end
 end

--- a/spec/components/what_happened_component_spec.rb
+++ b/spec/components/what_happened_component_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe WhatHappenedComponent, type: :component do
   subject(:component) { described_class.new(referral:) }
 
-  let(:referral) { create(:referral, :employer_complete) }
+  let(:referral) { create(:referral, :employer_complete, submitted_at: nil) }
 
   let(:row_labels) { component.rows.map { |row| row.dig(:key, :text) } }
   let(:row_values) { component.rows.map { |row| row.dig(:value, :text) }.map(&:strip) }
@@ -38,5 +38,13 @@ RSpec.describe WhatHappenedComponent, type: :component do
         "/referrals/#{referral.id}/allegation/dbs/edit?return_to=%2F"
       ]
     )
+  end
+
+  context "when referral is submitted" do
+    let(:referral) { create(:referral, :submitted) }
+
+    it "does not have any action links" do
+      expect(row_links.compact).to be_empty
+    end
   end
 end


### PR DESCRIPTION
### Context

Strip action links when the referral is submitted

### Changes proposed in this pull request

Change links should not be visible on referrals that have been submitted already.

![Screenshot 2023-04-06 at 13 21 02](https://user-images.githubusercontent.com/1955084/230377502-f6885876-ead6-45a7-9c50-ec178fd031ba.png)

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
