### PR TITLE
Hide "Not known" rows when the previous answer is "No"

### DIFF
--- a/app/components/contact_details_component.rb
+++ b/app/components/contact_details_component.rb
@@ -10,12 +10,12 @@ class ContactDetailsComponent < ViewComponent::Base
     items =
       summary_rows [
                      email_known_row,
-                     email_row,
+                     referral.email_known? && email_row,
                      phone_number_known_row,
-                     phone_number_row,
+                     referral.phone_known? && phone_number_row,
                      address_known_row,
-                     address_row
-                   ].compact
+                     referral.address_known? && address_row
+                   ].compact_blank
 
     referral.submitted? ? remove_actions(items) : items
   end
@@ -32,11 +32,7 @@ class ContactDetailsComponent < ViewComponent::Base
   end
 
   def email_row
-    {
-      label: "Email address",
-      value: referral.email_known ? referral.email_address : "Not known",
-      path: :contact_details_email
-    }
+    { label: "Email address", value: referral.email_address, path: :contact_details_email }
   end
 
   def phone_number_known_row

--- a/app/components/manage_interface/employment_details_component.rb
+++ b/app/components/manage_interface/employment_details_component.rb
@@ -25,7 +25,7 @@ module ManageInterface
     private
 
     def job_title_row
-      { label: "Job title", value: referral.job_title || "Not known" }
+      { label: "Job title", value: referral.job_title }
     end
 
     def details_about_main_duties_row

--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -33,11 +33,7 @@ class PersonalDetailsComponent < ViewComponent::Base
   end
 
   def name_row
-    {
-      label: "Their name",
-      value: "#{referral.first_name} #{referral.last_name}",
-      path: :personal_details_name
-    }
+    { label: "Their name", value: full_name, path: :personal_details_name }
   end
 
   def other_name_row
@@ -123,5 +119,13 @@ class PersonalDetailsComponent < ViewComponent::Base
       path: :personal_details_ni_number,
       visually_hidden_text: "National Insurance number"
     }
+  end
+
+  private
+
+  def full_name
+    return unless referral.first_name.present? && referral.last_name.present?
+
+    [referral.first_name, referral.last_name].join(" ")
   end
 end

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -50,6 +50,8 @@ module AddressHelper
   private
 
   def address_fields_to_html(address)
+    return unless address.any?
+
     address.compact_blank.join("<br />").html_safe
   end
 end

--- a/spec/components/contact_details_component_spec.rb
+++ b/spec/components/contact_details_component_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe ContactDetailsComponent, type: :component do
       expect(page).to have_link "Change",
                 href: "/referrals/#{referral.id}/contact-details/email/edit?return_to=%2F"
     end
+
+    it "does not render the referral email row" do
+      expect(page).not_to have_css("dt", text: "Email address")
+    end
   end
 
   context "when the phone number is known" do
@@ -74,6 +78,10 @@ RSpec.describe ContactDetailsComponent, type: :component do
       expect(page).to have_link "Change",
                 href: "/referrals/#{referral.id}/contact-details/telephone/edit?return_to=%2F"
     end
+
+    it "does not render the referral phone number row" do
+      expect(page).not_to have_css("dt", text: "Phone number")
+    end
   end
 
   context "when the home address is known" do
@@ -100,6 +108,10 @@ RSpec.describe ContactDetailsComponent, type: :component do
     it "renders the home address not known row" do
       expect(page).to have_css("dt", text: "Do you know their home address?")
       expect(page).to have_css("dd", text: "No")
+    end
+
+    it "does not render the home address row" do
+      expect(page).not_to have_css("dt", text: "Home address")
     end
   end
 


### PR DESCRIPTION
They were showing up as "Not known" or "Not answered" when the previous answer was "No". This change makes the referral forms consistent with the manage interface.

Before:
<img width="665" alt="Screenshot 2023-04-24 at 18 03 33" src="https://user-images.githubusercontent.com/1636476/234067126-37ae92c5-3ade-463d-89de-a1e5f35677d3.png">

After:
<img width="736" alt="Screenshot 2023-04-24 at 18 03 16" src="https://user-images.githubusercontent.com/1636476/234067150-b555ae28-e1a8-40a4-b2da-22d8417060bc.png">

I also updated the "Their name" row because it needs to be `nil` to show a "Not answered" row. If the name was missing the interpolation would return an empty string.

Before:
<img width="751" alt="Screenshot 2023-04-24 at 18 05 38" src="https://user-images.githubusercontent.com/1636476/234067171-549294e8-f3e0-4a08-8f2d-e76333bc50fd.png">

After:
<img width="692" alt="Screenshot 2023-04-24 at 18 04 38" src="https://user-images.githubusercontent.com/1636476/234067195-2d38b33a-76e2-40ab-9675-e1aba12853de.png">
