### PR TITLE
Refactor manage referrals

### DIFF
--- a/app/components/manage_interface/referral_component.html.erb
+++ b/app/components/manage_interface/referral_component.html.erb
@@ -1,0 +1,6 @@
+<div class="app-list__item">
+  <h2 class="govuk-heading-m">
+    <%= govuk_link_to title, manage_interface_referral_path(referral.id) %>
+  </h2>
+  <%= govuk_summary_list(actions: false, classes: ["govuk-summary-list--no-border"], rows:) %>
+</div>

--- a/app/components/manage_interface/referral_component.rb
+++ b/app/components/manage_interface/referral_component.rb
@@ -1,0 +1,28 @@
+module ManageInterface
+  class ReferralComponent < ViewComponent::Base
+    include ActiveModel::Model
+    include ReferralHelper
+    include ComponentHelper
+
+    attr_accessor :referral
+
+    def rows
+      items = summary_rows [submitted_at, referrer_row].compact
+      remove_actions(items)
+    end
+
+    def title
+      "#{referral.first_name} #{referral.last_name}"
+    end
+
+    private
+
+    def submitted_at
+      { label: "Referral date", value: referral.submitted_at.to_fs(:day_month_year_time) }
+    end
+
+    def referrer_row
+      { label: "Referrer", value: referral.referrer_name }
+    end
+  end
+end

--- a/app/views/manage_interface/referrals/index.html.erb
+++ b/app/views/manage_interface/referrals/index.html.erb
@@ -5,19 +5,7 @@
     <h1 class="govuk-heading-l">Referrals (<%= @referrals_count %>)</h1>
     <div class="app-list">
       <% @referrals.each do |referral| %>
-        <div class="app-list__item">
-          <h2 class="govuk-heading-m">
-            <%= govuk_link_to "#{referral.first_name} #{referral.last_name}", manage_interface_referral_path(referral.id) %>
-          </h2>
-
-          <%= govuk_summary_list(
-            classes: ["govuk-summary-list--no-border"],
-            rows: [
-              { key: { text: "Referral date" }, value: { text: referral.submitted_at.to_fs(:day_month_year_time)} },
-              { key: { text: "Referrer" }, value: { text: referral.referrer_name } }
-            ])
-          %>
-        </div>
+        <%= render ManageInterface::ReferralComponent.new(referral:) %>
       <% end %>
     </div>
   </div>

--- a/spec/components/manage_interface/referral_component_spec.rb
+++ b/spec/components/manage_interface/referral_component_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ManageInterface::ReferralComponent, type: :component do
+  subject(:component) { described_class.new(referral:) }
+
+  let(:row_labels) { component.rows.map { |row| row.dig(:key, :text) } }
+  let(:row_values) { component.rows.map { |row| row.dig(:value, :text) }.map(&:strip) }
+  let(:referral) do
+    create(
+      :referral,
+      :complete,
+      :personal_details_employer,
+      submitted_at: Time.zone.local(2022, 11, 22, 12, 0, 0)
+    )
+  end
+
+  before { render_inline(component) }
+
+  it "renders the correct labels" do
+    expect(row_labels).to eq(["Referral date", "Referrer"])
+  end
+
+  it "renders the correct values" do
+    expect(row_values).to eq(["22 November 2022 at 12:00 pm", "Jane Smith"])
+  end
+
+  describe "#title" do
+    it "returns the correct title" do
+      expect(component.title).to eq("John Smith")
+    end
+  end
+end


### PR DESCRIPTION
Moved the referral list from the manage interface into componnents to keep it consistent with the changes implemented in https://github.com/DFE-Digital/refer-serious-misconduct/pull/675