### PR TITLE
Fix referral with reminders deletion

### DIFF
--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -13,7 +13,7 @@ class Referral < ApplicationRecord
            -> { order(:created_at) },
            class_name: "ReferralEvidence",
            dependent: :destroy
-  has_many :reminder_emails
+  has_many :reminder_emails, dependent: :destroy
 
   scope :employer,
         -> { joins(:eligibility_check).where(eligibility_check: { reporting_as: :employer }) }


### PR DESCRIPTION
Deleting a referral would raise a foreign key constraint error if the
referral had reminders.

Fixes: https://dfe-teacher-services.sentry.io/issues/4065334184/?project=4504136292237312