### PR TITLE
Ignore Simplecov when running smoke tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,14 +16,16 @@
 
 require "simplecov"
 
-SimpleCov.start "rails" do
-  minimum_coverage 90
+if ARGV.grep(/smoke_spec\.rb/).empty?
+  SimpleCov.start "rails" do
+    minimum_coverage 90
 
-  add_filter "db/migrate"
-  add_group "Components", "app/components"
+    add_filter "db/migrate"
+    add_group "Components", "app/components"
 
-  enable_coverage :branch
-  primary_coverage :branch
+    enable_coverage :branch
+    primary_coverage :branch
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
### Context

Ignore Simplecov when running smoke tests

Otherwise it does block the deploys because the smoke tests produce 0 test coverage.