### PR TITLE
Use CustomAttrs for eligibility forms

### DIFF
--- a/app/controllers/eligibility_screener/is_teacher_controller.rb
+++ b/app/controllers/eligibility_screener/is_teacher_controller.rb
@@ -1,7 +1,7 @@
 module EligibilityScreener
   class IsTeacherController < EligibilityScreenerController
     def new
-      @is_teacher_form = EligibilityScreener::IsTeacherForm.new
+      @is_teacher_form = EligibilityScreener::IsTeacherForm.new(eligibility_check:)
     end
 
     def create

--- a/app/controllers/eligibility_screener/unsupervised_teaching_controller.rb
+++ b/app/controllers/eligibility_screener/unsupervised_teaching_controller.rb
@@ -1,7 +1,8 @@
 module EligibilityScreener
   class UnsupervisedTeachingController < EligibilityScreenerController
     def new
-      @unsupervised_teaching_form = EligibilityScreener::UnsupervisedTeachingForm.new
+      @unsupervised_teaching_form =
+        EligibilityScreener::UnsupervisedTeachingForm.new(eligibility_check:)
     end
 
     def create

--- a/app/forms/eligibility_screener/have_complained_form.rb
+++ b/app/forms/eligibility_screener/have_complained_form.rb
@@ -1,16 +1,8 @@
 module EligibilityScreener
-  class HaveComplainedForm
-    include ActiveModel::Model
+  class HaveComplainedForm < EligibilityScreenerForm
+    attr_eligibility_check :complained
 
-    attr_accessor :eligibility_check
-    attr_reader :complained
-
-    validates :eligibility_check, presence: true
     validates :complained, inclusion: { in: [true, false] }
-
-    def complained=(value)
-      @complained = ActiveModel::Type::Boolean.new.cast(value)
-    end
 
     def save
       return false unless valid?

--- a/app/forms/eligibility_screener/is_teacher_form.rb
+++ b/app/forms/eligibility_screener/is_teacher_form.rb
@@ -1,10 +1,7 @@
 module EligibilityScreener
-  class IsTeacherForm
-    include ActiveModel::Model
+  class IsTeacherForm < EligibilityScreenerForm
+    attr_eligibility_check :is_teacher
 
-    attr_accessor :eligibility_check, :is_teacher
-
-    validates :eligibility_check, presence: true
     validates :is_teacher, inclusion: { in: %w[yes no not_sure] }
 
     def save

--- a/app/forms/eligibility_screener/reporting_as_form.rb
+++ b/app/forms/eligibility_screener/reporting_as_form.rb
@@ -1,10 +1,7 @@
 module EligibilityScreener
-  class ReportingAsForm
-    include ActiveModel::Model
+  class ReportingAsForm < EligibilityScreenerForm
+    attr_eligibility_check :reporting_as
 
-    attr_accessor :eligibility_check, :reporting_as
-
-    validates :eligibility_check, presence: true
     validates :reporting_as, presence: true
 
     def save

--- a/app/forms/eligibility_screener/serious_misconduct_form.rb
+++ b/app/forms/eligibility_screener/serious_misconduct_form.rb
@@ -1,10 +1,7 @@
 module EligibilityScreener
-  class SeriousMisconductForm
-    include ActiveModel::Model
+  class SeriousMisconductForm < EligibilityScreenerForm
+    attr_eligibility_check :serious_misconduct
 
-    attr_accessor :eligibility_check, :serious_misconduct
-
-    validates :eligibility_check, presence: true
     validates :serious_misconduct, inclusion: { in: %w[yes no not_sure] }
 
     def save

--- a/app/forms/eligibility_screener/teaching_in_england_form.rb
+++ b/app/forms/eligibility_screener/teaching_in_england_form.rb
@@ -1,10 +1,7 @@
 module EligibilityScreener
-  class TeachingInEnglandForm
-    include ActiveModel::Model
+  class TeachingInEnglandForm < EligibilityScreenerForm
+    attr_eligibility_check :teaching_in_england
 
-    attr_accessor :eligibility_check, :teaching_in_england
-
-    validates :eligibility_check, presence: true
     validates :teaching_in_england, inclusion: { in: %w[yes no not_sure] }
 
     def save

--- a/app/forms/eligibility_screener/unsupervised_teaching_form.rb
+++ b/app/forms/eligibility_screener/unsupervised_teaching_form.rb
@@ -1,10 +1,7 @@
 module EligibilityScreener
-  class UnsupervisedTeachingForm
-    include ActiveModel::Model
+  class UnsupervisedTeachingForm < EligibilityScreenerForm
+    attr_eligibility_check :unsupervised_teaching
 
-    attr_accessor :eligibility_check, :unsupervised_teaching
-
-    validates :eligibility_check, presence: true
     validates :unsupervised_teaching, inclusion: { in: %w[yes no not_sure] }
 
     def save

--- a/app/forms/eligibility_screener_form.rb
+++ b/app/forms/eligibility_screener_form.rb
@@ -1,0 +1,7 @@
+class EligibilityScreenerForm
+  include ActiveModel::Model
+  include CustomAttrs
+
+  attr_accessor :eligibility_check
+  validates :eligibility_check, presence: true
+end

--- a/app/lib/custom_attrs.rb
+++ b/app/lib/custom_attrs.rb
@@ -16,7 +16,7 @@ module CustomAttrs
     when :boolean
       ActiveModel::Type::Boolean.new.cast(value)
     when :string
-      value&.strip
+      value.is_a?(String) ? value&.strip : value
     else
       value
     end
@@ -33,6 +33,10 @@ module CustomAttrs
 
     def attr_referrer(*args)
       attr_object(:referrer, *args)
+    end
+
+    def attr_eligibility_check(*args)
+      attr_object(:eligibility_check, *args)
     end
 
     def attr_object(obj, *args)

--- a/spec/lib/custom_attrs_spec.rb
+++ b/spec/lib/custom_attrs_spec.rb
@@ -3,10 +3,11 @@ require "rails_helper"
 class TestClass
   include CustomAttrs
 
-  attr_accessor :referral, :referrer, :organisation
+  attr_accessor :referral, :referrer, :organisation, :eligibility_check
   attr_referral :email_known, :email_address
   attr_organisation :name, :street_1
   attr_referrer :first_name, :last_name
+  attr_eligibility_check :serious_misconduct
 end
 
 RSpec.describe CustomAttrs do
@@ -114,6 +115,34 @@ RSpec.describe CustomAttrs do
         it "returns the referral's updated values" do
           expect(first_name).to eq("Jane")
           expect(last_name).to eq("Doey")
+        end
+      end
+    end
+  end
+
+  describe ".attr_eligibility_check" do
+    let(:serious_misconduct) { test_class.serious_misconduct }
+
+    context "when the class doesn't have an eligibility_check object" do
+      it "returns nil" do
+        expect(serious_misconduct).to eq(nil)
+      end
+    end
+
+    context "when the class has an eligibility_check object" do
+      let(:eligibility_check) { build(:eligibility_check, :complete) }
+
+      before { test_class.eligibility_check = eligibility_check }
+
+      it "returns the eligibility_check's values" do
+        expect(serious_misconduct).to eq("yes")
+      end
+
+      context "when updating the values" do
+        before { test_class.serious_misconduct = "No" }
+
+        it "returns the eligibility_check's updated values" do
+          expect(serious_misconduct).to eq("No")
         end
       end
     end


### PR DESCRIPTION
Updates the eligibility pages to use custom attributes. This will also help with showing the selected answers when navigating back to the page and automatically converting true/false to boolean values.

It also fixes a bug where calling `process_type` for a db string value that get processed as a symbol. E.g. the `reporting_as` values of :public, :employer