### PR TITLE
Make path argument optional for summary rows

### DIFF
--- a/app/components/about_you_component.rb
+++ b/app/components/about_you_component.rb
@@ -20,7 +20,7 @@ class AboutYouComponent < ViewComponent::Base
   end
 
   def email_row
-    { label: "Your email address", value: user.email, path: nil }
+    { label: "Your email address", value: user.email }
   end
 
   def job_title_row

--- a/app/components/manage_interface/allegation_details_component.rb
+++ b/app/components/manage_interface/allegation_details_component.rb
@@ -22,15 +22,11 @@ module ManageInterface
     private
 
     def allegation_details_format_row
-      {
-        label: "How do you want to give details about the allegation?",
-        value: details_format,
-        path: nil
-      }
+      { label: "How do you want to give details about the allegation?", value: details_format }
     end
 
     def allegation_details_row
-      { label: "Allegation details", value: allegation_details(referral), path: nil }
+      { label: "Allegation details", value: allegation_details(referral) }
     end
 
     def complain_consideration_row
@@ -38,8 +34,7 @@ module ManageInterface
 
       {
         label: "Details about how this complaint has been considered",
-        value: simple_format(referral.allegation_consideration_details),
-        path: nil
+        value: simple_format(referral.allegation_consideration_details)
       }
     end
 
@@ -48,8 +43,7 @@ module ManageInterface
 
       {
         label: "Have you told the Disclosure and Barring Service (DBS)?",
-        value: referral.dbs_notified,
-        path: nil
+        value: referral.dbs_notified
       }
     end
 

--- a/app/components/manage_interface/evidence_component.rb
+++ b/app/components/manage_interface/evidence_component.rb
@@ -12,7 +12,7 @@ module ManageInterface
     private
 
     def evidence_row
-      { label: "Is there anything to upload?", value: "No", path: nil }
+      { label: "Is there anything to upload?", value: "No" }
     end
   end
 end

--- a/app/components/manage_interface/other_employment_details_component.rb
+++ b/app/components/manage_interface/other_employment_details_component.rb
@@ -17,7 +17,7 @@ module ManageInterface
     private
 
     def organisation_row
-      { label: "Organisation", value: teaching_address(referral), path: nil }
+      { label: "Organisation", value: teaching_address(referral) }
     end
   end
 end

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -114,7 +114,7 @@ module ReferralHelper
     rows.map { |row| summary_row(**row) }
   end
 
-  def summary_row(path:, label:, value:, visually_hidden_text: nil)
+  def summary_row(label:, value:, path: nil, visually_hidden_text: nil)
     {
       actions: summary_row_actions(path:, label:, visually_hidden_text:),
       key: {
@@ -126,7 +126,7 @@ module ReferralHelper
     }
   end
 
-  def summary_row_actions(path:, label:, visually_hidden_text: nil)
+  def summary_row_actions(label:, path: nil, visually_hidden_text: nil)
     return {} unless path
 
     visually_hidden_text = label.downcase if visually_hidden_text.blank?

--- a/spec/helpers/referral_helper_spec.rb
+++ b/spec/helpers/referral_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ReferralHelper, type: :helper do
     end
 
     context "when called without a path" do
-      let(:row) { { path: nil, label: "label", value: "value" } }
+      let(:row) { { label: "label", value: "value" } }
 
       it "returns a hash with the correct keys" do
         expect(helper_method.keys).to eq %i[actions key value]


### PR DESCRIPTION
The manage interface summary rows don't require a path, so by making the argument optional we avoid lots of nil values being passed in.