### PR TITLE
Fix back links on the eligibility pages

### DIFF
--- a/app/controllers/concerns/enforce_question_order.rb
+++ b/app/controllers/concerns/enforce_question_order.rb
@@ -66,6 +66,10 @@ module EnforceQuestionOrder
     questions[(requested_question_index + 1)..].find { |q| q[:needs_answer] }
   end
 
+  def previous_question
+    questions[..(requested_question_index - 1)].reverse.find { |q| q[:needs_answer] }
+  end
+
   def referral_type_answered?
     !eligibility_check.reporting_as.nil?
   end

--- a/app/controllers/eligibility_screener_controller.rb
+++ b/app/controllers/eligibility_screener_controller.rb
@@ -4,6 +4,11 @@ class EligibilityScreenerController < ApplicationController
 
   before_action { redirect_if_feature_flag_inactive(:eligibility_screener) }
 
+  def previous_question_path
+    previous_question&.dig(:path) || start_path
+  end
+  helper_method :previous_question_path
+
   private
 
   # Eligibility check is saved in the form objects

--- a/app/views/eligibility_screener/have_complained/new.html.erb
+++ b/app/views/eligibility_screener/have_complained/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @have_complained_form.errors.any?}Have you already made a complaint to the school, school governors or your local council?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, previous_question_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/eligibility_screener/is_teacher/new.html.erb
+++ b/app/views/eligibility_screener/is_teacher/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @is_teacher_form.errors.any?}Who the allegation is about" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, previous_question_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/eligibility_screener/serious_misconduct/new.html.erb
+++ b/app/views/eligibility_screener/serious_misconduct/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @serious_misconduct_form.errors.any?}Check that your allegation involves serious misconduct" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, previous_question_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/eligibility_screener/teaching_in_england/new.html.erb
+++ b/app/views/eligibility_screener/teaching_in_england/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @teaching_in_england_form.errors.any?}Were they employed in England at the time the alleged misconduct took place?" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, previous_question_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/eligibility_screener/unsupervised_teaching/new.html.erb
+++ b/app/views/eligibility_screener/unsupervised_teaching/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @unsupervised_teaching_form.errors.any?}You can refer someone who does unsupervised teaching work" %>
-<% content_for :back_link_url, url_for(:back) %>
+<% content_for :back_link_url, previous_question_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
+++ b/spec/system/screener/user_completes_eligibility_screener_as_member_of_public_spec.rb
@@ -27,7 +27,6 @@ RSpec.feature "Eligibility screener", type: :system do
     then_i_see_the_is_a_teacher_page
 
     when_i_go_back
-    when_i_go_back
     when_i_choose_yes_i_have_complained
     when_i_press_continue
     then_i_see_the_is_a_teacher_page


### PR DESCRIPTION
The back links were using the `url_for(:back)` method which was causing the back link to go back to the previous page in the browser history rather than the previous page in the eligibility flow.