### PR TITLE
Fix translation error message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,7 +41,7 @@ en:
           attributes:
             declaration_agreed:
               accepted: You must agree to the declaration
-        registration_exists_form":
+        registration_exists_form:
           attributes:
             registration_exists:
               inclusion: Select yes if you have an account

--- a/spec/system/user_auth/user_signs_in_spec.rb
+++ b/spec/system/user_auth/user_signs_in_spec.rb
@@ -10,7 +10,10 @@ RSpec.feature "User accounts" do
     and_the_referral_form_feature_is_active
 
     when_i_visit_the_root_page
-    and_choose_continue_referral
+    when_i_click_continue
+    then_i_see_an_error_about_not_choosing_an_option
+
+    when_i_choose_continue_referral
     then_i_should_see_the_sign_in_page
 
     when_i_submit_my_email
@@ -62,10 +65,15 @@ RSpec.feature "User accounts" do
     visit root_path
   end
 
+  def then_i_see_an_error_about_not_choosing_an_option
+    expect(page).to have_content "Select yes if you have an account"
+  end
+
   def and_choose_continue_referral
     choose "Yes, sign in and continue making a referral", visible: false
     click_on "Continue"
   end
+  alias_method :when_i_choose_continue_referral, :and_choose_continue_referral
 
   def and_i_submit_my_email
     fill_in "user-email-field", with: "test@example.com"


### PR DESCRIPTION
The translation error message was not being displayed when the user wasn't selecting an option on the "Do you have an account?" page.
I fixed the issue in the `en.yml` file and added a spec to cover this scenario.

Before:
<img width="703" alt="Screenshot 2023-05-17 at 10 38 15" src="https://github.com/DFE-Digital/refer-serious-misconduct/assets/1636476/403de521-42fa-46cf-a72d-2c10eb3b140f">

After:
<img width="694" alt="Screenshot 2023-05-17 at 10 37 50" src="https://github.com/DFE-Digital/refer-serious-misconduct/assets/1636476/b87578b7-e434-46f3-b5b7-1c1c24c7c7c4">
