### PR TITLE
Refactor file upload to use Upload model

### DIFF
--- a/app/controllers/referrals/allegation/details_controller.rb
+++ b/app/controllers/referrals/allegation/details_controller.rb
@@ -6,7 +6,7 @@ module Referrals
           DetailsForm.new(
             allegation_details: current_referral.allegation_details,
             allegation_format: current_referral.allegation_format,
-            allegation_upload: current_referral.allegation_upload
+            allegation_attachment: current_referral.allegation_attachment
           )
       end
 
@@ -27,7 +27,7 @@ module Referrals
         params.require(:referrals_allegation_details_form).permit(
           :allegation_format,
           :allegation_details,
-          :allegation_upload
+          :allegation_attachment
         )
       end
     end

--- a/app/forms/referrals/allegation/details_form.rb
+++ b/app/forms/referrals/allegation/details_form.rb
@@ -6,7 +6,7 @@ module Referrals
       validates :allegation_details, presence: true, if: -> { allegation_format == "details" }
       validates :allegation_upload,
                 presence: true,
-                if: -> { allegation_format == "upload" && !referral.allegation_upload.attached? }
+                if: -> { allegation_format == "upload" && !referral.allegation_upload }
       validates :allegation_upload, file_upload: true, if: -> { allegation_format == "upload" }
 
       attr_referral :allegation_details, :allegation_format, :allegation_upload
@@ -22,11 +22,14 @@ module Referrals
 
         case allegation_format
         when "details"
-          referral.allegation_upload.purge
+          referral.allegation_upload&.record&.destroy
           attrs.merge!(allegation_details:)
         when "upload"
           if allegation_upload.present? && valid_upload_classes.member?(allegation_upload.class)
-            attrs.merge!(allegation_details: nil, allegation_upload:)
+            referral.allegation_upload&.record&.destroy
+            referral.uploads.create(section: "allegation", attachment: allegation_upload)
+
+            attrs.merge!(allegation_details: nil)
           end
         end
 

--- a/app/forms/referrals/allegation/details_form.rb
+++ b/app/forms/referrals/allegation/details_form.rb
@@ -4,12 +4,12 @@ module Referrals
     class DetailsForm < FormItem
       validates :allegation_format, inclusion: { in: %w[details upload] }
       validates :allegation_details, presence: true, if: -> { allegation_format == "details" }
-      validates :allegation_upload,
+      validates :allegation_attachment,
                 presence: true,
-                if: -> { allegation_format == "upload" && !referral.allegation_upload }
-      validates :allegation_upload, file_upload: true, if: -> { allegation_format == "upload" }
+                if: -> { allegation_format == "upload" && !referral.allegation_attachment }
+      validates :allegation_attachment, file_upload: true, if: -> { allegation_format == "upload" }
 
-      attr_referral :allegation_details, :allegation_format, :allegation_upload
+      attr_referral :allegation_details, :allegation_format, :allegation_attachment
 
       def slug
         "allegation_details"
@@ -22,12 +22,13 @@ module Referrals
 
         case allegation_format
         when "details"
-          referral.allegation_upload&.record&.destroy
+          referral.allegation_attachment&.destroy
           attrs.merge!(allegation_details:)
         when "upload"
-          if allegation_upload.present? && valid_upload_classes.member?(allegation_upload.class)
-            referral.allegation_upload&.record&.destroy
-            referral.uploads.create(section: "allegation", attachment: allegation_upload)
+          if allegation_attachment.present? &&
+               valid_upload_classes.member?(allegation_attachment.class)
+            referral.allegation_attachment&.destroy
+            referral.uploads.create(section: "allegation", attachment: allegation_attachment)
 
             attrs.merge!(allegation_details: nil)
           end

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -48,7 +48,7 @@ module ReferralHelper
     when "details"
       referral.allegation_details.present? ? "Describe the allegation" : "Incomplete"
     when "upload"
-      referral.allegation_upload ? "Upload file" : "Incomplete"
+      referral.allegation_attachment ? "Upload file" : "Incomplete"
     else
       "Not answered"
     end
@@ -63,10 +63,10 @@ module ReferralHelper
         "Incomplete"
       end
     when "upload"
-      if referral.allegation_upload
+      if referral.allegation_attachment
         govuk_link_to(
-          referral.allegation_upload.filename,
-          rails_blob_path(referral.allegation_upload, disposition: "attachment")
+          referral.allegation_upload.name,
+          rails_blob_path(referral.allegation_attachment, disposition: "attachment")
         )
       else
         "Incomplete"

--- a/app/helpers/referral_helper.rb
+++ b/app/helpers/referral_helper.rb
@@ -48,7 +48,7 @@ module ReferralHelper
     when "details"
       referral.allegation_details.present? ? "Describe the allegation" : "Incomplete"
     when "upload"
-      referral.allegation_upload.attached? ? "Upload file" : "Incomplete"
+      referral.allegation_upload ? "Upload file" : "Incomplete"
     else
       "Not answered"
     end
@@ -63,7 +63,7 @@ module ReferralHelper
         "Incomplete"
       end
     when "upload"
-      if referral.allegation_upload.attached?
+      if referral.allegation_upload
         govuk_link_to(
           referral.allegation_upload.filename,
           rails_blob_path(referral.allegation_upload, disposition: "attachment")

--- a/app/lib/referral_zip_file.rb
+++ b/app/lib/referral_zip_file.rb
@@ -52,7 +52,7 @@ class ReferralZipFile
   end
 
   def attachments
-    files = [referral.duties_upload, referral.allegation_upload, referral.pdf]
+    files = [referral.duties_upload, referral.allegation_upload, referral.pdf].compact
 
     files + referral.evidences.map(&:document)
   end

--- a/app/lib/referral_zip_file.rb
+++ b/app/lib/referral_zip_file.rb
@@ -52,7 +52,7 @@ class ReferralZipFile
   end
 
   def attachments
-    files = [referral.duties_upload, referral.allegation_upload, referral.pdf].compact
+    files = [referral.duties_upload, referral.allegation_attachment, referral.pdf].compact
 
     files + referral.evidences.map(&:document)
   end

--- a/app/models/concerns/uploadable.rb
+++ b/app/models/concerns/uploadable.rb
@@ -1,0 +1,5 @@
+module Uploadable
+  extend ActiveSupport::Concern
+
+  included { has_many :uploads, as: :uploadable }
+end

--- a/app/models/concerns/uploadable.rb
+++ b/app/models/concerns/uploadable.rb
@@ -2,4 +2,16 @@ module Uploadable
   extend ActiveSupport::Concern
 
   included { has_many :uploads, as: :uploadable }
+
+  def self.included(klass)
+    klass.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def has_one_uploaded(attr_name)
+      define_method("#{attr_name}_upload") { uploads.find_by(section: attr_name) }
+
+      define_method("#{attr_name}_attachment") { send("#{attr_name}_upload").try(:attachment) }
+    end
+  end
 end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -1,10 +1,12 @@
 class Referral < ApplicationRecord
+  include Uploadable
+
   belongs_to :eligibility_check, dependent: :destroy
   belongs_to :user
 
   has_one :organisation, dependent: :destroy
   has_one :referrer, dependent: :destroy
-  has_one_attached :allegation_upload
+  # has_one_attached :allegation_upload
   has_one_attached :previous_misconduct_upload
   has_one_attached :duties_upload
   has_one_attached :pdf
@@ -25,6 +27,10 @@ class Referral < ApplicationRecord
         -> { where(submitted_at: nil).where("updated_at <= ?", 83.days.ago) }
 
   delegate :name, to: :referrer, prefix: true, allow_nil: true
+
+  def allegation_upload
+    uploads.find_by(section: "allegation").try(:attachment)
+  end
 
   def submit
     self.declaration = DeclarationRenderer.new.render

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -11,6 +11,17 @@ class Referral < ApplicationRecord
   has_one_attached :duties_upload
   has_one_attached :pdf
 
+  # has_one :allegation_upload, -> { where(section: :allegation) }, class_name: "Upload", dependent: :destroy, foreign_key: :uploadable_id
+  # has_one :previous_misconduct_upload, -> { where(section: :previous_misconduct) }, class_name: "Upload", dependent: :destroy, foreign_key: :uploadable_id
+  # has_one :duties_upload, -> { where(section: :duties) }, class_name: "Upload", dependent: :destroy, foreign_key: :uploadable_id
+  # has_one :pdf, -> { where(section: :pdf) }, class_name: "Upload", dependent: :destroy, foreign_key: :uploadable_id
+
+  # def allegation_attachment
+  #   allegation_upload&.attachment
+  # end
+
+  has_one_uploaded :allegation
+
   has_many :evidences,
            -> { order(:created_at) },
            class_name: "ReferralEvidence",
@@ -27,10 +38,6 @@ class Referral < ApplicationRecord
         -> { where(submitted_at: nil).where("updated_at <= ?", 83.days.ago) }
 
   delegate :name, to: :referrer, prefix: true, allow_nil: true
-
-  def allegation_upload
-    uploads.find_by(section: "allegation").try(:attachment)
-  end
 
   def submit
     self.declaration = DeclarationRenderer.new.render

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -1,0 +1,12 @@
+class Upload < ApplicationRecord
+  belongs_to :uploadable, polymorphic: true
+
+  has_one_attached :attachment, dependent: :purge_later
+
+  enum section: {
+         allegation: "allegation",
+         duties: "duties",
+         previous_misconduct: "previous_misconduct",
+         evidence: "evidence"
+       }
+end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -9,4 +9,8 @@ class Upload < ApplicationRecord
          previous_misconduct: "previous_misconduct",
          evidence: "evidence"
        }
+
+  def name
+    attachment.filename.to_s
+  end
 end

--- a/app/views/referrals/allegation/details/edit.html.erb
+++ b/app/views/referrals/allegation/details/edit.html.erb
@@ -10,25 +10,25 @@
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset(:allegation_format, legend: { size: "l", text: "How do you want to give details about the allegation?", tag: 'h1' }) do %>
           <%= f.govuk_radio_button :allegation_format, "upload", label: { text: "Upload file" }, link_errors: true do %>
-            <% if current_referral.allegation_upload %>
+            <% if current_referral.allegation_attachment %>
               <div class="app-uploaded-file">
                 <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
                     Currently uploaded file
                 </h2>
                 <p>
                   <%= govuk_link_to(
-                    "#{current_referral.allegation_upload.filename} (#{file_size(current_referral.allegation_upload)})",
-                    rails_blob_path(current_referral.allegation_upload, disposition: "attachment")
+                    "#{current_referral.allegation_attachment.filename} (#{file_size(current_referral.allegation_attachment)})",
+                    rails_blob_path(current_referral.allegation_attachment, disposition: "attachment")
                     )
                   %>
                 </p>
-                <%= f.govuk_file_field :allegation_upload,
+                <%= f.govuk_file_field :allegation_attachment,
                   label: { text: "Upload new file", size: "s" },
                   hint: { text: "Must be smaller than #{max_allowed_file_size}" }
                 %>
               </div>
             <% else %>
-              <%= f.govuk_file_field :allegation_upload,
+              <%= f.govuk_file_field :allegation_attachment,
                 label: { text: "Upload file", size: "s" },
                 hint: { text: "Must be smaller than #{max_allowed_file_size}" }
               %>

--- a/app/views/referrals/allegation/details/edit.html.erb
+++ b/app/views/referrals/allegation/details/edit.html.erb
@@ -10,7 +10,7 @@
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset(:allegation_format, legend: { size: "l", text: "How do you want to give details about the allegation?", tag: 'h1' }) do %>
           <%= f.govuk_radio_button :allegation_format, "upload", label: { text: "Upload file" }, link_errors: true do %>
-            <% if current_referral.allegation_upload.attached? %>
+            <% if current_referral.allegation_upload %>
               <div class="app-uploaded-file">
                 <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
                     Currently uploaded file

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -181,3 +181,10 @@ shared:
     - referral_id
     - created_at
     - updated_at
+  :uploads:
+    - id
+    - section
+    - uploadable_type
+    - uploadable_id
+    - created_at
+    - updated_at

--- a/db/migrate/20230525101522_create_uploads.rb
+++ b/db/migrate/20230525101522_create_uploads.rb
@@ -1,0 +1,9 @@
+class CreateUploads < ActiveRecord::Migration[7.0]
+  def change
+    create_table :uploads do |t|
+      t.string "section", null: false
+      t.references :uploadable, polymorphic: true, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_28_092509) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_25_101522) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
 
@@ -212,6 +212,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_28_092509) do
     t.index %w[invited_by_type invited_by_id], name: "index_staff_on_invited_by"
     t.index ["reset_password_token"], name: "index_staff_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_staff_on_unlock_token", unique: true
+  end
+
+  create_table "uploads", force: :cascade do |t|
+    t.string "section", null: false
+    t.string "uploadable_type"
+    t.bigint "uploadable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index %w[uploadable_type uploadable_id], name: "index_uploads_on_uploadable"
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/tasks/transfer_attachments.rake
+++ b/lib/tasks/transfer_attachments.rake
@@ -1,0 +1,11 @@
+desc "Transfers the ActiveStorage attachments from referrals to uploads"
+task transfer_attachments: :environment do
+  attachments = ActiveStorage::Attachment.where(record_type: "Referral", name: "allegation_upload")
+
+  ActiveRecord::Base.transaction do
+    attachments.each do |attachment|
+      upload = attachment.record.uploads.create!(section: "allegation")
+      attachment.update(record: upload, record_type: "Upload", name: "attachment")
+    end
+  end
+end

--- a/spec/components/referrals/public_allegation_component_spec.rb
+++ b/spec/components/referrals/public_allegation_component_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Referrals::PublicAllegationComponent, type: :component do
   let(:row_links) { component.rows.map { |row| row.dig(:actions, :href) } }
   let(:allegation_format) { nil }
   let(:allegation_details) { nil }
-  let(:allegation_upload) { nil }
   let(:allegation_consideration_details) { nil }
 
   let(:referral) do
@@ -24,7 +23,6 @@ RSpec.describe Referrals::PublicAllegationComponent, type: :component do
       :public,
       allegation_format:,
       allegation_details:,
-      allegation_upload:,
       allegation_consideration_details:
     )
   end
@@ -74,6 +72,8 @@ RSpec.describe Referrals::PublicAllegationComponent, type: :component do
         "application/pdf"
       )
     end
+
+    before { referral.uploads.create(section: "allegation", attachment: allegation_upload) }
 
     it "renders the correct values" do
       expect(row_values_sanitized).to eq(["Upload file", "upload1.pdf", "Not answered"])

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -56,7 +56,13 @@ FactoryBot.define do
       allegation_format { "upload" }
       duties_format { "upload" }
 
-      allegation_upload { Rack::Test::UploadedFile.new("spec/fixtures/files/upload1.pdf") }
+      after(:create) do |referral|
+        referral.uploads.create(
+          section: "allegation",
+          attachment: Rack::Test::UploadedFile.new("spec/fixtures/files/upload1.pdf")
+        )
+      end
+
       duties_upload { Rack::Test::UploadedFile.new("spec/fixtures/files/upload2.pdf") }
     end
 

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :upload do
+    attachment { Rack::Test::UploadedFile.new("spec/fixtures/files/upload1.pdf") }
+
+    trait :allegation do
+      association :uploadable, factory: :referral
+      uploadable_type { "Referral" }
+      section { "allegation" }
+    end
+  end
+end

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Referral, type: :model do
   it { is_expected.to have_one(:organisation).dependent(:destroy) }
   it { is_expected.to have_one(:referrer).dependent(:destroy) }
   it { is_expected.to have_one_attached(:previous_misconduct_upload) }
-  it { is_expected.to have_one_attached(:allegation_upload) }
   it { is_expected.to have_one_attached(:duties_upload) }
   it { is_expected.to have_one_attached(:pdf) }
 


### PR DESCRIPTION
This commit refactors the file upload functionality to use the Upload model. This is a polymorphic model that can be attached to any other model. It is used to store the file data and metadata.

I also added a rake task to transfer the existing file data to the new model.