### PR TITLE
Disambiguate filenames in zip file

### DIFF
--- a/app/lib/referral_zip_file.rb
+++ b/app/lib/referral_zip_file.rb
@@ -26,9 +26,9 @@ class ReferralZipFile
     temp_attachments = []
 
     Zip::File.open(temp_zip_file.path, create: true) do |zip|
-      referral.uploads.each do |upload|
-        zip_file_path = "#{upload.section}/#{filename_for(upload:)}"
-        file = file_for(upload:)
+      referral.uploads.each_with_index do |upload, index|
+        zip_file_path = "#{upload.section}/#{filename_for(upload:, index:)}"
+        file = file_for(upload:, index:)
         zip.add(zip_file_path, File.join(file.path))
 
         temp_attachments << file
@@ -50,16 +50,16 @@ class ReferralZipFile
     temp_zip_file
   end
 
-  def filename_for(upload:)
-    base_filename = "#{referral.id}-#{upload.filename}"
+  def filename_for(upload:, index:)
+    base_filename = "#{referral.id}-#{index}-#{upload.filename}"
     return "#{base_filename}-file-removed-due-to-suspected-virus.txt" if upload.scan_result_suspect?
     return "#{base_filename}-file-being-checked-for-viruses.txt" if upload.scan_result_pending?
 
     base_filename
   end
 
-  def file_for(upload:)
-    temp_file_for(filename: filename_for(upload:)) do |file|
+  def file_for(upload:, index:)
+    temp_file_for(filename: filename_for(upload:, index:)) do |file|
       if upload.scan_result_clean? && upload.file.attached?
         upload.file.blob.download { |chunk| file.write(chunk) }
       else

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -3,11 +3,11 @@ FactoryBot.define do
     association :uploadable, factory: :referral
 
     file { Rack::Test::UploadedFile.new("spec/fixtures/files/upload1.pdf") }
+    section { "allegation" }
 
     trait :allegation do
       association :uploadable, factory: :referral
       uploadable_type { "Referral" }
-      section { "allegation" }
     end
 
     trait :duties do
@@ -28,6 +28,10 @@ FactoryBot.define do
 
     trait :pending do
       malware_scan_result { "pending" }
+    end
+
+    trait :clean do
+      malware_scan_result { "clean" }
     end
   end
 end

--- a/spec/lib/referral_zip_file_spec.rb
+++ b/spec/lib/referral_zip_file_spec.rb
@@ -29,7 +29,7 @@ describe ReferralZipFile do
       let(:referral) { create(:referral, :with_clean_attachment) }
 
       it "includes the attachment in a folder named by section" do
-        expect(zip_contents).to match_array("allegation/#{referral.id}-upload1.pdf")
+        expect(zip_contents).to match_array("allegation/#{referral.id}-0-upload1.pdf")
       end
     end
 
@@ -38,7 +38,7 @@ describe ReferralZipFile do
 
       it "includes a text file warning that the file is pending" do
         attachment_filepath =
-          "allegation/#{referral.id}-upload1.pdf-file-being-checked-for-viruses.txt"
+          "allegation/#{referral.id}-0-upload1.pdf-file-being-checked-for-viruses.txt"
         expect(zip_contents).to include(attachment_filepath)
       end
     end
@@ -48,8 +48,22 @@ describe ReferralZipFile do
 
       it "includes a text file warning that the file is suspect" do
         attachment_filepath =
-          "allegation/#{referral.id}-upload1.pdf-file-removed-due-to-suspected-virus.txt"
+          "allegation/#{referral.id}-0-upload1.pdf-file-removed-due-to-suspected-virus.txt"
         expect(zip_contents).to include(attachment_filepath)
+      end
+    end
+
+    context "with multiple identically named files" do
+      let(:referral) { create(:referral) }
+
+      before do
+        referral.uploads << build(:upload, :clean)
+        referral.uploads << build(:upload, :clean)
+      end
+
+      it "disambiguates the names" do
+        expect(zip_contents).to include("allegation/#{referral.id}-0-upload1.pdf")
+        expect(zip_contents).to include("allegation/#{referral.id}-1-upload1.pdf")
       end
     end
   end


### PR DESCRIPTION
We create a zip file of uploads from a referral to allow transfer into the case management system. The existing implementation has a bug where if multiple files have the same name in a section a `Zip::EntryExistsError
` is raised.

* Add an incrementing index to the file names as we're creating the downloadable zip file.

This handles the case where the user has uploaded identically named files to the same section. We could probably handle this more gracefully as this implementation adds an index to every file name when it is very rarely required. That could be a further iteration but this fixes a production issue.