### PR TITLE
[1406] Feedback form

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -9,6 +9,7 @@ class FeedbacksController < ApplicationController
     @feedback = Feedback.new(feedback_params)
 
     if @feedback.save
+      redirect_to :confirmation
     else
       render(:new)
     end
@@ -17,6 +18,11 @@ class FeedbacksController < ApplicationController
   private
 
   def feedback_params
-    params.require(:feedback).permit(:satisfaction_rating)
+    params.require(:feedback).permit(
+      :satisfaction_rating,
+      :improvement_suggestion,
+      :contact_permission_given,
+      :email
+    )
   end
 end

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class FeedbacksController < ApplicationController
+  def new
+    @feedback = Feedback.new
+  end
+
+  def create
+    @feedback = Feedback.new(feedback_params)
+
+    if @feedback.save
+    else
+      render(:new)
+    end
+  end
+
+  private
+
+  def feedback_params
+    params.require(:feedback).permit(:satisfaction_rating)
+  end
+end

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -11,7 +11,7 @@ class FeedbacksController < ApplicationController
     if @feedback.save
       redirect_to :confirmation
     else
-      render(:new)
+      render :new
     end
   end
 

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -1,0 +1,5 @@
+module FeedbackHelper
+  def satisfaction_rating_options(ratings)
+    ratings.map { |rating| OpenStruct.new(label: rating.humanize, value: rating) }
+  end
+end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -8,7 +8,7 @@ class Feedback < ApplicationRecord
   ].freeze
 
   validates :satisfaction_rating, inclusion: { in: SATISFACTION_RATINGS }
-  validates_presence_of :improvement_suggestion
+  validates :improvement_suggestion, presence: true
   validates :contact_permission_given, inclusion: { in: [true, false] }
   validates :email, presence: true, if: :contact_permission_given?
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -9,5 +9,5 @@ class Feedback < ApplicationRecord
 
   validates :satisfaction_rating, inclusion: { in: SATISFACTION_RATINGS }
   validates_presence_of :improvement_suggestion
-  validates_presence_of :contact_permission_given
+  validates :contact_permission_given, inclusion: { in: [true, false] }
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -10,4 +10,5 @@ class Feedback < ApplicationRecord
   validates :satisfaction_rating, inclusion: { in: SATISFACTION_RATINGS }
   validates_presence_of :improvement_suggestion
   validates :contact_permission_given, inclusion: { in: [true, false] }
+  validates :email, presence: true, if: :contact_permission_given?
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,0 +1,13 @@
+class Feedback < ApplicationRecord
+  SATISFACTION_RATINGS = %w[
+    very_satisfied
+    satisfied
+    neither_satisfied_or_dissatisfied
+    dissatisfied
+    very_dissatisfied
+  ].freeze
+
+  validates :satisfaction_rating, inclusion: { in: SATISFACTION_RATINGS }
+  validates_presence_of :improvement_suggestion
+  validates_presence_of :contact_permission_given
+end

--- a/app/views/feedbacks/confirmation.html.erb
+++ b/app/views/feedbacks/confirmation.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, "Feedback sent" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= govuk_panel(title_text: "Feedback sent") %>
+
+    <h2 class="govuk-heading-m">Next steps</h2>
+
+    <p class="govuk_body">
+      Return to <%= govuk_link_to("report serious teacher misconduct", root_path) %>.
+    </p>
+  </div>
+</div>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, "Give feedback about referring serious misconduct by a teacher" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Give feedback about referring serious misconduct by a teacher
+    </h1>
+
+    <%= form_with model: @feedback do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons(
+          :satisfaction_rating,
+          satisfaction_rating_options(Feedback::SATISFACTION_RATINGS),
+          :value,
+          :label,
+          legend: { text: "How satisfied are you with the service?", size: "m" },
+        ) %>
+
+      <%= f.govuk_submit "Send feedback" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -21,6 +21,13 @@
         <%= f.govuk_text_area :improvement_suggestion, label: { text: "How can we improve the service?", size: "m" } %>
       </div>
 
+      <%= f.govuk_radio_buttons_fieldset :contact_permission_given, legend: { size: "m", text: "Can we contact you about your feedback?" } do %>
+        <%= f.govuk_radio_button :contact_permission_given, 'true', label: { text: "Yes" }, link_errors: true do %>
+          <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" } %>
+        <% end %>
+        <%= f.govuk_radio_button :contact_permission_given, 'false', label: { text: "No" } %>
+      <% end %>
+
       <%= f.govuk_submit "Send feedback" %>
     <% end %>
   </div>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -8,6 +8,7 @@
 
     <%= form_with model: @feedback do |f| %>
       <%= f.govuk_error_summary %>
+
       <%= f.govuk_collection_radio_buttons(
           :satisfaction_rating,
           satisfaction_rating_options(Feedback::SATISFACTION_RATINGS),
@@ -15,6 +16,10 @@
           :label,
           legend: { text: "How satisfied are you with the service?", size: "m" },
         ) %>
+
+      <div class="govuk-form-group">
+        <%= f.govuk_text_area :improvement_suggestion, label: { text: "How can we improve the service?", size: "m" } %>
+      </div>
 
       <%= f.govuk_submit "Send feedback" %>
     <% end %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -32,7 +32,7 @@
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: "Beta" }) do %>
-        This is a new service – your <%= govuk_link_to("feedback", feedbacks_path) %> will help us to improve it.
+        This is a new service – your <%= govuk_link_to("feedback", main_app.feedbacks_path) %> will help us to improve it.
       <% end %>
       <%= govuk_back_link(href: yield(:back_link_url)) if content_for?(:back_link_url) %>
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -32,7 +32,7 @@
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: "Beta" }) do %>
-        This is a new service – your <%= govuk_link_to("feedback", "https://forms.gle/mroZH7aVYGPrB37G6") %> will help us to improve it.
+        This is a new service – your <%= govuk_link_to("feedback", feedbacks_path) %> will help us to improve it.
       <% end %>
       <%= govuk_back_link(href: yield(:back_link_url)) if content_for?(:back_link_url) %>
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>

--- a/app/views/referrals/confirmation/show.html.erb
+++ b/app/views/referrals/confirmation/show.html.erb
@@ -23,5 +23,10 @@
       <li>a formal investigation will be launched</li>
     </ul>
     <p class="govuk_body">You’ll be sent an email with the decision.</p>
+
+    <h2 class="govuk-heading-m">Give feedback</h2>
+    <p class="govuk_body">
+      <%= govuk_link_to("Give feedback about this service", feedbacks_path) %> (takes 30 seconds).
+    </p>
   </div>
 </div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -190,3 +190,11 @@ shared:
     - created_at
     - updated_at
     - malware_scan_result
+  :feedbacks:
+    - id
+    - satisfaction_rating
+    - improvement_suggestion
+    - contact_permission_given
+    - email
+    - created_at
+    - updated_at

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -44,3 +44,6 @@
     - email
   :staff:
     - email
+  :feedbacks:
+    - email
+    - feedback_suggestion

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -401,6 +401,8 @@ en:
               blank: Tell us how we can improve the service
             contact_permission_given:
               blank: Tell us whether we can contact you about your feedback
+            email:
+              blank: Enter an email address
         user:
           attributes:
             email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -399,6 +399,8 @@ en:
               inclusion: Select how satisfied you are with the service
             improvement_suggestion:
               blank: Tell us how we can improve the service
+            contact_permission_given:
+              blank: Tell us whether we can contact you about your feedback
         user:
           attributes:
             email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -400,7 +400,7 @@ en:
             improvement_suggestion:
               blank: Enter how we can improve the service
             contact_permission_given:
-              blank: Select yes if we can contact you about your feedback
+              inclusion: Select yes if we can contact you about your feedback
             email:
               blank: Enter an email address
         user:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,9 +398,9 @@ en:
             satisfaction_rating:
               inclusion: Select how satisfied you are with the service
             improvement_suggestion:
-              blank: Tell us how we can improve the service
+              blank: Enter how we can improve the service
             contact_permission_given:
-              blank: Tell us whether we can contact you about your feedback
+              blank: Select yes if we can contact you about your feedback
             email:
               blank: Enter an email address
         user:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -397,6 +397,8 @@ en:
           attributes:
             satisfaction_rating:
               inclusion: Select how satisfied you are with the service
+            improvement_suggestion:
+              blank: Tell us how we can improve the service
         user:
           attributes:
             email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -393,6 +393,10 @@ en:
   activerecord:
     errors:
       models:
+        feedback:
+          attributes:
+            satisfaction_rating:
+              inclusion: Select how satisfied you are with the service
         user:
           attributes:
             email:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,11 @@ Rails.application.routes.draw do
   get "malware-scan/:upload_id/pending", to: "malware_scan#pending", as: :malware_scan_pending
   get "malware-scan/:upload_id/suspect", to: "malware_scan#suspect", as: :malware_scan_suspect
 
+  scope "/feedback" do
+    get "/" => "feedbacks#new", :as => :feedbacks
+    post "/" => "feedbacks#create"
+  end
+
   get "/accessibility", to: "static#accessibility"
   get "/cookies", to: "static#cookies"
   get "/privacy", to: "static#privacy"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -272,6 +272,7 @@ Rails.application.routes.draw do
   scope "/feedback" do
     get "/" => "feedbacks#new", :as => :feedbacks
     post "/" => "feedbacks#create"
+    get "/confirmation" => "feedbacks#confirmation"
   end
 
   get "/accessibility", to: "static#accessibility"

--- a/db/migrate/20230629131752_create_feedbacks.rb
+++ b/db/migrate/20230629131752_create_feedbacks.rb
@@ -1,0 +1,12 @@
+class CreateFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :feedbacks do |t|
+      t.string :satisfaction_rating, null: false
+      t.text :improvement_suggestion, null: false
+      t.boolean :contact_permission_given, null: false
+      t.string :email
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_05_104919) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_29_131752) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
 
@@ -63,6 +63,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_05_104919) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_feature_flags_features_on_name", unique: true
+  end
+
+  create_table "feedbacks", force: :cascade do |t|
+    t.string "satisfaction_rating", null: false
+    t.text "improvement_suggestion", null: false
+    t.boolean "contact_permission_given", null: false
+    t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "organisations", force: :cascade do |t|

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Feedback, type: :model do
+  it do
+    is_expected.to validate_inclusion_of(:satisfaction_rating).in_array(
+      %w[very_satisfied satisfied neither_satisfied_or_dissatisfied dissatisfied very_dissatisfied]
+    )
+  end
+end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,9 +1,28 @@
 require "rails_helper"
 
 RSpec.describe Feedback, type: :model do
-  it do
-    is_expected.to validate_inclusion_of(:satisfaction_rating).in_array(
-      %w[very_satisfied satisfied neither_satisfied_or_dissatisfied dissatisfied very_dissatisfied]
-    )
+  subject(:form) { described_class.new }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:improvement_suggestion) }
+    it { is_expected.not_to validate_presence_of(:email) }
+
+    specify do
+      expect(form).to validate_inclusion_of(:satisfaction_rating).in_array(
+        %w[
+          very_satisfied
+          satisfied
+          neither_satisfied_or_dissatisfied
+          dissatisfied
+          very_dissatisfied
+        ]
+      )
+    end
+
+    context "when contact permission is given" do
+      subject(:form) { described_class.new(contact_permission_given: true) }
+
+      it { is_expected.to validate_presence_of(:email) }
+    end
   end
 end

--- a/spec/system/feedback/user_gives_feedback_spec.rb
+++ b/spec/system/feedback/user_gives_feedback_spec.rb
@@ -18,14 +18,15 @@ RSpec.feature "Feedback", type: :system do
     then_i_see_validation_errors
     when_i_fill_in_how_we_can_improve
     then_i_see_validation_errors
-
+    when_i_choose_no
     when_i_press_send_feedback
+    then_i_see_the_feedback_sent_page
   end
 
   private
 
   def and_i_click_on_feedback
-    click_on("feedback")
+    click_on "feedback"
   end
 
   def then_i_see_the_feedback_form
@@ -35,7 +36,7 @@ RSpec.feature "Feedback", type: :system do
   end
 
   def when_i_press_send_feedback
-    click_on("Send feedback")
+    click_on "Send feedback"
   end
 
   def then_i_see_validation_errors
@@ -48,5 +49,15 @@ RSpec.feature "Feedback", type: :system do
 
   def when_i_fill_in_how_we_can_improve
     fill_in "How can we improve the service?", with: "Make it better"
+  end
+
+  def when_i_choose_no
+    choose "No", visible: false
+  end
+
+  def then_i_see_the_feedback_sent_page
+    expect(page).to have_current_path("/feedback/confirmation")
+    expect(page).to have_title("Feedback sent")
+    expect(page).to have_content("Next steps")
   end
 end

--- a/spec/system/feedback/user_gives_feedback_spec.rb
+++ b/spec/system/feedback/user_gives_feedback_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Feedback", type: :system do
+  include CommonSteps
+
+  scenario "User gives feedback" do
+    given_the_service_is_open
+    and_the_referral_form_feature_is_active
+    and_the_eligibility_screener_feature_is_active
+    when_i_visit_the_service
+    and_i_click_on_feedback
+
+    then_i_see_the_feedback_form
+    when_i_press_send_feedback
+    then_i_see_validation_errors
+    when_i_choose_satisfied
+    when_i_press_send_feedback
+  end
+
+  private
+
+  def and_i_click_on_feedback
+    click_on("feedback")
+  end
+
+  def then_i_see_the_feedback_form
+    expect(page).to have_current_path("/feedback")
+    expect(page).to have_title("Give feedback about referring serious misconduct by a teacher")
+    expect(page).to have_content("How satisfied are you with the service?")
+  end
+
+  def when_i_press_send_feedback
+    click_on("Send feedback")
+  end
+
+  def then_i_see_validation_errors
+    expect(page).to have_content("There’s a problem")
+  end
+
+  def when_i_choose_satisfied
+    choose("Satisfied", visible: false)
+  end
+end

--- a/spec/system/feedback/user_gives_feedback_spec.rb
+++ b/spec/system/feedback/user_gives_feedback_spec.rb
@@ -15,6 +15,10 @@ RSpec.feature "Feedback", type: :system do
     when_i_press_send_feedback
     then_i_see_validation_errors
     when_i_choose_satisfied
+    then_i_see_validation_errors
+    when_i_fill_in_how_we_can_improve
+    then_i_see_validation_errors
+
     when_i_press_send_feedback
   end
 
@@ -39,6 +43,10 @@ RSpec.feature "Feedback", type: :system do
   end
 
   def when_i_choose_satisfied
-    choose("Satisfied", visible: false)
+    choose "Satisfied", visible: false
+  end
+
+  def when_i_fill_in_how_we_can_improve
+    fill_in "How can we improve the service?", with: "Make it better"
   end
 end

--- a/spec/system/feedback/user_gives_feedback_spec.rb
+++ b/spec/system/feedback/user_gives_feedback_spec.rb
@@ -18,7 +18,9 @@ RSpec.feature "Feedback", type: :system do
     then_i_see_validation_errors
     when_i_fill_in_how_we_can_improve
     then_i_see_validation_errors
-    when_i_choose_no
+    when_i_choose_yes
+    then_i_see_validation_errors
+    when_i_enter_an_email
     when_i_press_send_feedback
     then_i_see_the_feedback_sent_page
   end
@@ -51,8 +53,12 @@ RSpec.feature "Feedback", type: :system do
     fill_in "How can we improve the service?", with: "Make it better"
   end
 
-  def when_i_choose_no
-    choose "No", visible: false
+  def when_i_choose_yes
+    choose "Yes", visible: false
+  end
+
+  def when_i_enter_an_email
+    fill_in "Email address", with: "my_email@example.com"
   end
 
   def then_i_see_the_feedback_sent_page


### PR DESCRIPTION
### Context

The feedback used to to be collected via Google form.
Since we migrated away from GSuite we need a new way of collecting.

https://trello.com/c/UcyWgDU3/1406-feedback-form

### Changes proposed in this pull request

- New feedback form page that lives on /feedback
- Migration to add `feedbacks` table with `satisfaction_rating`, `improvment_suggestion`,
  `contact_permission_given` and `email`
- `Feedback` model with presence/inclusion validations
- New 'Feedback sent' page shown when feedback submitted
- Link to feedback from banner and 'Referral sent' confirmation page

### Guidance to review

- Click the link in the banner to give feedback
- Check that each of the three questions are required and the error messages are ok
- Answer 'yes' to contact and check that the email field is required
- Submit the form and check that you are redirected to the new Feedback sent page

**Form**

<img width="1276" alt="Screenshot 2023-06-30 at 16 38 29" src="https://github.com/DFE-Digital/refer-serious-misconduct/assets/18436946/504b5c69-be29-447e-9780-fb18838963b1">

<img width="1552" alt="Screenshot 2023-06-30 at 16 39 08" src="https://github.com/DFE-Digital/refer-serious-misconduct/assets/18436946/b4f54483-5799-44e4-9b67-c95fe73443c4">

**Feedback sent confirmation page**

<img width="866" alt="Screenshot 2023-06-30 at 16 39 18" src="https://github.com/DFE-Digital/refer-serious-misconduct/assets/18436946/0e8fc6c1-db76-4342-80e3-f30f077db82f">

**Link to feedback from Referral sent confirmation**

<img width="834" alt="Screenshot 2023-06-30 at 16 45 38" src="https://github.com/DFE-Digital/refer-serious-misconduct/assets/18436946/b7d595c1-9a7f-4d93-baf1-73c00a0ffdcb">
