### PR TITLE
Fix CI exact row match expectation

### DIFF
--- a/spec/system/public_referrals/user_adds_allegation_evidence_spec.rb
+++ b/spec/system/public_referrals/user_adds_allegation_evidence_spec.rb
@@ -191,7 +191,10 @@ RSpec.feature "Evidence", type: :system do
   def then_i_am_asked_to_confirm_the_evidence_details
     expect(page).to have_content("Check and confirm your answers")
 
-    expect_summary_row(key: "Uploaded evidence", value: "upload1.pdf\nupload2.pdf\nupload.txt")
+    expect_summary_row(key: "Uploaded evidence", value: "upload1.pdf")
+    expect_summary_row(key: "Uploaded evidence", value: "upload2.pdf")
+    expect_summary_row(key: "Uploaded evidence", value: "upload.txt")
+
     expect(page).to have_link(
       "upload1.pdf",
       href: rails_blob_path(@referral.evidence_uploads.first.file, disposition: "attachment")

--- a/spec/system/referrals/user_adds_allegation_evidence_spec.rb
+++ b/spec/system/referrals/user_adds_allegation_evidence_spec.rb
@@ -201,7 +201,10 @@ RSpec.feature "Evidence", type: :system do
   def then_i_am_asked_to_confirm_the_evidence_details
     expect(page).to have_content("Check and confirm your answers")
 
-    expect_summary_row(key: "Uploaded evidence", value: "upload1.pdf\nupload2.pdf\nupload.txt")
+    expect_summary_row(key: "Uploaded evidence", value: "upload1.pdf")
+    expect_summary_row(key: "Uploaded evidence", value: "upload2.pdf")
+    expect_summary_row(key: "Uploaded evidence", value: "upload.txt")
+
     expect(page).to have_link(
       "upload1.pdf",
       href: rails_blob_path(@referral.evidence_uploads.first.file, disposition: "attachment")


### PR DESCRIPTION
On CI, the exact row match expectation was failing quite often because of the random upload order. Changing it to a non exact match should fix the issue.