### PR TITLE
Fix NoMethodError: undefined method `phone' for nil:NilClass

### DIFF
--- a/app/forms/referrals/referrer/job_title_form.rb
+++ b/app/forms/referrals/referrer/job_title_form.rb
@@ -17,7 +17,11 @@ module Referrals
         referrer.update(job_title:)
       end
 
-      delegate :referrer, to: :referral, allow_nil: true
+      private
+
+      def referrer
+        @referrer ||= referral&.referrer || referral&.build_referrer
+      end
     end
   end
 end

--- a/app/forms/referrals/referrer/phone_form.rb
+++ b/app/forms/referrals/referrer/phone_form.rb
@@ -22,7 +22,11 @@ module Referrals
         referrer.update(phone:)
       end
 
-      delegate :referrer, to: :referral, allow_nil: true
+      private
+
+      def referrer
+        @referrer ||= referral&.referrer || referral&.build_referrer
+      end
     end
   end
 end


### PR DESCRIPTION
When trying to add a phone number or job title directly, before adding a name, the page will crash because the referrer object is nil.

Fixes: https://dfe-teacher-services.sentry.io/issues/4034073291/events/a35fb96fc3334ee48ca1d88f007c776e/?project=4504136292237312

https://trello.com/c/q2qhHZnj/1353-updating-the-phone-number-job-title-without-adding-a-name-first-throws-a-nomethoderror-error