### PR TITLE
Retry smoke test if it fails on CI

### DIFF
--- a/spec/support/common.rb
+++ b/spec/support/common.rb
@@ -1,0 +1,12 @@
+def retry_block(error: StandardError, max_attempts: 3, wait: 20)
+  attempts = 0
+  begin
+    yield
+  rescue error => e
+    attempts += 1
+    raise e if attempts >= max_attempts
+
+    sleep(wait)
+    retry
+  end
+end

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -2,6 +2,7 @@
 require "spec_helper"
 require "capybara/rspec"
 require "capybara/cuprite"
+require "support/common"
 
 Capybara.javascript_driver = :cuprite
 Capybara.always_include_port = false
@@ -27,7 +28,7 @@ RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
   end
 
   def when_i_visit_the_service
-    page.visit("#{ENV["HOSTING_DOMAIN"]}/start")
+    retry_block(error: Ferrum::TimeoutError) { page.visit("#{ENV["HOSTING_DOMAIN"]}/start") }
   end
 
   def then_it_loads_successfully


### PR DESCRIPTION
Potential fix for:

```
Failures:

  1) Smoke test works as expected
     Failure/Error: page.visit("#***ENV["HOSTING_DOMAIN"]***/start")

     Ferrum::PendingConnectionsError:
       Request to https://preprod.refer-serious-misconduct.education.gov.uk/start reached server, but there are still pending connections: https://preprod.refer-serious-misconduct.education.gov.uk/users/registrations/exists
```

e.g. https://github.com/DFE-Digital/refer-serious-misconduct/actions/runs/5220693901/jobs/9424128978