### PR TITLE
Change smoke test authentication

### DIFF
--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -10,24 +10,19 @@ TEST_ENVIRONMENTS = "local dev test preprod review"
 
 RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
   it "works as expected" do
-    given_i_am_authorized_as_a_support_user
     when_i_visit_the_service
     then_it_loads_successfully
   end
 
   it "/health/all returns 200" do
-    page.visit("#{ENV["HOSTING_DOMAIN"]}/health/all")
+    page.visit("#{hosting_authenticated_url}/health/all")
     expect(page.status_code).to eq(200)
   end
 
   private
 
-  def given_i_am_authorized_as_a_support_user
-    page.driver.basic_authorize(ENV["SUPPORT_USERNAME"], ENV["SUPPORT_PASSWORD"])
-  end
-
   def when_i_visit_the_service
-    page.visit("#{ENV["HOSTING_DOMAIN"]}/start")
+    page.visit("#{hosting_authenticated_url}/start")
   end
 
   def then_it_loads_successfully
@@ -42,5 +37,13 @@ RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
 
   def hosting_environment_name
     ENV.fetch("HOSTING_ENVIRONMENT_NAME", "unknown")
+  end
+
+  def hosting_authenticated_url
+    url = ENV["HOSTING_DOMAIN"].dup
+    username = ENV["SUPPORT_USERNAME"]
+    password = ENV["SUPPORT_PASSWORD"]
+
+    url.insert(8, "#{username}:#{password}@")
   end
 end


### PR DESCRIPTION
Add login and password to the URL instead of using the basic auth pop-up. This should be more reliable for CI.