### PR TITLE
Homogenize forms

### DIFF
--- a/app/controllers/public_referrals/allegation_details/considerations_controller.rb
+++ b/app/controllers/public_referrals/allegation_details/considerations_controller.rb
@@ -4,7 +4,7 @@ module PublicReferrals
   module AllegationDetails
     class ConsiderationsController < Referrals::BaseController
       def edit
-        @allegation_considerations_form =
+        @form =
           Referrals::AllegationDetails::ConsiderationsForm.new(
             referral: current_referral,
             allegation_consideration_details: current_referral.allegation_consideration_details
@@ -12,13 +12,13 @@ module PublicReferrals
       end
 
       def update
-        @allegation_considerations_form =
+        @form =
           Referrals::AllegationDetails::ConsiderationsForm.new(
             allegation_considerations_params.merge(referral: current_referral)
           )
 
-        if @allegation_considerations_form.save
-          redirect_to @allegation_considerations_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/allegation_details/check_answers_controller.rb
+++ b/app/controllers/referrals/allegation_details/check_answers_controller.rb
@@ -2,7 +2,7 @@ module Referrals
   module AllegationDetails
     class CheckAnswersController < Referrals::BaseController
       def edit
-        @allegation_check_answers_form =
+        @form =
           CheckAnswersForm.new(
             referral: current_referral,
             allegation_details_complete: current_referral.allegation_details_complete
@@ -10,11 +10,10 @@ module Referrals
       end
 
       def update
-        @allegation_check_answers_form =
-          CheckAnswersForm.new(check_answers_params.merge(referral: current_referral))
+        @form = CheckAnswersForm.new(check_answers_params.merge(referral: current_referral))
 
-        if @allegation_check_answers_form.save
-          redirect_to [:edit, current_referral.routing_scope, current_referral]
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/allegation_details/dbs_controller.rb
+++ b/app/controllers/referrals/allegation_details/dbs_controller.rb
@@ -2,14 +2,14 @@ module Referrals
   module AllegationDetails
     class DbsController < Referrals::BaseController
       def edit
-        @allegation_dbs_form = DbsForm.new(dbs_notified: current_referral.dbs_notified)
+        @form = DbsForm.new(referral: current_referral, dbs_notified: current_referral.dbs_notified)
       end
 
       def update
-        @allegation_dbs_form = DbsForm.new(allegation_dbs_params.merge(referral: current_referral))
+        @form = DbsForm.new(allegation_dbs_params.merge(referral: current_referral))
 
-        if @allegation_dbs_form.save
-          redirect_to @allegation_dbs_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/allegation_details/details_controller.rb
+++ b/app/controllers/referrals/allegation_details/details_controller.rb
@@ -2,8 +2,9 @@ module Referrals
   module AllegationDetails
     class DetailsController < Referrals::BaseController
       def edit
-        @allegation_details_form =
+        @form =
           DetailsForm.new(
+            referral: current_referral,
             allegation_details: current_referral.allegation_details,
             allegation_format: current_referral.allegation_format,
             allegation_upload_file: current_referral.allegation_upload_file
@@ -11,11 +12,10 @@ module Referrals
       end
 
       def update
-        @allegation_details_form =
-          DetailsForm.new(allegation_details_params.merge(referral: current_referral))
+        @form = DetailsForm.new(allegation_details_params.merge(referral: current_referral))
 
-        if @allegation_details_form.save
-          redirect_to @allegation_details_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/allegation_evidence/check_answers_controller.rb
+++ b/app/controllers/referrals/allegation_evidence/check_answers_controller.rb
@@ -4,7 +4,7 @@ module Referrals
       include ReferralHelper
 
       def edit
-        @evidence_check_answers_form =
+        @form =
           CheckAnswersForm.new(
             referral: current_referral,
             evidence_details_complete: current_referral.evidence_details_complete
@@ -12,21 +12,22 @@ module Referrals
       end
 
       def update
-        @evidence_check_answers_form =
-          CheckAnswersForm.new(check_answers_params.merge(referral: current_referral))
+        @form = CheckAnswersForm.new(check_answers_params.merge(referral: current_referral))
 
-        if @evidence_check_answers_form.save
-          redirect_to([:edit, current_referral.routing_scope, current_referral])
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end
       end
 
       def delete
+        @form = CheckAnswersForm.new(referral: current_referral)
       end
 
       def destroy
-        filename = evidence.file.filename
+        @form = CheckAnswersForm.new(referral: current_referral)
+        filename = evidence.filename
         evidence.destroy
 
         subsection =

--- a/app/controllers/referrals/allegation_evidence/start_controller.rb
+++ b/app/controllers/referrals/allegation_evidence/start_controller.rb
@@ -4,24 +4,21 @@ module Referrals
       include ReferralHelper
 
       def edit
-        @evidence_start_form = StartForm.new(has_evidence: current_referral.has_evidence)
+        @form =
+          StartForm.new(referral: current_referral, has_evidence: current_referral.has_evidence)
       end
 
       def update
-        @evidence_start_form = StartForm.new(start_params.merge(referral: current_referral))
+        @form = StartForm.new(start_params.merge(referral: current_referral))
 
-        if @evidence_start_form.save
+        if @form.save
           redirect_path = [
             :edit,
             current_referral.routing_scope,
             current_referral,
             :allegation_evidence
           ]
-          if @evidence_start_form.has_evidence
-            redirect_path.push(:upload)
-          else
-            redirect_path.push(:check_answers)
-          end
+          @form.has_evidence ? redirect_path.push(:upload) : redirect_path.push(:check_answers)
           redirect_to redirect_path
         else
           render :edit

--- a/app/controllers/referrals/allegation_evidence/upload_controller.rb
+++ b/app/controllers/referrals/allegation_evidence/upload_controller.rb
@@ -4,16 +4,19 @@ module Referrals
       include ReferralHelper
 
       def edit
-        @evidence_upload_form = UploadForm.new(referral: current_referral)
+        @form = UploadForm.new(referral: current_referral)
       end
 
       def update
-        @evidence_upload_form = UploadForm.new(upload_params.merge(referral: current_referral))
+        @form = UploadForm.new(upload_params.merge(referral: current_referral))
 
-        if @evidence_upload_form.save
-          redirect_to(
-            [:edit, current_referral.routing_scope, current_referral, :allegation_evidence_uploaded]
-          )
+        if @form.save
+          redirect_to [
+                        :edit,
+                        current_referral.routing_scope,
+                        current_referral,
+                        :allegation_evidence_uploaded
+                      ]
         else
           render :edit
         end

--- a/app/controllers/referrals/allegation_evidence/uploaded_controller.rb
+++ b/app/controllers/referrals/allegation_evidence/uploaded_controller.rb
@@ -4,16 +4,16 @@ module Referrals
       include ReferralHelper
 
       def edit
-        @uploaded_form = UploadedForm.new(referral: current_referral)
+        @form = UploadedForm.new(referral: current_referral)
       end
 
       def update
-        @uploaded_form = UploadedForm.new(more_evidence_params.merge(referral: current_referral))
+        @form = UploadedForm.new(more_evidence_params.merge(referral: current_referral))
 
-        if @uploaded_form.valid?(:update)
+        if @form.valid?(:update)
           subsection =
             (
-              if @uploaded_form.more_evidence?
+              if @form.more_evidence?
                 :allegation_evidence_upload
               else
                 :allegation_evidence_check_answers

--- a/app/controllers/referrals/allegation_previous_misconduct/check_answers_controller.rb
+++ b/app/controllers/referrals/allegation_previous_misconduct/check_answers_controller.rb
@@ -2,7 +2,7 @@ module Referrals
   module AllegationPreviousMisconduct
     class CheckAnswersController < Referrals::BaseController
       def edit
-        @previous_misconduct_check_answers_form =
+        @form =
           CheckAnswersForm.new(
             referral: current_referral,
             previous_misconduct_complete: current_referral.previous_misconduct_complete
@@ -10,11 +10,10 @@ module Referrals
       end
 
       def update
-        @previous_misconduct_check_answers_form =
-          CheckAnswersForm.new(previous_misconduct_params.merge(referral: current_referral))
+        @form = CheckAnswersForm.new(previous_misconduct_params.merge(referral: current_referral))
 
-        if @previous_misconduct_check_answers_form.save
-          redirect_to [:edit, current_referral.routing_scope, current_referral]
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/allegation_previous_misconduct/detailed_account_controller.rb
+++ b/app/controllers/referrals/allegation_previous_misconduct/detailed_account_controller.rb
@@ -2,8 +2,9 @@ module Referrals
   module AllegationPreviousMisconduct
     class DetailedAccountController < Referrals::BaseController
       def edit
-        @detailed_account_form =
+        @form =
           DetailedAccountForm.new(
+            referral: current_referral,
             previous_misconduct_format: current_referral.previous_misconduct_format,
             previous_misconduct_details: current_referral.previous_misconduct_details,
             previous_misconduct_upload_file: current_referral.previous_misconduct_upload_file
@@ -11,10 +12,10 @@ module Referrals
       end
 
       def update
-        @detailed_account_form =
+        @form =
           DetailedAccountForm.new(detailed_account_form_params.merge(referral: current_referral))
-        if @detailed_account_form.save
-          redirect_to @detailed_account_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/allegation_previous_misconduct/reported_controller.rb
+++ b/app/controllers/referrals/allegation_previous_misconduct/reported_controller.rb
@@ -2,13 +2,13 @@ module Referrals
   module AllegationPreviousMisconduct
     class ReportedController < Referrals::BaseController
       def edit
-        @reported_form = ReportedForm.new(referral: current_referral)
+        @form = ReportedForm.new(referral: current_referral)
       end
 
       def update
-        @reported_form = ReportedForm.new(reported_form_params.merge(referral: current_referral))
-        if @reported_form.save
-          redirect_to @reported_form.next_path
+        @form = ReportedForm.new(reported_form_params.merge(referral: current_referral))
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -21,13 +21,18 @@ module Referrals
     end
     helper_method :current_referral
 
-    def next_page
-      next_path
+    def back_link_url
+      polymorphic_path(form.previous_path)
     end
+    helper_method :back_link_url
 
-    # Overwrite this method with the path of the next page in the journey
-    def next_path
-      root_path
-    end
+    delegate :page_title, :section_label, :form_path, to: :form
+    helper_method :page_title, :section_label, :form_path
+
+    delegate :label, to: :form, prefix: true
+    helper_method :form_label
+
+    attr_reader :form
+    helper_method :form
   end
 end

--- a/app/controllers/referrals/referrer_details/check_answers_controller.rb
+++ b/app/controllers/referrals/referrer_details/check_answers_controller.rb
@@ -4,7 +4,7 @@ module Referrals
       before_action :set_referrer
 
       def edit
-        @check_answers_form =
+        @form =
           CheckAnswersForm.new(
             referral: current_referral,
             referrer: @referrer,
@@ -13,15 +13,15 @@ module Referrals
       end
 
       def update
-        @check_answers_form =
+        @form =
           CheckAnswersForm.new(
             referral: current_referral,
             referrer: @referrer,
             complete: referrer_params[:complete]
           )
 
-        if @check_answers_form.save
-          redirect_to @check_answers_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/referrer_details/job_title_controller.rb
+++ b/app/controllers/referrals/referrer_details/job_title_controller.rb
@@ -2,17 +2,16 @@ module Referrals
   module ReferrerDetails
     class JobTitleController < Referrals::BaseController
       def edit
-        @referrer_job_title_form =
-          Referrals::ReferrerDetails::JobTitleForm.new(referral: current_referral)
+        @form = Referrals::ReferrerDetails::JobTitleForm.new(referral: current_referral)
       end
 
       def update
-        @referrer_job_title_form =
+        @form =
           Referrals::ReferrerDetails::JobTitleForm.new(
             job_title_params.merge(referral: current_referral)
           )
-        if @referrer_job_title_form.save
-          redirect_to @referrer_job_title_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/referrer_details/name_controller.rb
+++ b/app/controllers/referrals/referrer_details/name_controller.rb
@@ -2,14 +2,14 @@ module Referrals
   module ReferrerDetails
     class NameController < Referrals::BaseController
       def edit
-        @referrer_name_form = Referrals::ReferrerDetails::NameForm.new(referral: current_referral)
+        @form = Referrals::ReferrerDetails::NameForm.new(referral: current_referral)
       end
 
       def update
-        @referrer_name_form =
+        @form =
           Referrals::ReferrerDetails::NameForm.new(name_params.merge(referral: current_referral))
-        if @referrer_name_form.save
-          redirect_to @referrer_name_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/referrer_details/phone_controller.rb
+++ b/app/controllers/referrals/referrer_details/phone_controller.rb
@@ -2,16 +2,16 @@ module Referrals
   module ReferrerDetails
     class PhoneController < Referrals::BaseController
       def edit
-        @referrer_phone_form = Referrals::ReferrerDetails::PhoneForm.new(referral: current_referral)
+        @form = Referrals::ReferrerDetails::PhoneForm.new(referral: current_referral)
       end
 
       def update
-        @referrer_phone_form =
+        @form =
           Referrals::ReferrerDetails::PhoneForm.new(
             referrer_phone_form_params.merge(referral: current_referral)
           )
-        if @referrer_phone_form.save
-          redirect_to @referrer_phone_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/referrer_organisation/address_controller.rb
+++ b/app/controllers/referrals/referrer_organisation/address_controller.rb
@@ -2,14 +2,13 @@ module Referrals
   module ReferrerOrganisation
     class AddressController < BaseController
       def edit
-        @organisation_address_form = AddressForm.new(referral: current_referral)
+        @form = AddressForm.new(referral: current_referral)
       end
 
       def update
-        @organisation_address_form =
-          AddressForm.new(organisation_address_form_params.merge(referral: current_referral))
-        if @organisation_address_form.save
-          redirect_to @organisation_address_form.next_path
+        @form = AddressForm.new(organisation_address_form_params.merge(referral: current_referral))
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/referrer_organisation/check_answers_controller.rb
+++ b/app/controllers/referrals/referrer_organisation/check_answers_controller.rb
@@ -3,15 +3,14 @@ module Referrals
     class CheckAnswersController < BaseController
       def edit
         @organisation = current_referral.organisation || current_referral.build_organisation
-        @organisation_form =
-          CheckAnswersForm.new(referral: current_referral, complete: @organisation.complete)
+        @form = CheckAnswersForm.new(referral: current_referral, complete: @organisation.complete)
       end
 
       def update
-        @organisation_form =
+        @form =
           CheckAnswersForm.new(complete: organisation_params[:complete], referral: current_referral)
 
-        if @organisation_form.save
+        if @form.save
           redirect_to [:edit, current_referral.routing_scope, current_referral]
         else
           @organisation = current_referral.organisation

--- a/app/controllers/referrals/teacher_contact_details/address_controller.rb
+++ b/app/controllers/referrals/teacher_contact_details/address_controller.rb
@@ -2,8 +2,9 @@ module Referrals
   module TeacherContactDetails
     class AddressController < Referrals::BaseController
       def edit
-        @contact_details_address_form =
+        @form =
           AddressForm.new(
+            referral: current_referral,
             address_line_1: current_referral.address_line_1,
             address_line_2: current_referral.address_line_2,
             town_or_city: current_referral.town_or_city,
@@ -13,10 +14,10 @@ module Referrals
       end
 
       def update
-        @contact_details_address_form =
+        @form =
           AddressForm.new(contact_details_address_form_params.merge(referral: current_referral))
-        if @contact_details_address_form.save
-          redirect_to @contact_details_address_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_contact_details/address_known_controller.rb
+++ b/app/controllers/referrals/teacher_contact_details/address_known_controller.rb
@@ -2,17 +2,20 @@ module Referrals
   module TeacherContactDetails
     class AddressKnownController < Referrals::BaseController
       def edit
-        @contact_details_address_known_form =
-          AddressKnownForm.new(address_known: current_referral.address_known)
+        @form =
+          AddressKnownForm.new(
+            referral: current_referral,
+            address_known: current_referral.address_known
+          )
       end
 
       def update
-        @contact_details_address_known_form =
+        @form =
           AddressKnownForm.new(
             contact_details_address_known_form_params.merge(referral: current_referral)
           )
-        if @contact_details_address_known_form.save
-          redirect_to @contact_details_address_known_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_contact_details/check_answers_controller.rb
+++ b/app/controllers/referrals/teacher_contact_details/check_answers_controller.rb
@@ -2,7 +2,7 @@ module Referrals
   module TeacherContactDetails
     class CheckAnswersController < Referrals::BaseController
       def edit
-        @contact_details_check_answers_form =
+        @form =
           CheckAnswersForm.new(
             referral: current_referral,
             contact_details_complete: current_referral.contact_details_complete
@@ -10,11 +10,11 @@ module Referrals
       end
 
       def update
-        @contact_details_check_answers_form =
+        @form =
           CheckAnswersForm.new(
             contact_details_check_answers_form_params.merge(referral: current_referral)
           )
-        if @contact_details_check_answers_form.save
+        if @form.save
           redirect_to [:edit, current_referral.routing_scope, current_referral]
         else
           render :edit

--- a/app/controllers/referrals/teacher_contact_details/email_controller.rb
+++ b/app/controllers/referrals/teacher_contact_details/email_controller.rb
@@ -2,18 +2,18 @@ module Referrals
   module TeacherContactDetails
     class EmailController < Referrals::BaseController
       def edit
-        @contact_details_email_form =
+        @form =
           EmailForm.new(
+            referral: current_referral,
             email_known: current_referral.email_known,
             email_address: current_referral.email_address
           )
       end
 
       def update
-        @contact_details_email_form =
-          EmailForm.new(contact_details_email_form_params.merge(referral: current_referral))
-        if @contact_details_email_form.save
-          redirect_to @contact_details_email_form.next_path
+        @form = EmailForm.new(contact_details_email_form_params.merge(referral: current_referral))
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_contact_details/telephone_controller.rb
+++ b/app/controllers/referrals/teacher_contact_details/telephone_controller.rb
@@ -2,18 +2,19 @@ module Referrals
   module TeacherContactDetails
     class TelephoneController < Referrals::BaseController
       def edit
-        @contact_details_telephone_form =
+        @form =
           TelephoneForm.new(
+            referral: current_referral,
             phone_known: current_referral.phone_known,
             phone_number: current_referral.phone_number
           )
       end
 
       def update
-        @contact_details_telephone_form =
+        @form =
           TelephoneForm.new(contact_details_telephone_form_params.merge(referral: current_referral))
-        if @contact_details_telephone_form.save
-          redirect_to @contact_details_telephone_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_personal_details/age_controller.rb
+++ b/app/controllers/referrals/teacher_personal_details/age_controller.rb
@@ -2,21 +2,22 @@ module Referrals
   module TeacherPersonalDetails
     class AgeController < Referrals::BaseController
       def edit
-        @personal_details_age_form =
+        @form =
           AgeForm.new(
+            referral: current_referral,
             age_known: current_referral.age_known,
             date_of_birth: current_referral.date_of_birth
           )
       end
 
       def update
-        @personal_details_age_form =
+        @form =
           AgeForm.new(
             age_params.merge(date_params: date_of_birth_params, referral: current_referral)
           )
 
-        if @personal_details_age_form.save
-          redirect_to @personal_details_age_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_personal_details/check_answers_controller.rb
+++ b/app/controllers/referrals/teacher_personal_details/check_answers_controller.rb
@@ -2,7 +2,7 @@ module Referrals
   module TeacherPersonalDetails
     class CheckAnswersController < Referrals::BaseController
       def edit
-        @personal_details_check_answers_form =
+        @form =
           CheckAnswersForm.new(
             referral: current_referral,
             personal_details_complete: current_referral.personal_details_complete
@@ -10,11 +10,10 @@ module Referrals
       end
 
       def update
-        @personal_details_check_answers_form =
-          CheckAnswersForm.new(check_answers_params.merge(referral: current_referral))
+        @form = CheckAnswersForm.new(check_answers_params.merge(referral: current_referral))
 
-        if @personal_details_check_answers_form.save
-          redirect_to @personal_details_check_answers_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_personal_details/name_controller.rb
+++ b/app/controllers/referrals/teacher_personal_details/name_controller.rb
@@ -2,8 +2,9 @@ module Referrals
   module TeacherPersonalDetails
     class NameController < Referrals::BaseController
       def edit
-        @personal_details_name_form =
+        @form =
           NameForm.new(
+            referral: current_referral,
             first_name: current_referral.first_name,
             last_name: current_referral.last_name,
             name_has_changed: current_referral.name_has_changed,
@@ -12,10 +13,10 @@ module Referrals
       end
 
       def update
-        @personal_details_name_form = NameForm.new(name_params.merge(referral: current_referral))
+        @form = NameForm.new(name_params.merge(referral: current_referral))
 
-        if @personal_details_name_form.save
-          redirect_to @personal_details_name_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_personal_details/ni_number_controller.rb
+++ b/app/controllers/referrals/teacher_personal_details/ni_number_controller.rb
@@ -2,17 +2,18 @@ module Referrals
   module TeacherPersonalDetails
     class NiNumberController < Referrals::BaseController
       def edit
-        @ni_number_form =
+        @form =
           NiNumberForm.new(
+            referral: current_referral,
             ni_number: current_referral.ni_number,
             ni_number_known: current_referral.ni_number_known
           )
       end
 
       def update
-        @ni_number_form = NiNumberForm.new(ni_number_form_params.merge(referral: current_referral))
-        if @ni_number_form.save
-          redirect_to @ni_number_form.next_path
+        @form = NiNumberForm.new(ni_number_form_params.merge(referral: current_referral))
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_personal_details/qts_controller.rb
+++ b/app/controllers/referrals/teacher_personal_details/qts_controller.rb
@@ -2,14 +2,14 @@ module Referrals
   module TeacherPersonalDetails
     class QtsController < Referrals::BaseController
       def edit
-        @personal_details_qts_form = QtsForm.new(has_qts: current_referral.has_qts)
+        @form = QtsForm.new(referral: current_referral, has_qts: current_referral.has_qts)
       end
 
       def update
-        @personal_details_qts_form = QtsForm.new(qts_params.merge(referral: current_referral))
+        @form = QtsForm.new(qts_params.merge(referral: current_referral))
 
-        if @personal_details_qts_form.save
-          redirect_to @personal_details_qts_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_personal_details/trn_controller.rb
+++ b/app/controllers/referrals/teacher_personal_details/trn_controller.rb
@@ -2,15 +2,19 @@ module Referrals
   module TeacherPersonalDetails
     class TrnController < Referrals::BaseController
       def edit
-        @personal_details_trn_form =
-          TrnForm.new(trn: current_referral.trn, trn_known: current_referral.trn_known)
+        @form =
+          TrnForm.new(
+            referral: current_referral,
+            trn: current_referral.trn,
+            trn_known: current_referral.trn_known
+          )
       end
 
       def update
-        @personal_details_trn_form = TrnForm.new(trn_params.merge(referral: current_referral))
+        @form = TrnForm.new(trn_params.merge(referral: current_referral))
 
-        if @personal_details_trn_form.save
-          redirect_to @personal_details_trn_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/check_answers_controller.rb
+++ b/app/controllers/referrals/teacher_role/check_answers_controller.rb
@@ -2,7 +2,7 @@ module Referrals
   module TeacherRole
     class CheckAnswersController < Referrals::BaseController
       def edit
-        @teacher_role_check_answers_form =
+        @form =
           CheckAnswersForm.new(
             referral: current_referral,
             teacher_role_complete: current_referral.teacher_role_complete
@@ -10,12 +10,12 @@ module Referrals
       end
 
       def update
-        @teacher_role_check_answers_form =
+        @form =
           CheckAnswersForm.new(
             teacher_role_check_answers_form_params.merge(referral: current_referral)
           )
-        if @teacher_role_check_answers_form.save
-          redirect_to @teacher_role_check_answers_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/duties_controller.rb
+++ b/app/controllers/referrals/teacher_role/duties_controller.rb
@@ -2,8 +2,9 @@ module Referrals
   module TeacherRole
     class DutiesController < Referrals::BaseController
       def edit
-        @duties_form =
+        @form =
           DutiesForm.new(
+            referral: current_referral,
             duties_details: current_referral.duties_details,
             duties_format: current_referral.duties_format,
             duties_upload_file: current_referral.duties_upload_file
@@ -11,10 +12,10 @@ module Referrals
       end
 
       def update
-        @duties_form = DutiesForm.new(duties_params.merge(referral: current_referral))
+        @form = DutiesForm.new(duties_params.merge(referral: current_referral))
 
-        if @duties_form.save
-          redirect_to @duties_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/employment_status_controller.rb
+++ b/app/controllers/referrals/teacher_role/employment_status_controller.rb
@@ -2,16 +2,18 @@ module Referrals
   module TeacherRole
     class EmploymentStatusController < Referrals::BaseController
       def edit
-        @employment_status_form =
-          EmploymentStatusForm.new(employment_status: current_referral.employment_status)
+        @form =
+          EmploymentStatusForm.new(
+            referral: current_referral,
+            employment_status: current_referral.employment_status
+          )
       end
 
       def update
-        @employment_status_form =
-          EmploymentStatusForm.new(employment_status_params.merge(referral: current_referral))
+        @form = EmploymentStatusForm.new(employment_status_params.merge(referral: current_referral))
 
-        if @employment_status_form.save
-          redirect_to @employment_status_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/end_date_controller.rb
+++ b/app/controllers/referrals/teacher_role/end_date_controller.rb
@@ -2,21 +2,22 @@ module Referrals
   module TeacherRole
     class EndDateController < Referrals::BaseController
       def edit
-        @role_end_date_form =
+        @form =
           EndDateForm.new(
+            referral: current_referral,
             role_end_date_known: current_referral.role_end_date_known,
             role_end_date: current_referral.role_end_date
           )
       end
 
       def update
-        @role_end_date_form =
+        @form =
           EndDateForm.new(
             role_params.merge(date_params: end_date_params, referral: current_referral)
           )
 
-        if @role_end_date_form.save
-          redirect_to @role_end_date_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/job_title_controller.rb
+++ b/app/controllers/referrals/teacher_role/job_title_controller.rb
@@ -2,14 +2,14 @@ module Referrals
   module TeacherRole
     class JobTitleController < Referrals::BaseController
       def edit
-        @job_title_form = JobTitleForm.new(job_title: current_referral.job_title)
+        @form = JobTitleForm.new(referral: current_referral, job_title: current_referral.job_title)
       end
 
       def update
-        @job_title_form = JobTitleForm.new(job_title_params.merge(referral: current_referral))
+        @form = JobTitleForm.new(job_title_params.merge(referral: current_referral))
 
-        if @job_title_form.save
-          redirect_to @job_title_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/organisation_address_controller.rb
+++ b/app/controllers/referrals/teacher_role/organisation_address_controller.rb
@@ -2,8 +2,9 @@ module Referrals
   module TeacherRole
     class OrganisationAddressController < Referrals::BaseController
       def edit
-        @organisation_address_form =
+        @form =
           OrganisationAddressForm.new(
+            referral: current_referral,
             organisation_name: current_referral.organisation_name,
             organisation_address_line_1: current_referral.organisation_address_line_1,
             organisation_address_line_2: current_referral.organisation_address_line_2,
@@ -13,11 +14,11 @@ module Referrals
       end
 
       def update
-        @organisation_address_form =
+        @form =
           OrganisationAddressForm.new(organisation_address_params.merge(referral: current_referral))
 
-        if @organisation_address_form.save
-          redirect_to @organisation_address_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/organisation_address_known_controller.rb
+++ b/app/controllers/referrals/teacher_role/organisation_address_known_controller.rb
@@ -2,20 +2,21 @@ module Referrals
   module TeacherRole
     class OrganisationAddressKnownController < Referrals::BaseController
       def edit
-        @organisation_address_known_form =
+        @form =
           OrganisationAddressKnownForm.new(
+            referral: current_referral,
             organisation_address_known: current_referral.organisation_address_known
           )
       end
 
       def update
-        @organisation_address_known_form =
+        @form =
           OrganisationAddressKnownForm.new(
             organisation_address_known_params.merge(referral: current_referral)
           )
 
-        if @organisation_address_known_form.save
-          redirect_to @organisation_address_known_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/reason_leaving_role_controller.rb
+++ b/app/controllers/referrals/teacher_role/reason_leaving_role_controller.rb
@@ -2,16 +2,19 @@ module Referrals
   module TeacherRole
     class ReasonLeavingRoleController < Referrals::BaseController
       def edit
-        @reason_leaving_role_form =
-          ReasonLeavingRoleForm.new(reason_leaving_role: current_referral.reason_leaving_role)
+        @form =
+          ReasonLeavingRoleForm.new(
+            referral: current_referral,
+            reason_leaving_role: current_referral.reason_leaving_role
+          )
       end
 
       def update
-        @reason_leaving_role_form =
+        @form =
           ReasonLeavingRoleForm.new(reason_leaving_role_params.merge(referral: current_referral))
 
-        if @reason_leaving_role_form.save
-          redirect_to @reason_leaving_role_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/same_organisation_controller.rb
+++ b/app/controllers/referrals/teacher_role/same_organisation_controller.rb
@@ -2,16 +2,18 @@ module Referrals
   module TeacherRole
     class SameOrganisationController < Referrals::BaseController
       def edit
-        @same_organisation_form =
-          SameOrganisationForm.new(same_organisation: current_referral.same_organisation)
+        @form =
+          SameOrganisationForm.new(
+            referral: current_referral,
+            same_organisation: current_referral.same_organisation
+          )
       end
 
       def update
-        @same_organisation_form =
-          SameOrganisationForm.new(same_organisation_params.merge(referral: current_referral))
+        @form = SameOrganisationForm.new(same_organisation_params.merge(referral: current_referral))
 
-        if @same_organisation_form.save
-          redirect_to @same_organisation_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/start_date_controller.rb
+++ b/app/controllers/referrals/teacher_role/start_date_controller.rb
@@ -2,21 +2,22 @@ module Referrals
   module TeacherRole
     class StartDateController < Referrals::BaseController
       def edit
-        @role_start_date_form =
+        @form =
           StartDateForm.new(
+            referral: current_referral,
             role_start_date_known: current_referral.role_start_date_known,
             role_start_date: current_referral.role_start_date
           )
       end
 
       def update
-        @role_start_date_form =
+        @form =
           StartDateForm.new(
             role_params.merge(date_params: start_date_params, referral: current_referral)
           )
 
-        if @role_start_date_form.save
-          redirect_to @role_start_date_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/work_location_controller.rb
+++ b/app/controllers/referrals/teacher_role/work_location_controller.rb
@@ -2,8 +2,9 @@ module Referrals
   module TeacherRole
     class WorkLocationController < Referrals::BaseController
       def edit
-        @work_location_form =
+        @form =
           WorkLocationForm.new(
+            referral: current_referral,
             work_organisation_name: current_referral.work_organisation_name,
             work_address_line_1: current_referral.work_address_line_1,
             work_address_line_2: current_referral.work_address_line_2,
@@ -13,11 +14,10 @@ module Referrals
       end
 
       def update
-        @work_location_form =
-          WorkLocationForm.new(work_location_params.merge(referral: current_referral))
+        @form = WorkLocationForm.new(work_location_params.merge(referral: current_referral))
 
-        if @work_location_form.save
-          redirect_to @work_location_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/work_location_known_controller.rb
+++ b/app/controllers/referrals/teacher_role/work_location_known_controller.rb
@@ -2,16 +2,19 @@ module Referrals
   module TeacherRole
     class WorkLocationKnownController < Referrals::BaseController
       def edit
-        @work_location_known_form =
-          WorkLocationKnownForm.new(work_location_known: current_referral.work_location_known)
+        @form =
+          WorkLocationKnownForm.new(
+            referral: current_referral,
+            work_location_known: current_referral.work_location_known
+          )
       end
 
       def update
-        @work_location_known_form =
+        @form =
           WorkLocationKnownForm.new(work_location_known_params.merge(referral: current_referral))
 
-        if @work_location_known_form.save
-          redirect_to @work_location_known_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/controllers/referrals/teacher_role/working_somewhere_else_controller.rb
+++ b/app/controllers/referrals/teacher_role/working_somewhere_else_controller.rb
@@ -2,20 +2,21 @@ module Referrals
   module TeacherRole
     class WorkingSomewhereElseController < Referrals::BaseController
       def edit
-        @working_somewhere_else_form =
+        @form =
           WorkingSomewhereElseForm.new(
+            referral: current_referral,
             working_somewhere_else: current_referral.working_somewhere_else
           )
       end
 
       def update
-        @working_somewhere_else_form =
+        @form =
           WorkingSomewhereElseForm.new(
             working_somewhere_else_params.merge(referral: current_referral)
           )
 
-        if @working_somewhere_else_form.save
-          redirect_to @working_somewhere_else_form.next_path
+        if @form.save
+          redirect_to @form.next_path
         else
           render :edit
         end

--- a/app/forms/referrals/form_item.rb
+++ b/app/forms/referrals/form_item.rb
@@ -9,9 +9,7 @@ module Referrals
 
     validates :referral, presence: true
 
-    def slug
-      self.class.to_s.split("::")[1..].join.remove("Form").underscore.to_sym
-    end
+    delegate :label, to: :section, prefix: true
 
     def complete?
       valid_without_tracking?
@@ -22,7 +20,15 @@ module Referrals
     end
 
     def path
-      [:edit, referral.routing_scope, referral, slug.to_sym]
+      [:edit, referral.routing_scope, referral, section.slug, slug]
+    end
+
+    def edit_path
+      [:edit, referral.routing_scope, referral]
+    end
+
+    def form_path
+      [referral.routing_scope, referral, section.slug, slug]
     end
 
     def section
@@ -30,13 +36,40 @@ module Referrals
     end
 
     def next_path
-      check_answers? ? [:edit, referral.routing_scope, referral] : section.next_path
+      check_answers? ? edit_path : section.next_path
+    end
+
+    def previous_path
+      check_answers? || first? ? edit_path : section.previous_path
+    end
+
+    def first?
+      section.items.first == self
     end
 
     def check_answers?
       self.class.to_s.include? "CheckAnswers"
     end
 
+    def label
+      I18n.t("referral_form.forms.#{section.slug}.#{slug}")
+    end
+
+    def page_title
+      if check_answers?
+        "Check and confirm your answers - #{section_label}"
+      else
+        "#{"Error: " if errors.any?}#{label} - #{section_label}"
+      end
+    end
+
+    # Turns a class name like module Referrals::ReferrerDetails::NameForm into a slug like :name
+    def slug
+      self.class.to_s.split("::").last.remove("Form").underscore.to_sym
+    end
+
+    # Turns a class name like module Referrals::ReferrerDetails::NameForm into a section class
+    # like Referrals::Sections::ReferrerDetailsSection
     def section_class
       class_name = "Referrals::Sections::#{self.class.to_s.split("::").second}Section"
       class_name.constantize

--- a/app/forms/referrals/section.rb
+++ b/app/forms/referrals/section.rb
@@ -27,7 +27,7 @@ module Referrals
     end
 
     def label
-      I18n.t("referral_form.#{slug}")
+      I18n.t("referral_form.sections.#{slug}")
     end
 
     def error_id
@@ -48,6 +48,10 @@ module Referrals
 
     def next_path
       items.find(&:incomplete?)&.path || path
+    end
+
+    def previous_path
+      items.reverse.find(&:complete?)&.path || [:edit, referral.routing_scope, referral]
     end
 
     def status

--- a/app/forms/referrals/section_group.rb
+++ b/app/forms/referrals/section_group.rb
@@ -8,7 +8,7 @@ module Referrals
     alias_method :sections, :items
 
     def label
-      I18n.t("referral_form.#{slug}")
+      I18n.t("referral_form.section_groups.#{slug}")
     end
 
     def complete?

--- a/app/views/public_referrals/allegation_details/check_answers/edit.html.erb
+++ b/app/views/public_referrals/allegation_details/check_answers/edit.html.erb
@@ -1,12 +1,12 @@
-<% content_for :page_title, "#{'Error: ' if @allegation_check_answers_form.errors.any?}Check and confirm your answers" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @allegation_check_answers_form, url: public_referral_allegation_details_check_answers_path(current_referral), method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">The allegation</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
 
       <h1 class="govuk-heading-l">Check and confirm your answers</h1>
 

--- a/app/views/public_referrals/allegation_details/considerations/edit.html.erb
+++ b/app/views/public_referrals/allegation_details/considerations/edit.html.erb
@@ -1,12 +1,12 @@
-<% content_for :page_title, "#{'Error: ' if @allegation_considerations_form.errors.any?}How this complaint has been considered" %>
-<% content_for :back_link_url, edit_public_referral_path(current_referral) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @allegation_considerations_form, url: public_referral_allegation_details_considerations_path(current_referral), method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
-      <span class="govuk-caption-l">The allegation</span>
-      <h1 class="govuk-heading-l">How this complaint has been considered</h1>
+      <span class="govuk-caption-l"><%= section_label %></span>
+      <h1 class="govuk-heading-l"><%= form_label %></h1>
       <p>Include details about:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>the local procedures you followed, for example if you made a complaint to the headteacher, local authority or police</li>

--- a/app/views/public_referrals/allegation_evidence/check_answers/edit.html.erb
+++ b/app/views/public_referrals/allegation_evidence/check_answers/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{'Error: ' if @evidence_check_answers_form.errors.any?}Check and confirm your answers - Evidence and supporting information" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @evidence_check_answers_form, url: public_referral_allegation_evidence_check_answers_path(current_referral), method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">Evidence and supporting information</span>
+        <span class="govuk-caption-l"><%= section_label %></span>
         Check and confirm your answers
       </h1>
 

--- a/app/views/public_referrals/allegation_evidence/start/edit.html.erb
+++ b/app/views/public_referrals/allegation_evidence/start/edit.html.erb
@@ -1,14 +1,12 @@
-<% content_for :page_title, "#{'Error: ' if @evidence_start_form.errors.any?}Evidence and supporting information" %>
-<% content_for :back_link_url, edit_public_referral_path(current_referral) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">
-    <%= form_with model: @evidence_start_form, url: public_referral_allegation_evidence_start_path(current_referral), method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">
-        Evidence and supporting information
-      </h1>
+      <h1 class="govuk-heading-l"><%= section_label %></h1>
 
       <p>For example:</p>
 

--- a/app/views/public_referrals/allegation_evidence/upload/edit.html.erb
+++ b/app/views/public_referrals/allegation_evidence/upload/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{'Error: ' if @evidence_upload_form.errors.any?}Upload evidence and supporting information" %>
-<% content_for :back_link_url, edit_public_referral_allegation_evidence_start_path(current_referral) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">
-    <%= form_with model: @evidence_upload_form, url: public_referral_allegation_evidence_upload_path(current_referral), method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Evidence and supporting information</span>
-      <h1 class="govuk-heading-l">Upload evidence</h1>
+      <span class="govuk-caption-l"><%= section_label %></span>
+      <h1 class="govuk-heading-l"><%= form_label %></h1>
 
       <p>For example:</p>
 

--- a/app/views/public_referrals/allegation_evidence/uploaded/edit.html.erb
+++ b/app/views/public_referrals/allegation_evidence/uploaded/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "Uploaded evidence" %>
-<% content_for :back_link_url, edit_public_referral_allegation_evidence_upload_path(current_referral) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop ">
-    <%= form_with model: @uploaded_form, url: public_referral_allegation_evidence_uploaded_path(current_referral), method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Evidence and supporting information</span>
-      <h1 class="govuk-heading-l">Uploaded evidence</h1>
+      <span class="govuk-caption-l"><%= section_label %></span>
+      <h1 class="govuk-heading-l"><%= form_label %></h1>
 
       <h2 class="govuk-heading-m">Files added</h2>
 

--- a/app/views/public_referrals/referrer_details/personal_details.html.erb
+++ b/app/views/public_referrals/referrer_details/personal_details.html.erb
@@ -1,10 +1,10 @@
-<% content_for :page_title, "How your personal details will be used" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <span class="govuk-caption-l">Your details</span>
-    <h1 class="govuk-heading-l">How your personal details will be&nbsp;used</h1>
+    <span class="govuk-caption-l"><%= section_label %></span>
+    <h1 class="govuk-heading-l"><%= form_label %></h1>
     <p>If your case is investigated, your name will be shared with the teacher you’re referring and their employer. The teacher has a right to know who referred them.</p>
     <p>Your contact details will not be shared. These will only be used to contact you about this case.</p>
     <%= govuk_button_link_to "Continue", polymorphic_path([:edit, current_referral.routing_scope, current_referral, :referrer_details, :name]) %>

--- a/app/views/referrals/allegation_details/check_answers/edit.html.erb
+++ b/app/views/referrals/allegation_details/check_answers/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{'Error: ' if @allegation_check_answers_form.errors.any?}Check and confirm your answers - The allegation" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @allegation_check_answers_form, url: [current_referral.routing_scope, current_referral, :allegation_details, :check_answers], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">The allegation</span>
+        <span class="govuk-caption-l"><%= section_label %></span>
         Check and confirm your answers
       </h1>
 

--- a/app/views/referrals/allegation_details/dbs/edit.html.erb
+++ b/app/views/referrals/allegation_details/dbs/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{'Error: ' if @allegation_dbs_form.errors.any?}Telling DBS about this case - The allegation" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :allegation_details, :details]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @allegation_dbs_form, url: [current_referral.routing_scope, current_referral, :allegation_details_dbs], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">The allegation</span>
-      <h1 class="govuk-heading-l">Telling DBS about this case</h1>
+      <span class="govuk-caption-l"><%= section_label %></span>
+      <h1 class="govuk-heading-l"><%= form_label %></h1>
 
       <p>DBS (Disclosure and Barring Service) need to know about any allegations that involve harm to a child, or the risk of harm to a child.</p>
 

--- a/app/views/referrals/allegation_details/details/edit.html.erb
+++ b/app/views/referrals/allegation_details/details/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @allegation_details_form.errors.any?}How do you want to give details about the allegation? - The allegation" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @allegation_details_form, url: [current_referral.routing_scope, current_referral, :allegation_details, :details], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">The allegation</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <div class="govuk-form-group">
-        <%= f.govuk_radio_buttons_fieldset(:allegation_format, legend: { size: "l", text: "How do you want to give details about the allegation?", tag: 'h1' }) do %>
+        <%= f.govuk_radio_buttons_fieldset(:allegation_format, legend: { size: "l", text: form_label, tag: 'h1' }) do %>
           <%= f.govuk_radio_button :allegation_format, "upload", label: { text: "Upload file" }, link_errors: true do %>
             <% if current_referral.allegation_upload %>
               <div class="app-uploaded-file">

--- a/app/views/referrals/allegation_evidence/check_answers/delete.html.erb
+++ b/app/views/referrals/allegation_evidence/check_answers/delete.html.erb
@@ -1,10 +1,10 @@
-<% content_for :page_title, "Are you sure you want to delete #{evidence.file.filename} - Evidence and supporting information" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :allegation_evidence_uploaded]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l">Evidence and supporting information</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       Confirm that you want to delete <%= evidence.file.filename %>?
     </h1>
 

--- a/app/views/referrals/allegation_evidence/check_answers/edit.html.erb
+++ b/app/views/referrals/allegation_evidence/check_answers/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{'Error: ' if @evidence_check_answers_form.errors.any?}Check and confirm your answers - Evidence and supporting information" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @evidence_check_answers_form, url: [current_referral.routing_scope, current_referral, :allegation_evidence, :check_answers], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">Evidence and supporting information</span>
+        <span class="govuk-caption-l"><%= section_label %></span>
         Check and confirm your answers
       </h1>
 

--- a/app/views/referrals/allegation_evidence/start/edit.html.erb
+++ b/app/views/referrals/allegation_evidence/start/edit.html.erb
@@ -1,14 +1,12 @@
-<% content_for :page_title, "#{'Error: ' if @evidence_start_form.errors.any?}Evidence and supporting information" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @evidence_start_form, url: referral_allegation_evidence_start_path(current_referral), method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">
-        Evidence and supporting information
-      </h1>
+      <h1 class="govuk-heading-l"><%= section_label %></h1>
 
       <p>For example:</p>
 

--- a/app/views/referrals/allegation_evidence/upload/edit.html.erb
+++ b/app/views/referrals/allegation_evidence/upload/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{'Error: ' if @evidence_upload_form.errors.any?}Upload evidence and supporting information" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :allegation_evidence_start]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @evidence_upload_form, url: referral_allegation_evidence_upload_path(current_referral), method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Evidence and supporting information</span>
-      <h1 class="govuk-heading-l">Upload evidence</h1>
+      <span class="govuk-caption-l"><%= section_label %></span>
+      <h1 class="govuk-heading-l"><%= form_label %></h1>
 
       <p>For example:</p>
 

--- a/app/views/referrals/allegation_evidence/uploaded/edit.html.erb
+++ b/app/views/referrals/allegation_evidence/uploaded/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "Uploaded evidence - Evidence and supporting information" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :allegation_evidence_upload]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @uploaded_form, url: referral_allegation_evidence_uploaded_path(current_referral), method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Evidence and supporting information</span>
-      <h1 class="govuk-heading-l">Uploaded evidence</h1>
+      <span class="govuk-caption-l"><%= section_label %></span>
+      <h1 class="govuk-heading-l"><%= form_label %></h1>
 
       <h2 class="govuk-heading-m">Files added</h2>
 

--- a/app/views/referrals/allegation_previous_misconduct/check_answers/edit.html.erb
+++ b/app/views/referrals/allegation_previous_misconduct/check_answers/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "Check and confirm your answers - Previous allegations" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @previous_misconduct_check_answers_form, url: [current_referral.routing_scope, current_referral, :allegation_previous_misconduct, :check_answers], method: :patch do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">Previous allegations</span>
+        <span class="govuk-caption-l"><%= section_label %></span>
         Check and confirm your answers
       </h1>
 

--- a/app/views/referrals/allegation_previous_misconduct/detailed_account/edit.html.erb
+++ b/app/views/referrals/allegation_previous_misconduct/detailed_account/edit.html.erb
@@ -1,12 +1,12 @@
-<% content_for :page_title, "#{'Error: ' if @detailed_account_form.errors.any?}Give a detailed account of previous allegations - Previous allegations" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :allegation_previous_misconduct_reported]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @detailed_account_form, url: [current_referral.routing_scope, current_referral, :allegation_previous_misconduct, :detailed_account], method: :patch do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
-      <span class="govuk-caption-l">Previous allegations</span>
-      <h1 class="govuk-heading-l">Detailed account of previous allegations</h1>
+      <span class="govuk-caption-l"><%= section_label %></span>
+      <h1 class="govuk-heading-l"><%= form_label %></h1>
       <p class="govuk-body">Provide details of:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>dates and locations</li>

--- a/app/views/referrals/allegation_previous_misconduct/reported/edit.html.erb
+++ b/app/views/referrals/allegation_previous_misconduct/reported/edit.html.erb
@@ -1,12 +1,12 @@
-<% content_for :page_title, "#{'Error: ' if @reported_form.errors.any?}Has there been any previous misconduct, disciplinary action or complaints? - Previous allegations" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, "#{'Error: ' if @form.errors.any?}Has there been any previous misconduct, disciplinary action or complaints? - Previous allegations" %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reported_form, url: [current_referral.routing_scope, current_referral, :allegation_previous_misconduct_reported], method: :patch do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">Previous allegations</h1>
+      <h1 class="govuk-heading-l"><%= section_label %></h1>
 
       <p class="govuk-body">This includes:</p>
 

--- a/app/views/referrals/referrer_details/check_answers/edit.html.erb
+++ b/app/views/referrals/referrer_details/check_answers/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "Check and confirm your answers - Your details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @check_answers_form, url: [current_referral.routing_scope, current_referral, :referrer_details, :check_answers], method: :patch do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">Your details</span>
+        <span class="govuk-caption-l"><%= section_label %></span>
         Check and confirm your answers
       </h1>
 

--- a/app/views/referrals/referrer_details/job_title/edit.html.erb
+++ b/app/views/referrals/referrer_details/job_title/edit.html.erb
@@ -1,12 +1,12 @@
-<% content_for :page_title, "#{'Error: ' if @referrer_job_title_form.errors.any?}Your job title - Your details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :referrer_details, :name]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @referrer_job_title_form, url: [current_referral.routing_scope, current_referral, :referrer_details_job_title], method: :patch do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Your details</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <%= f.govuk_text_field :job_title, label: { tag: 'h1', size: 'l', text: "Your job title" }, hint: { text: 'For example, ‘Headteacher’' } %>
       <%= f.govuk_submit 'Save and continue' %>
     <% end %>

--- a/app/views/referrals/referrer_details/name/edit.html.erb
+++ b/app/views/referrals/referrer_details/name/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{'Error: ' if @referrer_name_form.errors.any?}Your name - Your details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @referrer_name_form, url: [current_referral.routing_scope, current_referral, :referrer_details, :name], method: :patch do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Your details</span>
-      <h1 class="govuk-heading-l">Your name</h1>
+      <span class="govuk-caption-l"><%= section_label %></span>
+      <h1 class="govuk-heading-l"><%= form_label %></h1>
 
       <%= f.govuk_text_field :first_name, label: { size: 'm', text: "First name" }, hint: { text: "Or given name" } %>
       <%= f.govuk_text_field :last_name, label: { size: 'm', text: "Last name" }, hint: { text: "Or family name" } %>

--- a/app/views/referrals/referrer_details/phone/edit.html.erb
+++ b/app/views/referrals/referrer_details/phone/edit.html.erb
@@ -1,12 +1,12 @@
-<% content_for :page_title, "#{'Error: ' if @referrer_phone_form.errors.any?}Your phone number - Your details" %>
-<% content_for :back_link_url, previous_path %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @referrer_phone_form, url: [current_referral.routing_scope, current_referral, :referrer_details, :phone], method: :patch do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Your details</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <%= f.govuk_text_field :phone, type: :tel, autocomplete: :tel, label: { tag: 'h1', size: 'l', text: "Your phone number" }, hint: { text: 'It’ll only be used to contact you about your referral' }, class: 'govuk-input--width-20' %>
       <%= f.govuk_submit 'Save and continue' %>
     <% end %>

--- a/app/views/referrals/referrer_organisation/address/edit.html.erb
+++ b/app/views/referrals/referrer_organisation/address/edit.html.erb
@@ -1,12 +1,12 @@
-<% content_for :page_title, "#{'Error: ' if @organisation_address_form.errors.any?}Your organisation" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @organisation_address_form, url: [current_referral.routing_scope, current_referral, :referrer_organisation_address], method: :patch do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">Your organisation</h1>
+      <h1 class="govuk-heading-l"><%= section_label %></h1>
 
       <%= f.govuk_text_field :name, label: { size: "m", text: "Organisation name" } %>
       <%= f.govuk_text_field :street_1, autocomplete: "address-line1", label: { size: "m", text: "Address line 1" } %>

--- a/app/views/referrals/referrer_organisation/check_answers/edit.html.erb
+++ b/app/views/referrals/referrer_organisation/check_answers/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "Check and confirm your answers - Your organisation" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @organisation_form, url: referral_referrer_organisation_check_answers_path(current_referral), method: :patch do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">Your organisation</span>
+        <span class="govuk-caption-l"><%= section_label %></span>
         Check and confirm your answers
       </h1>
 

--- a/app/views/referrals/teacher_contact_details/address/edit.html.erb
+++ b/app/views/referrals/teacher_contact_details/address/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{"Error: " if @contact_details_address_form.errors.any?}Their home address - Contact details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_contact_details_address_known]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_address_form, url: [current_referral.routing_scope, current_referral, :teacher_contact_details_address], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Contact details</span>
-      <h1 class="govuk-heading-l">Their home address</h1>
+      <span class="govuk-caption-l"><%= section_label %></span>
+      <h1 class="govuk-heading-l"><%= form_label %></h1>
 
       <%= f.govuk_text_field :address_line_1, label: { size: 'm', text: "Address line 1" } %>
       <%= f.govuk_text_field :address_line_2, label: { size: 'm', text: "Address line 2 (optional)" } %>

--- a/app/views/referrals/teacher_contact_details/address_known/edit.html.erb
+++ b/app/views/referrals/teacher_contact_details/address_known/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{"Error: " if @contact_details_address_known_form.errors.any?}Do you know their home address? - Contact details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_contact_details_telephone]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_address_known_form, url: [current_referral.routing_scope, current_referral, :teacher_contact_details_address_known], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Contact details</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
 
-      <%= f.govuk_radio_buttons_fieldset :address_known, legend: { tag: 'h1', size: 'l', text: "Do you know their home address?" }  do %>
+      <%= f.govuk_radio_buttons_fieldset :address_known, legend: { tag: 'h1', size: 'l', text: form_label }  do %>
         <%= f.hidden_field :address_known %>
         <%= f.govuk_radio_button :address_known, true, label: { text: "Yes" }, link_errors: true do %>
         <% end %>

--- a/app/views/referrals/teacher_contact_details/check_answers/edit.html.erb
+++ b/app/views/referrals/teacher_contact_details/check_answers/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{"Error: " if @contact_details_check_answers_form.errors.any?}Check and confirm your answers - Contact details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_check_answers_form, url: [current_referral.routing_scope, current_referral, :teacher_contact_details, :check_answers], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">Contact details</span>
+        <span class="govuk-caption-l"><%= section_label %></span>
         Check and confirm your answers
       </h1>
 

--- a/app/views/referrals/teacher_contact_details/email/edit.html.erb
+++ b/app/views/referrals/teacher_contact_details/email/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{"Error: " if @contact_details_email_form.errors.any?}Do you know their email address? - Contact details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_email_form, url: referral_teacher_contact_details_email_url, method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Contact details</span>
-      <%= f.govuk_radio_buttons_fieldset :email_known, legend: { tag: 'h1', size: 'l', text: "Do you know their email address?" }  do %>
+      <span class="govuk-caption-l"><%= section_label %></span>
+      <%= f.govuk_radio_buttons_fieldset :email_known, legend: { tag: 'h1', size: 'l', text: form_label }  do %>
         <%= f.hidden_field :email_known %>
         <%= f.govuk_radio_button :email_known, true, label: { text: "Yes" }, link_errors: true do %>
           <%= f.govuk_text_field :email_address, label: { text: "Email address", size: 's' } %>

--- a/app/views/referrals/teacher_contact_details/telephone/edit.html.erb
+++ b/app/views/referrals/teacher_contact_details/telephone/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{"Error: " if @contact_details_telephone_form.errors.any?}Do you know their phone number? - Contact details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_contact_details_email]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_telephone_form, url: [current_referral.routing_scope, current_referral, :teacher_contact_details_telephone], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Contact details</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
 
-      <%= f.govuk_radio_buttons_fieldset :phone_known, legend: { tag: 'h1', size: "l", text: "Do you know their phone number?" }  do %>
+      <%= f.govuk_radio_buttons_fieldset :phone_known, legend: { tag: 'h1', size: "l", text: form_label }  do %>
         <%= f.hidden_field :phone_known %>
         <%= f.govuk_radio_button :phone_known, true, label: { text: "Yes" }, link_errors: true do %>
           <%= f.govuk_text_field :phone_number, type: :tel, label: { text: "Phone number", size: 's' } %>

--- a/app/views/referrals/teacher_personal_details/age/edit.html.erb
+++ b/app/views/referrals/teacher_personal_details/age/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @personal_details_age_form.errors.any?}Do you know their date of birth? - Personal details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_personal_details_name]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @personal_details_age_form, url: [current_referral.routing_scope, current_referral, :teacher_personal_details_age], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Personal details</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <div class="govuk-form-group">
-        <%= f.govuk_radio_buttons_fieldset(:age_known, legend: { size: "l", text: "Do you know their date of birth?" }) do %>
+        <%= f.govuk_radio_buttons_fieldset(:age_known, legend: { size: "l", text: form_label }) do %>
           <%= f.govuk_radio_button :age_known, "true", label: { text: "Yes" }, link_errors: true do %>
             <%= f.govuk_date_field :date_of_birth,
                 date_of_birth: true,

--- a/app/views/referrals/teacher_personal_details/check_answers/edit.html.erb
+++ b/app/views/referrals/teacher_personal_details/check_answers/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{'Error: ' if @personal_details_check_answers_form.errors.any?}Check and confirm your answers - Personal details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @personal_details_check_answers_form, url: [current_referral.routing_scope, current_referral, :teacher_personal_details, :check_answers], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">Personal details</span>
+        <span class="govuk-caption-l"><%= section_label %></span>
         Check and confirm your answers
       </h1>
 

--- a/app/views/referrals/teacher_personal_details/name/edit.html.erb
+++ b/app/views/referrals/teacher_personal_details/name/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{'Error: ' if @personal_details_name_form.errors.any?}What is the name of the person you’re referring? - Personal details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @personal_details_name_form, url: [current_referral.routing_scope, current_referral, :teacher_personal_details, :name], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Personal details</span>
-      <h1 class="govuk-heading-l">Their name</h1>
+      <span class="govuk-caption-l"><%= section_label %></span>
+      <h1 class="govuk-heading-l"><%= form_label %></h1>
       <p class="govuk-!-padding-bottom-6">This information is required by law. It’ll help us to identify the person you’re referring and decide if we need to investigate the case further.</p>
       <div class="govuk-form-group">
         <%= f.govuk_text_field(

--- a/app/views/referrals/teacher_personal_details/ni_number/edit.html.erb
+++ b/app/views/referrals/teacher_personal_details/ni_number/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @ni_number_form.errors.any?}Do you know their National Insurance number? - Personal details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_personal_details_age]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @ni_number_form, url: [current_referral.routing_scope, current_referral, :teacher_personal_details, :ni_number], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Personal details</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <div class="govuk-form-group">
-        <%= f.govuk_radio_buttons_fieldset(:ni_number_known, legend: { size: "l", text: "Do you know their National Insurance number?" }) do %>
+        <%= f.govuk_radio_buttons_fieldset(:ni_number_known, legend: { size: "l", text: form_label }) do %>
           <%= f.govuk_radio_button :ni_number_known, true, label: { text: "Yes" }, link_errors: true do %>
             <%= f.govuk_text_field :ni_number, label: { text: "National Insurance number", size: "s" },
                 hint: { size: 's', text: "For example, ‘QQ 12 34 56 C’" } %>

--- a/app/views/referrals/teacher_personal_details/qts/edit.html.erb
+++ b/app/views/referrals/teacher_personal_details/qts/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @personal_details_qts_form.errors.any?}Do they have qualified teacher status (QTS)? - Personal details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_personal_details_trn]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @personal_details_qts_form, url: [current_referral.routing_scope, current_referral, :teacher_personal_details_qts], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Personal details</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <div class="govuk-form-group">
-        <%= f.govuk_radio_buttons_fieldset(:has_qts, legend: { size: "l", text: "Do they have qualified teacher status (QTS)?" }) do %>
+        <%= f.govuk_radio_buttons_fieldset(:has_qts, legend: { size: "l", text: form_label }) do %>
           <%= f.govuk_radio_button :has_qts, "yes", label: { text: "Yes, they have QTS" }, link_errors: true %>
           <%= f.govuk_radio_button :has_qts, "no", label: { text: "No, they do not have QTS" } %>
           <%= f.govuk_radio_button :has_qts, "not_sure", label: { text: "I’m not sure" } %>

--- a/app/views/referrals/teacher_personal_details/trn/edit.html.erb
+++ b/app/views/referrals/teacher_personal_details/trn/edit.html.erb
@@ -1,15 +1,16 @@
-<% content_for :page_title, "#{'Error: ' if @personal_details_trn_form.errors.any?}Do you know their teacher reference number (TRN)? - Personal details" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_personal_details, :ni_number]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @personal_details_trn_form, url: [current_referral.routing_scope, current_referral, :teacher_personal_details_trn], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">Personal details</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset(
           :trn_known,
-          legend: { size: "l", text: "Do you know their teacher reference number (TRN)?" },
+          legend: { size: "l", text: form_label },
           hint: { text: "A TRN is 7 digits long, for example 4567814."},
         ) do %>
           <%= f.govuk_radio_button :trn_known, "true", label: { text: "Yes" }, link_errors: true do %>

--- a/app/views/referrals/teacher_role/check_answers/edit.html.erb
+++ b/app/views/referrals/teacher_role/check_answers/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{"Error: " if @teacher_role_check_answers_form.errors.any?}Check and confirm your answers - About their role" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @teacher_role_check_answers_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :check_answers], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">About their role</span>
+        <span class="govuk-caption-l"><%= section_label %></span>
         Check and confirm your answers
       </h1>
 

--- a/app/views/referrals/teacher_role/duties/edit.html.erb
+++ b/app/views/referrals/teacher_role/duties/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @duties_form.errors.any?}How do you want to give details about their main duties? - About their role" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :job_title]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @duties_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :duties], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">About their role</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <div class="govuk-form-group">
-        <%= f.govuk_radio_buttons_fieldset(:duties_format, legend: { text: "How do you want to give details about their main duties?", tag: 'h1', size: "l" }) do %>
+        <%= f.govuk_radio_buttons_fieldset(:duties_format, legend: { text: form_label, tag: 'h1', size: "l" }) do %>
           <%= f.govuk_radio_button :duties_format, "upload", label: { text: "Upload file" }, link_errors: true do %>
             <% if current_referral.duties_upload %>
               <div class="app-uploaded-file">

--- a/app/views/referrals/teacher_role/employment_status/edit.html.erb
+++ b/app/views/referrals/teacher_role/employment_status/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @employment_status_form.errors.any?}Are they still employed at the organisation where the alleged misconduct took place? - About their role" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :start_date]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @employment_status_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :employment_status], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">About their role</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <%= f.govuk_radio_buttons_fieldset :employment_status,
-        legend: { text: "Are they still employed at the organisation where the alleged misconduct took place?", tag: 'h1', size: "l" }  do %>
+        legend: { text: form_label, tag: 'h1', size: "l" }  do %>
         <%= f.hidden_field :employment_status %>
         <%= f.govuk_radio_button :employment_status, "employed", label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :employment_status, "suspended", label: { text: "They’re still employed but they’ve been suspended" } %>

--- a/app/views/referrals/teacher_role/end_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/end_date/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @role_end_date_form.errors.any?}Do you know when they left the job? - About their role" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :employment_status]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @role_end_date_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :end_date], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">About their role</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <%= f.govuk_radio_buttons_fieldset :role_end_date_known,
-        legend: { text: "Do you know when they left the job?", tag: 'h1', size: "l" } do %>
+        legend: { text: form_label, tag: 'h1', size: "l" } do %>
         <%= f.hidden_field :role_end_date_known %>
         <%= f.govuk_radio_button :role_end_date_known, true, label: { text: "Yes" }, link_errors: true do %>
           <%= f.govuk_date_field :role_end_date,

--- a/app/views/referrals/teacher_role/job_title/edit.html.erb
+++ b/app/views/referrals/teacher_role/job_title/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @job_title_form.errors.any?}Their job title - About their role" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @job_title_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :job_title], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">About their role</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <%= f.govuk_text_field :job_title,
-        label: { text: "Their job title", tag: 'h1', size: "l" },
+        label: { text: form_label, tag: 'h1', size: "l" },
         hint: { text: "For example, ‘Teacher’" }
       %>
       <%= f.govuk_submit "Save and continue" %>

--- a/app/views/referrals/teacher_role/organisation_address/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address/edit.html.erb
@@ -1,12 +1,12 @@
-<% content_for :page_title, "#{'Error: ' if @organisation_address_form.errors.any?}Name and address of the organisation where the alleged misconduct took place - About their role" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :organisation_address_known]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @organisation_address_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :organisation_address], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">About their role</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <h1 class="govuk-heading-l">
         Name and address of the organisation where the alleged misconduct took place
       </h1>

--- a/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address_known/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @organisation_address_known_form.errors.any?}Do you know the name and address of the organisation? - About their role" %>
-<% content_for :back_link_url, previous_path %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @organisation_address_known_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :organisation_address_known], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">About their role</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <%= f.govuk_radio_buttons_fieldset :organisation_address_known,
-        legend: { text: "Do you know the name and address of the organisation where the alleged misconduct took place?", tag: 'h1', size: "l" } do %>
+        legend: { text: form_label, tag: 'h1', size: "l" } do %>
         <%= f.hidden_field :organisation_address_known %>
         <%= f.govuk_radio_button :organisation_address_known, true, label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :organisation_address_known, false, label: { text: "No" } %>

--- a/app/views/referrals/teacher_role/reason_leaving_role/edit.html.erb
+++ b/app/views/referrals/teacher_role/reason_leaving_role/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @reason_leaving_role_form.errors.any?}Reason they left the job - About their role" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :end_date]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @reason_leaving_role_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :reason_leaving_role], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">About their role</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <%= f.govuk_radio_buttons_fieldset :reason_leaving_role,
-        legend: { text: "Reason they left the job", tag: 'h1', size: "l" }  do %>
+        legend: { text: form_label, tag: 'h1', size: "l" }  do %>
         <%= f.hidden_field :reason_leaving_role %>
 
         <%= f.govuk_radio_button :reason_leaving_role, "resigned", label: { text: "Resigned" }, link_errors: true %>

--- a/app/views/referrals/teacher_role/same_organisation/edit.html.erb
+++ b/app/views/referrals/teacher_role/same_organisation/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @same_organisation_form.errors.any?}Were they employed at the same organisation as you at the time of the alleged misconduct? - About their role" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :duties]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @same_organisation_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :same_organisation], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">About their role</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <%= f.govuk_radio_buttons_fieldset :same_organisation,
-        legend: { text: "Were they employed at the same organisation as you at the time of the alleged misconduct?", tag: 'h1', size: "l" } do %>
+        legend: { text: form_label, tag: 'h1', size: "l" } do %>
         <%= f.hidden_field :same_organisation %>
         <%= f.govuk_radio_button :same_organisation, true, label: { text: "Yes" }, link_errors: true %>
       <%= f.govuk_radio_button :same_organisation, false, label: { text: "No" } %>

--- a/app/views/referrals/teacher_role/start_date/edit.html.erb
+++ b/app/views/referrals/teacher_role/start_date/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :page_title, "#{'Error: ' if @role_start_date_form.errors.any?}Do you know when they started the job? - About their role" %>
-<% content_for :back_link_url, polymorphic_path([ :edit, current_referral.routing_scope, current_referral, :teacher_role, :same_organisation]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @role_start_date_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :start_date], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
-      <span class="govuk-caption-l">About their role</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <%= f.govuk_radio_buttons_fieldset :role_start_date_known,
-        legend: { text: "Do you know when they started the job?", tag: 'h1', size: "l" } do %>
+        legend: { text: form_label, tag: 'h1', size: "l" } do %>
         <%= f.hidden_field :role_start_date_known %>
         <%= f.govuk_radio_button :role_start_date_known, true, label: { text: "Yes" }, link_errors: true do %>
           <%= f.govuk_date_field :role_start_date,

--- a/app/views/referrals/teacher_role/work_location/edit.html.erb
+++ b/app/views/referrals/teacher_role/work_location/edit.html.erb
@@ -1,15 +1,13 @@
-<% content_for :page_title, "#{"Error: " if @work_location_form.errors.any?}Name and address of the organisation where they’re employed - About their role" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :work_location_known]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_location_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :work_location], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">About their role</span>
-      <h1 class="govuk-heading-l">
-        Name and address of the organisation where they’re employed
-      </h1>
+      <span class="govuk-caption-l"><%= section_label %></span>
+      <h1 class="govuk-heading-l"><%= form_label %></h1>
 
       <%= f.govuk_text_field :work_organisation_name, label: { text: "Organisation name", size: "m" } %>
       <%= f.govuk_text_field :work_address_line_1, label: { text: "Address line 1", size: "m" } %>

--- a/app/views/referrals/teacher_role/work_location_known/edit.html.erb
+++ b/app/views/referrals/teacher_role/work_location_known/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @work_location_known_form.errors.any?}Do you know the name and address of the organisation where they’re employed? - About their role" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :working_somewhere_else]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @work_location_known_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :work_location_known], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">About their role</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <%= f.govuk_radio_buttons_fieldset :work_location_known,
-        legend: { text: "Do you know the name and address of the organisation where they’re employed?", tag: 'h1', size: "l" } do %>
+        legend: { text: form_label, tag: 'h1', size: "l" } do %>
         <%= f.hidden_field :work_location_known %>
         <%= f.govuk_radio_button :work_location_known, true, label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :work_location_known, false, label: { text: "No" } %>

--- a/app/views/referrals/teacher_role/working_somewhere_else/edit.html.erb
+++ b/app/views/referrals/teacher_role/working_somewhere_else/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @working_somewhere_else_form.errors.any?}Are they employed somewhere else? - About their role" %>
-<% content_for :back_link_url, polymorphic_path([:edit, current_referral.routing_scope, current_referral, :teacher_role, :reason_leaving_role]) %>
+<% content_for :page_title, page_title %>
+<% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @working_somewhere_else_form, url: [current_referral.routing_scope, current_referral, :teacher_role, :working_somewhere_else], method: :put do |f| %>
+    <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">About their role</span>
+      <span class="govuk-caption-l"><%= section_label %></span>
       <%= f.govuk_radio_buttons_fieldset :working_somewhere_else,
-        legend: { size: "l", text: "Are they employed somewhere else?" } do %>
+        legend: { size: "l", text: form_label } do %>
         <%= f.hidden_field :working_somewhere_else %>
         <%= f.govuk_radio_button :working_somewhere_else, "yes", label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :working_somewhere_else, "no", label: { text: "No" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,17 +12,62 @@ en:
 
   referral_form:
     heading: Your referral
-    about_you: About you
-    referrer_details: Your details
-    referrer_organisation: Your organisation
-    about_the_person_you_are_referring: About the teacher
-    teacher_personal_details: Personal details
-    teacher_contact_details: Contact details
-    teacher_role: About their role
-    the_allegation: The allegation
-    allegation_details: Details of the allegation
-    allegation_previous_misconduct: Previous allegations
-    allegation_evidence: Evidence and supporting information
+    section_groups:
+      about_you: About you
+      about_the_person_you_are_referring: About the teacher
+      the_allegation: The allegation
+    sections:
+      referrer_details: Your details
+      referrer_organisation: Your organisation
+      teacher_personal_details: Personal details
+      teacher_contact_details: Contact details
+      teacher_role: About their role
+      allegation_details: Details of the allegation
+      allegation_previous_misconduct: Previous allegations
+      allegation_evidence: Evidence and supporting information
+    forms:
+      referrer_details:
+        name: Your name
+        phone: Your phone number
+        job_title: Your job title
+      referrer_organisation:
+        address: Your organisation
+      teacher_personal_details:
+        name: Their name
+        age: Do you know their date of birth?
+        ni_number: Do you know their National Insurance number?
+        trn: Do you know their teacher reference number (TRN)?
+        qts: Do they have qualified teacher status (QTS)?
+      teacher_contact_details:
+        email: Do you know their email address?
+        telephone: Do you know their phone number?
+        address_known: Do you know their home address?
+        address: Their home address
+      teacher_role:
+        job_title: Their job title
+        duties: How do you want to give details about their main duties?
+        same_organisation: Were they employed at the same organisation as you at the time of the alleged misconduct?
+        organisation_address_known: Do you know the name and address of the organisation where the alleged misconduct took place?
+        organisation_address: Name and address of the organisation where the alleged misconduct took place
+        start_date: Do you know when they started the job?
+        employment_status: Are they still employed at the organisation where the alleged misconduct took place?
+        end_date: Do you know when they left the job?
+        reason_leaving_role: Reason they left the job
+        working_somewhere_else: Are they employed somewhere else?
+        work_location_known: Do you know the name and address of the organisation where they’re employed?
+        work_location: Name and address of the organisation where they’re employed
+      allegation_details:
+        details: How do you want to give details about the allegation?
+        considerations: How this complaint has been considered
+        dbs: Telling DBS about this case
+      allegation_previous_misconduct:
+        reported: Previous allegations
+        detailed_account: Detailed account of previous allegations
+      allegation_evidence:
+        start: Evidence and supporting information
+        upload: Upload evidence
+        uploaded: Uploaded evidence
+
     statuses:
       incomplete: Incomplete
       completed: Completed

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -24,7 +24,7 @@ module Referrals
       subject(:label) { section.label }
 
       it "returns the correct label from the translation file" do
-        allow(I18n).to receive(:t).with("referral_form.test_section").and_return(
+        allow(I18n).to receive(:t).with("referral_form.sections.test_section").and_return(
           "Test Section Label"
         )
         expect(label).to eq "Test Section Label"
@@ -39,7 +39,8 @@ module Referrals
              :edit,
              referral.routing_scope,
              referral,
-             :referrer_organisation_address
+             :referrer_organisation,
+             :address
            ]
       end
     end
@@ -83,7 +84,7 @@ module Referrals
       subject(:next_path) { section.next_path }
 
       it "returns the path for the next incomplete item" do
-        expect(next_path).to eq [:edit, nil, referral, :referrer_organisation_address]
+        expect(next_path).to eq [:edit, nil, referral, :referrer_organisation, :address]
       end
     end
 

--- a/spec/system/public_referrals/user_adds_allegation_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_allegation_details_spec.rb
@@ -178,10 +178,8 @@ RSpec.feature "Details of the allegation", type: :system do
         [:edit, @referral.routing_scope, @referral, :allegation_details, :check_answers]
       )
     )
-    expect(page).to have_title(
-      "Check and confirm your answers - Refer serious misconduct by a teacher in England"
-    )
-    expect(page).to have_content("The allegation")
+    expect(page).to have_title("Check and confirm your answers - Details of the allegation")
+    expect(page).to have_content("Details of the allegation")
     expect(page).to have_content("Check and confirm your answers")
   end
 

--- a/spec/system/public_referrals/user_adds_teacher_role_details_spec.rb
+++ b/spec/system/public_referrals/user_adds_teacher_role_details_spec.rb
@@ -153,7 +153,9 @@ RSpec.feature "Teacher role", type: :system do
     expect(page).to have_current_path(
       edit_public_referral_teacher_role_organisation_address_known_path(@referral)
     )
-    expect(page).to have_title("Do you know the name and address of the organisation?")
+    expect(page).to have_title(
+      "Do you know the name and address of the organisation where the alleged misconduct took place?"
+    )
     expect(page).to have_content(
       "Do you know the name and address of the organisation where the alleged misconduct took place?"
     )

--- a/spec/system/referrals/user_adds_allegation_details_spec.rb
+++ b/spec/system/referrals/user_adds_allegation_details_spec.rb
@@ -174,9 +174,9 @@ RSpec.feature "Allegation", type: :system do
       )
     )
     expect(page).to have_title(
-      "Check and confirm your answers - The allegation - Refer serious misconduct by a teacher in England"
+      "Check and confirm your answers - Details of the allegation - Refer serious misconduct by a teacher in England"
     )
-    expect(page).to have_content("The allegation")
+    expect(page).to have_content("Details of the allegation")
     expect(page).to have_content("Check and confirm your answers")
   end
 end

--- a/spec/system/referrals/user_adds_teacher_role_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_spec.rb
@@ -295,7 +295,9 @@ RSpec.feature "Teacher role", type: :system do
     expect(page).to have_current_path(
       edit_referral_teacher_role_organisation_address_known_path(@referral)
     )
-    expect(page).to have_title("Do you know the name and address of the organisation?")
+    expect(page).to have_title(
+      "Do you know the name and address of the organisation where the alleged misconduct took place?"
+    )
     expect(page).to have_content(
       "Do you know the name and address of the organisation where the alleged misconduct took place?"
     )


### PR DESCRIPTION
In which we attempt to tidy up the form views and make them more consistent and less likely to make a mistake in.

Forms now get the following methods:
* `page_title`
* `back_link_url`
* `form` - the form object
* `form_path` - the url to submit the form to
* `section_label` - now pulls the section label from the translation file
* `form_label` - as above

I've only implemented it in `app/views/referrals/referrer_details` pending review
