### PR TITLE
Refactor eligibility checks page

### DIFF
--- a/app/components/support_interface/eligibility_check_component.html.erb
+++ b/app/components/support_interface/eligibility_check_component.html.erb
@@ -1,0 +1,6 @@
+<div class="app-list__item">
+  <h2 class="govuk-heading-m">
+    <%= title %>
+  </h2>
+  <%= govuk_summary_list(actions: false, classes: ["govuk-summary-list--no-border"], rows:) %>
+</div>

--- a/app/components/support_interface/eligibility_check_component.rb
+++ b/app/components/support_interface/eligibility_check_component.rb
@@ -1,0 +1,64 @@
+module SupportInterface
+  class EligibilityCheckComponent < ViewComponent::Base
+    include ActiveModel::Model
+    include ReferralHelper
+    include ComponentHelper
+
+    attr_accessor :eligibility_check
+
+    def rows
+      items =
+        summary_rows [
+                       date_started_row,
+                       date_updated_row,
+                       reporting_as_row,
+                       made_an_informal_complaint_row,
+                       teaching_in_england_row,
+                       serious_misconduct_row
+                     ].compact
+      remove_actions(items)
+    end
+
+    def title
+      "Eligibility check ##{eligibility_check.id}"
+    end
+
+    private
+
+    def date_started_row
+      { label: "Date started", value: eligibility_check.created_at.to_fs(:day_month_year_time) }
+    end
+
+    def date_updated_row
+      { label: "Date updated", value: eligibility_check.updated_at.to_fs(:day_month_year_time) }
+    end
+
+    def reporting_as_row
+      {
+        label: "Select if you’re making a referral as an employer or member of public",
+        value: eligibility_check.reporting_as&.titleize
+      }
+    end
+
+    def made_an_informal_complaint_row
+      return if eligibility_check.reporting_as_employer?
+
+      { label: "Made an informal complaint", value: eligibility_check.complained? ? "Yes" : "No" }
+    end
+
+    def teaching_in_england_row
+      {
+        label:
+          "Select yes if they were employed in England at the time the alleged misconduct took place",
+        value: eligibility_check.teaching_in_england&.titleize
+      }
+    end
+
+    def serious_misconduct_row
+      {
+        label: "Select yes if the allegation involves serious misconduct",
+        value: eligibility_check.serious_misconduct&.titleize
+      }
+    end
+  end
+end

--- a/app/views/support_interface/eligibility_checks/index.html.erb
+++ b/app/views/support_interface/eligibility_checks/index.html.erb
@@ -1,51 +1,19 @@
 <% content_for :page_title, 'Eligibility Checks' %>
 
-<h1 class="govuk-heading-l">
-  Eligibility checks
-  <span class="govuk-caption-l">
-    Ordered by last updated, showing <%= "#{[100, EligibilityCheck.count].min} of #{EligibilityCheck.count}" %> total
-  </span>
-</h1>
-
-<p>
-  <%= govuk_link_to("Download CSV", support_interface_eligibility_checks_path(format: :csv)) %>
-</p>
-
-<% @eligibility_checks.each do |eligibility_check| %>
-  <h2 class="govuk-heading-m">Eligibility Check #<%= eligibility_check.id %></h2>
-  <%= govuk_summary_list do |summary_list|
-    summary_list.row do |row|
-      row.key(text: 'Created at')
-      row.value(text: eligibility_check.created_at)
-    end
-
-    summary_list.row do |row|
-      row.key(text: 'Updated at')
-      row.value(text: eligibility_check.updated_at)
-    end
-
-    summary_list.row do |row|
-      row.key(text: 'Reporting as')
-      row.value(text: eligibility_check.reporting_as&.titleize)
-    end
-
-    unless eligibility_check.reporting_as_employer?
-      summary_list.row do |row|
-        row.key(text: 'Made an Informal Complaint')
-        row.value(text: eligibility_check.complained? ? 'Yes' : 'No')
-      end
-    end
-
-    summary_list.row do |row|
-      row.key(text: 'Teaching in England')
-      row.value(text: eligibility_check.teaching_in_england&.titleize)
-    end
-
-    summary_list.row do |row|
-      row.key(text: 'Serious misconduct')
-      row.value(text: eligibility_check.serious_misconduct&.titleize)
-    end
-  end %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">
+      Eligibility checks (<%= EligibilityCheck.count %>)
+    </h1>
+    <p>
+      <%= govuk_link_to("Download CSV", support_interface_eligibility_checks_path(format: :csv)) %>
+    </p>
+    <div class="app-list">
+      <% @eligibility_checks.each do |eligibility_check| %>
+        <%= render SupportInterface::EligibilityCheckComponent.new(eligibility_check:) %>
+      <% end %>
+    </div>
+  </div>
+</div>
 
 <%= govuk_pagination(pagy: @pagy) %>

--- a/spec/components/support_interface/eligibility_check_component_spec.rb
+++ b/spec/components/support_interface/eligibility_check_component_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe SupportInterface::EligibilityCheckComponent, type: :component do
+  subject(:component) { described_class.new(eligibility_check:) }
+
+  let(:row_labels) { component.rows.map { |row| row.dig(:key, :text) } }
+  let(:row_values) { component.rows.map { |row| row.dig(:value, :text) }.map(&:strip) }
+  let(:eligibility_check) do
+    create(
+      :eligibility_check,
+      :complete,
+      created_at: Time.zone.local(2022, 11, 22, 12, 0, 0),
+      updated_at: Time.zone.local(2022, 11, 23, 13, 1, 0)
+    )
+  end
+
+  before { render_inline(component) }
+
+  context "with an employer referral" do
+    it "renders the correct labels" do
+      expect(row_labels).to eq(
+        [
+          "Date started",
+          "Date updated",
+          "Select if you’re making a referral as an employer or member of public",
+          "Select yes if they were employed in England at the time the alleged misconduct took place",
+          "Select yes if the allegation involves serious misconduct"
+        ]
+      )
+    end
+
+    it "renders the correct values" do
+      expect(row_values).to eq(
+        ["22 November 2022 at 12:00 pm", "23 November 2022 at 1:01 pm", "Employer", "Yes", "Yes"]
+      )
+    end
+  end
+
+  context "with a public referral" do
+    before do
+      travel_to Time.zone.local(2022, 11, 23, 13, 13, 0)
+      eligibility_check.update!(reporting_as: "public")
+    end
+
+    it "renders the correct labels" do
+      expect(row_labels).to eq(
+        [
+          "Date started",
+          "Date updated",
+          "Select if you’re making a referral as an employer or member of public",
+          "Made an informal complaint",
+          "Select yes if they were employed in England at the time the alleged misconduct took place",
+          "Select yes if the allegation involves serious misconduct"
+        ]
+      )
+    end
+
+    it "renders the correct values" do
+      expect(row_values).to eq(
+        [
+          "22 November 2022 at 12:00 pm",
+          "23 November 2022 at 1:13 pm",
+          "Public",
+          "No",
+          "Yes",
+          "Yes"
+        ]
+      )
+    end
+  end
+end

--- a/spec/system/support/staff_user_with_permissions_can_visit_the_support_interface_spec.rb
+++ b/spec/system/support/staff_user_with_permissions_can_visit_the_support_interface_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe "Support" do
   def then_i_see_the_eligibility_checks_page
     expect(page).to have_current_path(support_interface_eligibility_checks_path)
     expect(page).to have_title("Eligibility Checks - Refer serious misconduct by a teacher")
-    expect(page).to have_content("Eligibility Checks")
-    expect(page).to have_content("1 of 1")
+    expect(page).to have_content("Eligibility checks (1)")
   end
 
   def then_i_see_the_feature_page


### PR DESCRIPTION
Update the support eligibility checks page as follows:

- use the styles from the referrals list (two-thirds-on-desktop)
- All dates should be 17 June 2023 at 1:55pm for example
- Created at => Date started
- Updated at => Date updated
- Reporting as => [Use the legend of the question]
- Teaching in England => [Use the legend of the question]
- Serious misconduct => [Use the legend of the question]
- Lowercase “Check” on h1 and h2s
- “Ordered by last updated, showing 72 of 72 total” - remove line

https://trello.com/c/MFHEJADY/1348-eligibility-checks-page