### PR TITLE
Temporarily stop deploying to dev

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -87,7 +87,7 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             DEPLOYMENT_MATRIX="{ 'environment': ['${{ github.event.inputs.environment }}'] }"
           else
-            DEPLOYMENT_MATRIX="{ 'environment': ['dev', 'test', 'preprod'] }"
+            DEPLOYMENT_MATRIX="{ 'environment': ['test', 'preprod'] }"
           fi
           echo "deployment_matrix=$DEPLOYMENT_MATRIX" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
There is an issue with the dev environment at the moment which is blocking deploys.

Temporarily take it out of the pipeline to enable deploys while we fix it.