### PR TITLE
[1354] Download eligibility checks CSV

### DIFF
--- a/app/controllers/support_interface/eligibility_checks_controller.rb
+++ b/app/controllers/support_interface/eligibility_checks_controller.rb
@@ -1,7 +1,73 @@
+require "csv"
 module SupportInterface
   class EligibilityChecksController < SupportInterfaceController
     def index
-      @eligibility_checks = EligibilityCheck.order(updated_at: :desc).limit(100)
+      respond_to do |format|
+        format.html { @eligibility_checks = EligibilityCheck.order(updated_at: :desc).limit(100) }
+        format.csv { stream_csv }
+      end
+    end
+
+    private
+
+    def stream_csv
+      write_response_headers
+      write_csv_header_row
+      write_csv_rows
+    end
+
+    def write_response_headers
+      response.headers.delete("Content-Length")
+      response.headers["Cache-Control"] = "no-cache"
+      response.headers["Content-Type"] = "text/csv"
+      response.headers[
+        "Content-Disposition"
+      ] = "attachment; filename=eligibility-checks-#{Time.zone.now.to_i}.csv"
+    end
+
+    def write_csv_header_row
+      response.stream.write(
+        CSV.generate_line(
+          %w[
+            id
+            reporting_as
+            complained
+            is_teacher
+            teaching_in_england
+            serious_misconduct
+            unsupervised_teaching
+            eligibility_check_started
+            eligibility_check_last_updated
+            draft_referral_created
+            referral_submitted
+          ]
+        )
+      )
+    end
+
+    def write_csv_rows
+      EligibilityCheck
+        .includes(:referral)
+        .order(:updated_at)
+        .find_each { |check| response.stream.write(csv_row(check)) }
+    end
+
+    def csv_row(check)
+      CSV.generate_line(
+        [
+          check.id,
+          check.reporting_as,
+          (check.complained? ? "yes" : "no"),
+          check.is_teacher,
+          check.teaching_in_england,
+          check.serious_misconduct,
+          check.unsupervised_teaching,
+          check.updated_at,
+          check.created_at,
+          check.referral&.created_at,
+          check.referral&.submitted_at
+        ]
+      )
     end
   end
 end

--- a/app/views/support_interface/eligibility_checks/index.html.erb
+++ b/app/views/support_interface/eligibility_checks/index.html.erb
@@ -1,11 +1,15 @@
 <% content_for :page_title, 'Eligibility Checks' %>
 
 <h1 class="govuk-heading-l">
-  Eligibility Checks
+  Eligibility checks
   <span class="govuk-caption-l">
     Ordered by last updated, showing <%= "#{[100, EligibilityCheck.count].min} of #{EligibilityCheck.count}" %> total
   </span>
 </h1>
+
+<p>
+  <%= govuk_link_to("Download CSV", support_interface_eligibility_checks_path(format: :csv)) %>
+</p>
 
 <% @eligibility_checks.each do |eligibility_check| %>
   <h2 class="govuk-heading-m">Eligibility Check #<%= eligibility_check.id %></h2>

--- a/spec/system/support/view_eligibility_checks_spec.rb
+++ b/spec/system/support/view_eligibility_checks_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.feature "View eligibility checks" do
+  include CommonSteps
+
+  scenario "visiting the eligibility checks page", type: :system do
+    given_the_service_is_open
+
+    when_i_login_as_a_case_worker_with_support_permissions_only
+    and_i_visit_the_eligibility_checks_page
+    then_i_see_the_eligibility_checks
+
+    when_i_click_the_download_csv_link
+    there_are_no_errors
+  end
+
+  private
+
+  def and_i_visit_the_eligibility_checks_page
+    visit "/support/eligibility-checks"
+  end
+
+  def then_i_see_the_eligibility_checks
+    expect(page).to have_content "Eligibility checks"
+  end
+
+  def when_i_click_the_download_csv_link
+    click_link "Download CSV"
+  end
+
+  alias_method :there_are_no_errors, :then_i_see_the_eligibility_checks
+end


### PR DESCRIPTION
### Context

We need to monitor the effect of some changes to the eligibility checker but don't have the data in an easily accessible place currently.

### Changes proposed in this pull request

* Add 'Download CSV' link to the eligibility checks index page

Stream the CSV as this is being generated from the transactional DB. As this data grows this page will start to timeout if we generate the whole CSV before responding.

Download link:

<img width="1076" alt="Screenshot 2023-04-13 at 17 02 29" src="https://user-images.githubusercontent.com/5216/231818486-441aa965-04b2-4554-b5e1-d7767c752405.png">

Example CSV format:

<img width="1152" alt="Screenshot 2023-04-13 at 17 03 17" src="https://user-images.githubusercontent.com/5216/231818640-c8671f88-2be1-41f6-b091-3a16d5ccf306.png">

