### PR TITLE
Update dfe-analytics to v1.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "bootsnap", require: false
 gem "cssbundling-rails"
 gem "devise"
 gem "devise_invitable"
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.9.0"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.8.1"
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 gem "govuk_feature_flags",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: fb72ceb04923ed28313c1c0ab053b95dccd772d0
-  tag: v1.9.0
+  revision: 528b82c6f694d3c23b3b23882a20124a20e1c756
+  tag: v1.8.1
   specs:
-    dfe-analytics (1.9.0)
+    dfe-analytics (1.8.1)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 


### PR DESCRIPTION
The v.1.9.0 tag was deleted from the repo because it was replaced with a minor version bump. Dependabot didn't pick this up and so I'm manually upgrading it. https://github.com/DFE-Digital/dfe-analytics/pull/71