### PR TITLE
Remove log file size limiter and fix typos

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,7 +74,4 @@ Rails.application.configure do
           end
         end
     )
-
-  # Limit logs to 50MB
-  config.logger = ActiveSupport::Logger.new(config.paths["log"].first, 1, 50.megabytes)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,7 +55,4 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_options = { from: "mail@example.com" }
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
-
-  # Limit logs to 50MB
-  config.logger = ActiveSupport::Logger.new(config.paths["log"].first, 1, 50.megabytes)
 end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -16,7 +16,7 @@ class LogStashFormatter < SemanticLogger::Formatters::Raw
   # Place a more readable version of the exception into the message field.
   def format_exception
     exception_message = hash.dig(:exception, :message)
-    hash[:message] = "Exception occured: #{exception_message}" if exception_message.present?
+    hash[:message] = "Exception occurred: #{exception_message}" if exception_message.present?
   end
 
   def format_stacktrace

--- a/spec/logs/formatters/log_stash_formatter_spec.rb
+++ b/spec/logs/formatters/log_stash_formatter_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe LogStashFormatter do
       name: "Rails",
       exception: {
         name: "ActionController::RoutingError",
-        message: "No route matches [GET] \"/users/referralsss/15\"",
+        message: "No route matches [GET] \"/users/referrals/15\"",
         stack_trace: [
           "stack trace line 1",
           "stack trace line 2",
@@ -82,7 +82,7 @@ RSpec.describe LogStashFormatter do
         formatter.format_exception
 
         expect(formatter.hash[:message]).to eq(
-          'Exception occured: No route matches [GET] "/users/referralsss/15"'
+          'Exception occurred: No route matches [GET] "/users/referrals/15"'
         )
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe LogStashFormatter do
       expect(formatter.hash[:exception]).to eq(
         {
           name: "ActionController::RoutingError",
-          message: "No route matches [GET] \"/users/referralsss/15\""
+          message: "No route matches [GET] \"/users/referrals/15\""
         }
       )
 


### PR DESCRIPTION
I noticed that the `test.log` on my local was over 800Mb. I looked into it as I knew I added a 50Mb limit. It seems that adding `rails_semantic_logger` will not use the environment setting anymore. I couldn't find a solution nor a setting in the official documentation https://logger.rocketjob.io/rails. In the specs the gem is only used for testing the `LogStashFormatter`. This is a mild annoyance as every test suite run adds another 10-15Mb to the log file.

I removed it for development as well as the log filesize is tiny in comparison, and Rails 7.1 should have a new setting `log_file_size ` set to 100Mb by default. https://github.com/rails/rails/pull/44888

I also fixed some random typos.