### PR TITLE
[1394] Handle virus scanned files in the zip download

### DIFF
--- a/app/lib/referral_zip_file.rb
+++ b/app/lib/referral_zip_file.rb
@@ -53,13 +53,11 @@ class ReferralZipFile
   end
 
   def attachments
-    files = [
-      referral.duties_upload_file,
-      referral.allegation_upload_file,
-      referral.previous_misconduct_upload_file,
-      referral.pdf
-    ].compact
+    attachable_uploads = referral.uploads.select(&:scan_result_clean?)
 
-    files + referral.evidence_uploads.map(&:file)
+    attachable_uploads
+      .map(&:file)
+      .select(&:attached?)
+      .tap { |files| files << referral.pdf if referral.pdf.present? }
   end
 end

--- a/spec/factories/referrals.rb
+++ b/spec/factories/referrals.rb
@@ -57,16 +57,21 @@ FactoryBot.define do
       duties_format { "upload" }
 
       after(:create) do |referral|
-        referral.uploads.create(
-          section: "allegation",
-          file: Rack::Test::UploadedFile.new("spec/fixtures/files/upload1.pdf")
-        )
-
-        referral.uploads.create(
-          section: "duties",
-          file: Rack::Test::UploadedFile.new("spec/fixtures/files/upload2.pdf")
-        )
+        referral.uploads << build(:upload, :allegation, :clean)
+        referral.uploads << build(:upload, :duties, :clean)
       end
+    end
+
+    trait :with_suspect_attachment do
+      after(:create) { |referral| referral.uploads << build(:upload, :allegation, :suspect) }
+    end
+
+    trait :with_pending_attachment do
+      after(:create) { |referral| referral.uploads << build(:upload, :allegation, :pending) }
+    end
+
+    trait :with_clean_attachment do
+      after(:create) { |referral| referral.uploads << build(:upload, :allegation, :clean) }
     end
 
     trait :with_pdf do

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -21,5 +21,14 @@ FactoryBot.define do
       uploadable_type { "Referral" }
       section { "evidence" }
     end
+
+    trait :suspect do
+      file { nil }
+      malware_scan_result { "suspect" }
+    end
+
+    trait :pending do
+      malware_scan_result { "pending" }
+    end
   end
 end

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -23,7 +23,6 @@ FactoryBot.define do
     end
 
     trait :suspect do
-      file { nil }
       malware_scan_result { "suspect" }
     end
 

--- a/spec/lib/referral_zip_file_spec.rb
+++ b/spec/lib/referral_zip_file_spec.rb
@@ -26,7 +26,7 @@ describe ReferralZipFile do
       let(:referral) { create(:referral) }
 
       it "returns false" do
-        expect(referral_zip_file.has_attachments?).to be false
+        expect(referral_zip_file).not_to have_attachments
       end
     end
 
@@ -34,7 +34,7 @@ describe ReferralZipFile do
       let(:referral) { create(:referral, :with_attachments) }
 
       it "returns true" do
-        expect(referral_zip_file.has_attachments?).to be true
+        expect(referral_zip_file).to have_attachments
       end
     end
 
@@ -42,7 +42,23 @@ describe ReferralZipFile do
       let(:referral) { create(:referral, :with_pdf) }
 
       it "returns true" do
-        expect(referral_zip_file.has_attachments?).to be true
+        expect(referral_zip_file).to have_attachments
+      end
+    end
+
+    context "with suspect attachment" do
+      let(:referral) { create(:referral, :with_suspect_attachment) }
+
+      it "returns false" do
+        expect(referral_zip_file).not_to have_attachments
+      end
+    end
+
+    context "with pending attachment" do
+      let(:referral) { create(:referral, :with_pending_attachment) }
+
+      it "returns false" do
+        expect(referral_zip_file).not_to have_attachments
       end
     end
   end


### PR DESCRIPTION
### Context

We accept uploaded files from users. They are scanned for viruses by 'Defender' on Azure and the files are removed if they are 'suspect'. Uploads can be in three states - pending, clean or suspect. We only want case workers to be able to access the files that are 'clean'. Case workers download all files in a zip file from the 'manage' part of the service. We need to exclude non-clean files from that and replace them with something informative.

https://trello.com/c/aEzaTDI6/1394-handle-virus-scanned-files-in-the-zip-download

### Changes

* replace 'suspect' and 'pending' files with a text file. The text files are named to indicate what has happened to the file ie, it's not ready yet or it's been removed. In practice it's highly unlikely a file would still be pending by the time the case worker gets to it. We also have had no 'suspect' files as yet.
* move the referral summary PDF out of a folder and into the route of the zip file. This was the original intention as the directory name doesn't add any extra meaning to that file as it does with the section files.

### Review

* This is a bit of a faff to run... To test I manually created a referral with file uploads for each section and then set their state to `upload.scan_result_clean!`, `upload.scan_result_pending!` and `upload.scan_result_suspect! && upload.file.purge`. You can then login as a caseworker and download the zip file.
