### PR TITLE
Add /start-govuk route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
 
   constraints(-> { FeatureFlags::FeatureFlag.active?(:eligibility_screener) }) do
     get "/start", to: "pages#start"
+    get "/start-govuk", to: "pages#start"
     get "/users/registrations/exists", to: "users/existing_registration#new"
     post "/users/registrations/exists", to: "users/existing_registration#create"
     get "/referral-type", to: "eligibility_screener/referral_type#new"


### PR DESCRIPTION
GOV.UK doesn't pass the referrer so we can't measure how many users are coming via the correct start page vs the other links on there. Until we can rationalise the links we can set it up to link to a specific URL for analysis.

Add `/start-govuk` route. This just redirects to `pages#start` which funnels the user to the correct first page based on whether they're logged in or not. We'll only use this for the GOV.UK start page.