### PR TITLE
Remove unnecessary remove_actions

### DIFF
--- a/app/components/manage_interface/referral_component.rb
+++ b/app/components/manage_interface/referral_component.rb
@@ -5,8 +5,7 @@ module ManageInterface
     include ComponentHelper
 
     def rows
-      items = summary_rows [submitted_at, referrer_row].compact
-      remove_actions(items)
+      summary_rows [submitted_at, referrer_row].compact
     end
 
     def title

--- a/app/components/support_interface/eligibility_check_component.rb
+++ b/app/components/support_interface/eligibility_check_component.rb
@@ -7,16 +7,14 @@ module SupportInterface
     attr_accessor :eligibility_check
 
     def rows
-      items =
-        summary_rows [
-                       date_started_row,
-                       date_updated_row,
-                       reporting_as_row,
-                       made_an_informal_complaint_row,
-                       teaching_in_england_row,
-                       serious_misconduct_row
-                     ].compact
-      remove_actions(items)
+      summary_rows [
+                     date_started_row,
+                     date_updated_row,
+                     reporting_as_row,
+                     made_an_informal_complaint_row,
+                     teaching_in_england_row,
+                     serious_misconduct_row
+                   ].compact
     end
 
     def title

--- a/app/helpers/component_helper.rb
+++ b/app/helpers/component_helper.rb
@@ -3,10 +3,6 @@ module ComponentHelper
 
   included { attr_accessor :referral, :user, :referral_form_invalid }
 
-  def remove_actions(items)
-    items.map { |item| item.tap { |i| i.delete(:actions) } }
-  end
-
   def editable
     !referral.submitted?
   end


### PR DESCRIPTION
Since the update to govuk-components v4 there is no need to remove the actions manually as the `actions: false` option is now working as expected.