### PR TITLE
Update pg gem to 1.5.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,7 +303,7 @@ GEM
     parallel (1.22.1)
     parser (3.2.1.0)
       ast (~> 2.4.1)
-    pg (1.5.2)
+    pg (1.5.3)
     prettier_print (1.2.1)
     propshaft (0.7.0)
       actionpack (>= 7.0.0)


### PR DESCRIPTION
This fixes the `PG::Coder.new(hash) is deprecated` errors.