### PR TITLE
Add various fixes related to back buttons

### DIFF
--- a/app/controllers/public_referrals/referrer/name_controller.rb
+++ b/app/controllers/public_referrals/referrer/name_controller.rb
@@ -1,11 +1,6 @@
 module PublicReferrals
   module Referrer
     class NameController < Referrals::Referrer::NameController
-      private
-
-      def previous_path
-        public_referral_personal_details_path(current_referral)
-      end
     end
   end
 end

--- a/app/controllers/public_referrals/referrer/phone_controller.rb
+++ b/app/controllers/public_referrals/referrer/phone_controller.rb
@@ -3,7 +3,7 @@ module PublicReferrals
     class PhoneController < Referrals::Referrer::PhoneController
       def previous_path
         polymorphic_path(
-          [:edit, current_referral.routing_scope, current_referral, :referrer, :check_answers]
+          [:edit, current_referral.routing_scope, current_referral, :referrer, :name]
         )
       end
     end

--- a/app/controllers/public_referrals/teacher_role/organisation_address_known_controller.rb
+++ b/app/controllers/public_referrals/teacher_role/organisation_address_known_controller.rb
@@ -3,7 +3,7 @@ module PublicReferrals
     class OrganisationAddressKnownController < Referrals::TeacherRole::OrganisationAddressKnownController
       private
 
-      def back_link
+      def previous_path
         polymorphic_path(
           [:edit, current_referral.routing_scope, current_referral, :teacher_role, :duties]
         )

--- a/app/controllers/referrals/referrer/name_controller.rb
+++ b/app/controllers/referrals/referrer/name_controller.rb
@@ -20,11 +20,6 @@ module Referrals
       def name_params
         params.require(:referrals_referrer_name_form).permit(:first_name, :last_name)
       end
-
-      def previous_path
-        polymorphic_path([:edit, current_referral.routing_scope, current_referral])
-      end
-      helper_method :previous_path
     end
   end
 end

--- a/app/controllers/referrals/teacher_role/organisation_address_known_controller.rb
+++ b/app/controllers/referrals/teacher_role/organisation_address_known_controller.rb
@@ -29,7 +29,7 @@ module Referrals
         )
       end
 
-      def back_link
+      def previous_path
         polymorphic_path(
           [
             :edit,
@@ -40,7 +40,7 @@ module Referrals
           ]
         )
       end
-      helper_method :back_link
+      helper_method :previous_path
     end
   end
 end

--- a/app/controllers/referrals/teacher_role/start_date_controller.rb
+++ b/app/controllers/referrals/teacher_role/start_date_controller.rb
@@ -35,19 +35,6 @@ module Referrals
           "role_start_date(1i)"
         )
       end
-
-      def back_link
-        polymorphic_path(
-          [
-            :edit,
-            current_referral.routing_scope,
-            current_referral,
-            :teacher_role,
-            :same_organisation
-          ]
-        )
-      end
-      helper_method :back_link
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -118,10 +118,6 @@ module ApplicationHelper
     { "true" => "Yes", "false" => "No", "not_sure" => "I’m not sure" }[choice]
   end
 
-  def return_to_session_or(url)
-    session[:return_to] || url
-  end
-
   def service_name
     return t("service.manage") if %w[manage support staff].include?(current_namespace)
 

--- a/app/views/public_referrals/allegation/check_answers/edit.html.erb
+++ b/app/views/public_referrals/allegation/check_answers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_check_answers_form.errors.any?}Check and confirm your answers" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/public_referrals/allegation/considerations/edit.html.erb
+++ b/app/views/public_referrals/allegation/considerations/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_considerations_form.errors.any?}How this complaint has been considered" %>
-<% content_for :back_link_url, return_to_session_or(edit_public_referral_path(current_referral)) %>
+<% content_for :back_link_url, edit_public_referral_path(current_referral) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/public_referrals/evidence/check_answers/edit.html.erb
+++ b/app/views/public_referrals/evidence/check_answers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_check_answers_form.errors.any?}Check and confirm your answers - Evidence and supporting information" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/public_referrals/evidence/start/edit.html.erb
+++ b/app/views/public_referrals/evidence/start/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_start_form.errors.any?}Evidence and supporting information" %>
-<% content_for :back_link_url, return_to_session_or(edit_public_referral_path(current_referral)) %>
+<% content_for :back_link_url, edit_public_referral_path(current_referral) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/public_referrals/evidence/upload/edit.html.erb
+++ b/app/views/public_referrals/evidence/upload/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_upload_form.errors.any?}Upload evidence and supporting information" %>
-<% content_for :back_link_url, return_to_session_or(edit_public_referral_evidence_start_path(current_referral)) %>
+<% content_for :back_link_url, edit_public_referral_evidence_start_path(current_referral) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">
@@ -41,4 +41,3 @@
     <% end %>
   </div>
 </div>
-

--- a/app/views/public_referrals/evidence/uploaded/edit.html.erb
+++ b/app/views/public_referrals/evidence/uploaded/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Uploaded evidence" %>
-<% content_for :back_link_url, return_to_session_or(edit_public_referral_evidence_upload_path(current_referral)) %>
+<% content_for :back_link_url, edit_public_referral_evidence_upload_path(current_referral) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">

--- a/app/views/public_referrals/referrers/personal_details.html.erb
+++ b/app/views/public_referrals/referrers/personal_details.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "How your personal details will be used" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/public_referrals/review/show.html.erb
+++ b/app/views/public_referrals/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, 'Check details and send referral' %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/referrals/allegation/check_answers/edit.html.erb
+++ b/app/views/referrals/allegation/check_answers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_check_answers_form.errors.any?}Check and confirm your answers - The allegation" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/allegation/dbs/edit.html.erb
+++ b/app/views/referrals/allegation/dbs/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_dbs_form.errors.any?}Telling DBS about this case - The allegation" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :allegation_details])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :allegation_details]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/allegation/details/edit.html.erb
+++ b/app/views/referrals/allegation/details/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @allegation_details_form.errors.any?}How do you want to give details about the allegation? - The allegation" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/contact_details/address/edit.html.erb
+++ b/app/views/referrals/contact_details/address/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @contact_details_address_form.errors.any?}Their home address - Contact details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :contact_details_address_known])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :contact_details_address_known]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/contact_details/address_known/edit.html.erb
+++ b/app/views/referrals/contact_details/address_known/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @contact_details_address_known_form.errors.any?}Do you know their home address? - Contact details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :contact_details_telephone])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :contact_details_telephone]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/contact_details/check_answers/edit.html.erb
+++ b/app/views/referrals/contact_details/check_answers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @contact_details_check_answers_form.errors.any?}Check and confirm your answers - Contact details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/contact_details/email/edit.html.erb
+++ b/app/views/referrals/contact_details/email/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @contact_details_email_form.errors.any?}Do you know their email address? - Contact details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/contact_details/telephone/edit.html.erb
+++ b/app/views/referrals/contact_details/telephone/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @contact_details_telephone_form.errors.any?}Do you know their phone number? - Contact details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :contact_details_email])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :contact_details_email]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/evidence/check_answers/delete.html.erb
+++ b/app/views/referrals/evidence/check_answers/delete.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Are you sure you want to delete #{evidence.filename} - Evidence and supporting information" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :evidence_uploaded])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :evidence_uploaded]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/evidence/check_answers/edit.html.erb
+++ b/app/views/referrals/evidence/check_answers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_check_answers_form.errors.any?}Check and confirm your answers - Evidence and supporting information" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/evidence/start/edit.html.erb
+++ b/app/views/referrals/evidence/start/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_start_form.errors.any?}Evidence and supporting information" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/evidence/upload/edit.html.erb
+++ b/app/views/referrals/evidence/upload/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @evidence_upload_form.errors.any?}Upload evidence and supporting information" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :evidence_start])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :evidence_start]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/evidence/uploaded/edit.html.erb
+++ b/app/views/referrals/evidence/uploaded/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Uploaded evidence - Evidence and supporting information" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :evidence_upload])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :evidence_upload]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/organisation/address/edit.html.erb
+++ b/app/views/referrals/organisation/address/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @organisation_address_form.errors.any?}Your organisation" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/organisation/check_answers/edit.html.erb
+++ b/app/views/referrals/organisation/check_answers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Check and confirm your answers - Your organisation" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/personal_details/age/edit.html.erb
+++ b/app/views/referrals/personal_details/age/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_age_form.errors.any?}Do you know their date of birth? - Personal details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details_name])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details_name]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/personal_details/check_answers/edit.html.erb
+++ b/app/views/referrals/personal_details/check_answers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_check_answers_form.errors.any?}Check and confirm your answers - Personal details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/personal_details/name/edit.html.erb
+++ b/app/views/referrals/personal_details/name/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_name_form.errors.any?}What is the name of the person you’re referring? - Personal details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/personal_details/ni_number/edit.html.erb
+++ b/app/views/referrals/personal_details/ni_number/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @ni_number_form.errors.any?}Do you know their National Insurance number? - Personal details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details_age])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details_age]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/personal_details/qts/edit.html.erb
+++ b/app/views/referrals/personal_details/qts/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_qts_form.errors.any?}Do they have qualified teacher status (QTS)? - Personal details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details_trn])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details_trn]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/personal_details/trn/edit.html.erb
+++ b/app/views/referrals/personal_details/trn/edit.html.erb
@@ -1,6 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @personal_details_trn_form.errors.any?}Do you know their teacher reference number (TRN)? - Personal details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details, :ni_number])) %>
-
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :personal_details, :ni_number]) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @personal_details_trn_form, url: [current_referral.routing_scope, current_referral, :personal_details_trn], method: :put do |f| %>

--- a/app/views/referrals/previous_misconduct/check_answers/edit.html.erb
+++ b/app/views/referrals/previous_misconduct/check_answers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Check and confirm your answers - Previous allegations" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/previous_misconduct/detailed_account/edit.html.erb
+++ b/app/views/referrals/previous_misconduct/detailed_account/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @detailed_account_form.errors.any?}Give a detailed account of previous allegations - Previous allegations" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :previous_misconduct_reported])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :previous_misconduct_reported]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/previous_misconduct/reported/edit.html.erb
+++ b/app/views/referrals/previous_misconduct/reported/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @reported_form.errors.any?}Has there been any previous misconduct, disciplinary action or complaints? - Previous allegations" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/referrer/check_answers/edit.html.erb
+++ b/app/views/referrals/referrer/check_answers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Check and confirm your answers - Your details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/referrer/job_title/edit.html.erb
+++ b/app/views/referrals/referrer/job_title/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @referrer_job_title_form.errors.any?}Your job title - Your details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :referrer_name])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :referrer_name]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/referrer/name/edit.html.erb
+++ b/app/views/referrals/referrer/name/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @referrer_name_form.errors.any?}Your name - Your details" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/referrer/phone/edit.html.erb
+++ b/app/views/referrals/referrer/phone/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @referrer_phone_form.errors.any?}Your phone number - Your details" %>
-<% content_for :back_link_url, return_to_session_or(previous_path) %>
+<% content_for :back_link_url, previous_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/review/show.html.erb
+++ b/app/views/referrals/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, 'Check details and send referral' %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/referrals/teacher_role/check_answers/edit.html.erb
+++ b/app/views/referrals/teacher_role/check_answers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @teacher_role_check_answers_form.errors.any?}Check and confirm your answers - About their role" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/teacher_role/duties/edit.html.erb
+++ b/app/views/referrals/teacher_role/duties/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @duties_form.errors.any?}How do you want to give details about their main duties? - About their role" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :job_title])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :job_title]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/teacher_role/employment_status/edit.html.erb
+++ b/app/views/referrals/teacher_role/employment_status/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @employment_status_form.errors.any?}Are they still employed at the organisation where the alleged misconduct took place? - About their role" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :start_date])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :start_date]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/teacher_role/end_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/end_date/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @role_end_date_form.errors.any?}Do you know when they left the job? - About their role" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :employment_status])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :employment_status]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/teacher_role/job_title/edit.html.erb
+++ b/app/views/referrals/teacher_role/job_title/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @job_title_form.errors.any?}Their job title - About their role" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/teacher_role/organisation_address/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @organisation_address_form.errors.any?}Name and address of the organisation where the alleged misconduct took place - About their role" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :organisation_address_known])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :organisation_address_known]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @organisation_address_known_form.errors.any?}Do you know the name and address of the organisation? - About their role" %>
-<% content_for :back_link_url, return_to_session_or(back_link) %>
+<% content_for :back_link_url, back_link %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @organisation_address_known_form.errors.any?}Do you know the name and address of the organisation? - About their role" %>
-<% content_for :back_link_url, back_link %>
+<% content_for :back_link_url, previous_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/teacher_role/reason_leaving_role/edit.html.erb
+++ b/app/views/referrals/teacher_role/reason_leaving_role/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @reason_leaving_role_form.errors.any?}Reason they left the job - About their role" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :end_date])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :end_date]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/teacher_role/same_organisation/edit.html.erb
+++ b/app/views/referrals/teacher_role/same_organisation/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @same_organisation_form.errors.any?}Were they employed at the same organisation as you at the time of the alleged misconduct? - About their role" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :duties])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :duties]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/teacher_role/start_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/start_date/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @role_start_date_form.errors.any?}Do you know when they started the job? - About their role" %>
-<% content_for :back_link_url, return_to_session_or(back_link) %>
+<% content_for :back_link_url, back_link %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/teacher_role/start_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/start_date/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @role_start_date_form.errors.any?}Do you know when they started the job? - About their role" %>
-<% content_for :back_link_url, back_link %>
+<% content_for :back_link_url, polymorphic_path([ :edit, current_referral.routing_scope, current_referral, :teacher_role, :same_organisation]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/teacher_role/work_location/edit.html.erb
+++ b/app/views/referrals/teacher_role/work_location/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @work_location_form.errors.any?}Name and address of the organisation where they’re employed - About their role" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :work_location_known])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :work_location_known]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referrals/teacher_role/work_location_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/work_location_known/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @work_location_known_form.errors.any?}Do you know the name and address of the organisation where they’re employed? - About their role" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :working_somewhere_else])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :working_somewhere_else]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/referrals/teacher_role/working_somewhere_else/edit.html.erb
+++ b/app/views/referrals/teacher_role/working_somewhere_else/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @working_somewhere_else_form.errors.any?}Are they employed somewhere else? - About their role" %>
-<% content_for :back_link_url, return_to_session_or(polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :reason_leaving_role])) %>
+<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :reason_leaving_role]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">


### PR DESCRIPTION
- remove two unused `previous_path` methods and updates a broken path.
- remove unused `return_to_session_or` method
- rename `back_link` to `previous_path` and remove unnecessary call