### PR TITLE
Fix skipping eligibility screener questions bug

### DIFF
--- a/app/controllers/eligibility_screener/referral_type_controller.rb
+++ b/app/controllers/eligibility_screener/referral_type_controller.rb
@@ -1,6 +1,8 @@
 module EligibilityScreener
   class ReferralTypeController < EligibilityScreenerController
     def new
+      eligibility_check.clear_answers! if from_users_journey?
+
       @reporting_as_form = EligibilityScreener::ReportingAsForm.new(eligibility_check:)
     end
 
@@ -20,6 +22,10 @@ module EligibilityScreener
 
     def reporting_as_params
       params.require(:eligibility_screener_reporting_as_form).permit(:reporting_as)
+    end
+
+    def from_users_journey?
+      request.referer&.include?("users/referrals")
     end
   end
 end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -37,4 +37,15 @@ class EligibilityCheck < ApplicationRecord
   def unsupervised_teaching?
     %w[yes not_sure].include?(unsupervised_teaching)
   end
+
+  def clear_answers!
+    unless reporting_as.nil?
+      update!(
+        is_teacher: nil,
+        serious_misconduct: nil,
+        teaching_in_england: nil,
+        unsupervised_teaching: nil
+      )
+    end
+  end
 end

--- a/app/views/users/referrals/index.html.erb
+++ b/app/views/users/referrals/index.html.erb
@@ -10,7 +10,7 @@
         <%= govuk_button_link_to "Complete referral", [:edit, @referral_in_progress.routing_scope, @referral_in_progress] %>
       <% end %>
     <% else %>
-      <%= govuk_button_link_to "Start new referral", new_referral_path %>
+      <%= govuk_button_link_to "Start new referral", referral_type_path %>
     <% end %>
 
     <% if @referrals_submitted.any? %>

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -88,4 +88,18 @@ RSpec.describe EligibilityCheck, type: :model do
       it { is_expected.to be_truthy }
     end
   end
+
+  describe "#clear_answers!" do
+    let(:eligibility_check) { create(:eligibility_check, :complete, :not_unsupervised) }
+
+    before { eligibility_check.clear_answers! }
+
+    it "clears the answers" do
+      expect(eligibility_check.reporting_as).not_to be_nil
+      expect(eligibility_check.is_teacher).to be_nil
+      expect(eligibility_check.serious_misconduct).to be_nil
+      expect(eligibility_check.teaching_in_england).to be_nil
+      expect(eligibility_check.unsupervised_teaching).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This changes the "Start new referral" button to be a link to the first question of the eligibility screener. This makes it easier to clear the answered questions and start over. Going to the new referral path was creating a referral without needing to answer all the eligibility screener questions.