### PR TITLE
Fix deprecated methods in performance views

### DIFF
--- a/app/components/eligibility_performance_table_component.rb
+++ b/app/components/eligibility_performance_table_component.rb
@@ -7,45 +7,45 @@ class EligibilityPerformanceTableComponent < ViewComponent::Base
 
   def call
     govuk_table(classes: "app-performance-table") do |table|
-      table.head do |head|
-        head.row do |row|
-          row.cell(
+      table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(
             header: true,
             text: "Date",
             classes: "app-performance-table-column-divider app-performance-table-date-column"
           )
-          row.cell(header: true, text: "Complete")
-          row.cell(header: true, text: "Screened out")
-          row.cell(
+          row.with_cell(header: true, text: "Complete")
+          row.with_cell(header: true, text: "Screened out")
+          row.with_cell(
             header: true,
             text: "Did not finish",
             classes: "app-performance-table-column-divider"
           )
-          row.cell(header: true, text: "Total", classes: "govuk-!-padding-left-2")
+          row.with_cell(header: true, text: "Total", classes: "govuk-!-padding-left-2")
         end
       end
-      table.body do |body|
+      table.with_body do |body|
         grouped_request_counts.map do |period_label, counts|
-          body.row do |row|
-            row.cell(classes: "app-performance-table-column-divider") { period_label }
-            row.cell { number_with_percentage_cell(counts, :complete_count) }
-            row.cell { number_with_percentage_cell(counts, :screened_out_count) }
-            row.cell(classes: "app-performance-table-column-divider") do
+          body.with_row do |row|
+            row.with_cell(classes: "app-performance-table-column-divider") { period_label }
+            row.with_cell { number_with_percentage_cell(counts, :complete_count) }
+            row.with_cell { number_with_percentage_cell(counts, :screened_out_count) }
+            row.with_cell(classes: "app-performance-table-column-divider") do
               number_with_percentage_cell(counts, :incomplete_count)
             end
-            row.cell { "#{number_with_delimiter(counts[:total])} checks" }
+            row.with_cell { "#{number_with_delimiter(counts[:total])} checks" }
           end
         end
-        body.row(classes: "app-performance-table-total-row") do |row|
-          row.cell(header: true, classes: "app-performance-table-column-divider") do
+        body.with_row(classes: "app-performance-table-total-row") do |row|
+          row.with_cell(header: true, classes: "app-performance-table-column-divider") do
             "Total (#{since})"
           end
-          row.cell { number_with_percentage_cell(total_grouped_requests, :complete_count) }
-          row.cell { number_with_percentage_cell(total_grouped_requests, :screened_out_count) }
-          row.cell(classes: "app-performance-table-column-divider") do
+          row.with_cell { number_with_percentage_cell(total_grouped_requests, :complete_count) }
+          row.with_cell { number_with_percentage_cell(total_grouped_requests, :screened_out_count) }
+          row.with_cell(classes: "app-performance-table-column-divider") do
             number_with_percentage_cell(total_grouped_requests, :incomplete_count)
           end
-          row.cell { "#{number_with_delimiter(total_grouped_requests[:total])} checks" }
+          row.with_cell { "#{number_with_delimiter(total_grouped_requests[:total])} checks" }
         end
       end
     end

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -28,7 +28,7 @@
       count: number_to_percentage(
         100 * @total_requests_by_day[:complete_count].fdiv(@total_requests_by_day[:total]),
         precision: 0
-      ), 
+      ),
       label: [
          "completed their checks",
          "straight away",
@@ -58,32 +58,32 @@
 
 <div class="govuk-!-margin-top-7">
   <%= govuk_table(classes: 'app-performance-table') do |table|
-      table.caption(size: 'm', text: "How quickly did users get their eligibility status (today and the previous 7 days)")
+      table.with_caption(size: 'm', text: "How quickly did users get their eligibility status (today and the previous 7 days)")
 
-      table.head do |head|
-        head.row do |row|
-          row.cell(header: true, text: 'Date')
-          row.cell(header: true) { '90% of users<br>got their eligibility status within'.html_safe }
-          row.cell(header: true) { '75% of users<br>got their eligibility status within'.html_safe }
-          row.cell(header: true) { '50% of users<br>got their eligibility status within'.html_safe }
+      table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(header: true, text: 'Date')
+          row.with_cell(header: true) { '90% of users<br>got their eligibility status within'.html_safe }
+          row.with_cell(header: true) { '75% of users<br>got their eligibility status within'.html_safe }
+          row.with_cell(header: true) { '50% of users<br>got their eligibility status within'.html_safe }
         end
       end
 
-      table.body do |body|
+      table.with_body do |body|
         @daily_percentiles.each do |data_row|
-          body.row do |row|
-            row.cell { data_row[0] }
-            row.cell { data_row[1] }
-            row.cell { data_row[2] }
-            row.cell { data_row[3] }
+          body.with_row do |row|
+            row.with_cell { data_row[0] }
+            row.with_cell { data_row[1] }
+            row.with_cell { data_row[2] }
+            row.with_cell { data_row[3] }
           end
         end
 
-        body.row(classes: 'app-performance-table-total-row') do |row|
-          row.cell(header: true) { 'Average (today and the last 7 days)' }
-          row.cell { @total_percentiles[0] }
-          row.cell { @total_percentiles[1] }
-          row.cell { @total_percentiles[2] }
+        body.with_row(classes: 'app-performance-table-total-row') do |row|
+          row.with_cell(header: true) { 'Average (today and the last 7 days)' }
+          row.with_cell { @total_percentiles[0] }
+          row.with_cell { @total_percentiles[1] }
+          row.with_cell { @total_percentiles[2] }
         end
      end; end %>
 </div>


### PR DESCRIPTION
The govuk-components methods weren't updated to the new v4.0 syntax when the gem was updated because these views are not covered by tests.

Solves https://dfe-teacher-services.sentry.io/issues/4187472291/?project=4504136292237312