### PR TITLE
20 file upload max

### DIFF
--- a/app/forms/referrals/allegation_evidence/uploaded_form.rb
+++ b/app/forms/referrals/allegation_evidence/uploaded_form.rb
@@ -3,10 +3,18 @@ module Referrals
     class UploadedForm < FormItem
       attr_accessor :more_evidence
 
-      validates :more_evidence, inclusion: { in: %w[yes no] }, on: :update
+      validates :more_evidence,
+        inclusion: { in: %w[yes no] },
+        on: :update,
+        if: Proc.new { |form| form.can_upload_more_evidence? }
+
 
       def more_evidence?
         @more_evidence == "yes"
+      end
+
+      def can_upload_more_evidence?
+        referral.can_upload_more_evidence?
       end
     end
   end

--- a/app/forms/referrals/allegation_evidence/uploaded_form.rb
+++ b/app/forms/referrals/allegation_evidence/uploaded_form.rb
@@ -6,16 +6,14 @@ module Referrals
       validates :more_evidence,
         inclusion: { in: %w[yes no] },
         on: :update,
-        if: Proc.new { |form| form.can_upload_more_evidence? }
+        if: proc { |form| form.can_upload_more_evidence? }
 
 
       def more_evidence?
         @more_evidence == "yes"
       end
 
-      def can_upload_more_evidence?
-        referral.can_upload_more_evidence?
-      end
+      delegate :can_upload_more_evidence?, to: :referral
     end
   end
 end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -93,4 +93,8 @@ class Referral < ApplicationRecord
   def submitted?
     submitted_at.present?
   end
+
+  def can_upload_more_evidence?
+    evidence_uploads.count < FileUploadValidator::MAX_FILES
+  end
 end

--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -2,7 +2,7 @@ class FileUploadValidator < ActiveModel::EachValidator
   include FileSizeHelper
 
   MAX_FILE_SIZE = 50.megabytes
-  MAX_FILES = 10
+  MAX_FILES = 20
 
   CONTENT_TYPES = {
     ".apng" => "image/apng",

--- a/app/views/public_referrals/allegation_evidence/check_answers/edit.html.erb
+++ b/app/views/public_referrals/allegation_evidence/check_answers/edit.html.erb
@@ -11,11 +11,13 @@
         Check and confirm your answers
       </h1>
 
-      <%= govuk_button_link_to(
-        "Add more evidence",
-        edit_public_referral_allegation_evidence_upload_path(current_referral),
-        class: "govuk-button--secondary govuk-!-margin-bottom-8"
-      ) if current_referral.has_evidence %>
+      <% if current_referral.can_upload_more_evidence? %>
+        <%= govuk_button_link_to(
+          "Add more evidence",
+          edit_public_referral_allegation_evidence_upload_path(current_referral),
+          class: "govuk-button--secondary govuk-!-margin-bottom-8"
+        ) if current_referral.has_evidence %>
+      <% end %>
 
       <%= render partial: 'referrals/shared/check_answers', locals: { f:, complete_field_name: :evidence_details_complete } %>
     <% end %>

--- a/app/views/public_referrals/allegation_evidence/uploaded/edit.html.erb
+++ b/app/views/public_referrals/allegation_evidence/uploaded/edit.html.erb
@@ -30,9 +30,11 @@
         <% end %>
       </dl>
 
-      <%= f.govuk_radio_buttons_fieldset(:more_evidence, legend: { size: "m", text: "Do you want to upload another file?" }) do %>
-        <%= f.govuk_radio_button :more_evidence, "yes", label: { text: "Yes" }, link_errors: true %>
-        <%= f.govuk_radio_button :more_evidence, "no", label: { text: "No" } %>
+      <% if f.object.referral.can_upload_more_evidence? %>
+        <%= f.govuk_radio_buttons_fieldset(:more_evidence, legend: { size: "m", text: "Do you want to upload another file?" }) do %>
+          <%= f.govuk_radio_button :more_evidence, "yes", label: { text: "Yes" }, link_errors: true %>
+          <%= f.govuk_radio_button :more_evidence, "no", label: { text: "No" } %>
+        <% end %>
       <% end %>
 
       <%= f.govuk_submit "Save and continue" %>

--- a/app/views/referrals/allegation_evidence/check_answers/edit.html.erb
+++ b/app/views/referrals/allegation_evidence/check_answers/edit.html.erb
@@ -11,11 +11,13 @@
         Check and confirm your answers
       </h1>
 
-      <%= govuk_button_link_to(
-        "Add more evidence",
-        [:edit, current_referral.routing_scope, current_referral, :allegation_evidence_upload],
-        class: "govuk-button--secondary govuk-!-margin-bottom-8",
-      ) if current_referral.has_evidence %>
+      <% if current_referral.can_upload_more_evidence? %>
+        <%= govuk_button_link_to(
+          "Add more evidence",
+          [:edit, current_referral.routing_scope, current_referral, :allegation_evidence_upload],
+          class: "govuk-button--secondary govuk-!-margin-bottom-8",
+        ) if current_referral.has_evidence %>
+      <% end %>
 
       <%= render partial: 'referrals/shared/check_answers', locals: { f:, complete_field_name: :evidence_details_complete } %>
     <% end %>

--- a/app/views/referrals/allegation_evidence/uploaded/edit.html.erb
+++ b/app/views/referrals/allegation_evidence/uploaded/edit.html.erb
@@ -30,9 +30,11 @@
         <% end %>
       </dl>
 
-      <%= f.govuk_radio_buttons_fieldset(:more_evidence, legend: { size: "m", text: "Do you want to upload another file?" }) do %>
-        <%= f.govuk_radio_button :more_evidence, "yes", label: { text: "Yes" }, link_errors: true %>
-        <%= f.govuk_radio_button :more_evidence, "no", label: { text: "No" } %>
+      <% if current_referral.can_upload_more_evidence? %>
+        <%= f.govuk_radio_buttons_fieldset(:more_evidence, legend: { size: "m", text: "Do you want to upload another file?" }) do %>
+          <%= f.govuk_radio_button :more_evidence, "yes", label: { text: "Yes" }, link_errors: true %>
+          <%= f.govuk_radio_button :more_evidence, "no", label: { text: "No" } %>
+        <% end %>
       <% end %>
 
       <%= f.govuk_submit "Save and continue" %>

--- a/spec/forms/referrals/allegation_evidence/upload_form_spec.rb
+++ b/spec/forms/referrals/allegation_evidence/upload_form_spec.rb
@@ -67,19 +67,11 @@ RSpec.describe Referrals::AllegationEvidence::UploadForm, type: :model do
       end
 
       it "validates that the maximum number of files is not exceeded" do
-        upload_form.evidence_uploads = [
-          fixture_file_upload("upload.txt"),
-          fixture_file_upload("upload.txt"),
-          fixture_file_upload("upload.txt"),
-          fixture_file_upload("upload.txt"),
-          fixture_file_upload("upload.txt"),
-          fixture_file_upload("upload.txt"),
-          fixture_file_upload("upload.txt"),
-          fixture_file_upload("upload.txt"),
+        upload_form.evidence_uploads = (described_class::MAX_FILES - 1).times.map do
           fixture_file_upload("upload.txt")
-        ]
+        end
         expect(upload_form.save).to be false
-        expect(upload_form.errors[:evidence_uploads]).to eq(["You can only upload 10 files"])
+        expect(upload_form.errors[:evidence_uploads]).to eq(["You can only upload 20 files"])
       end
     end
   end

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -99,21 +99,23 @@ RSpec.describe Referral, type: :model do
   end
 
   describe "#can_upload_more_evidence?" do
+    subject(:referral) { build(:referral) }
+
     context "when can upload more evidence" do
       it "returns true" do
-        expect(subject.can_upload_more_evidence?).to be_truthy
+        expect(referral).to be_can_upload_more_evidence
       end
     end
 
     context "when cannot upload more evidence" do
-      subject { create(:referral) }
+      subject(:referral) { create(:referral) }
 
       before do
-        create_list(:upload, FileUploadValidator::MAX_FILES, :evidence, uploadable: subject)
+        create_list(:upload, FileUploadValidator::MAX_FILES, :evidence, uploadable: referral)
       end
 
       it "returns false" do
-        expect(subject.can_upload_more_evidence?).to be_falsey
+        expect(referral).not_to be_can_upload_more_evidence
       end
     end
   end

--- a/spec/models/referral_spec.rb
+++ b/spec/models/referral_spec.rb
@@ -97,4 +97,24 @@ RSpec.describe Referral, type: :model do
       referral.submit
     end
   end
+
+  describe "#can_upload_more_evidence?" do
+    context "when can upload more evidence" do
+      it "returns true" do
+        expect(subject.can_upload_more_evidence?).to be_truthy
+      end
+    end
+
+    context "when cannot upload more evidence" do
+      subject { create(:referral) }
+
+      before do
+        create_list(:upload, FileUploadValidator::MAX_FILES, :evidence, uploadable: subject)
+      end
+
+      it "returns false" do
+        expect(subject.can_upload_more_evidence?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,13 +61,14 @@ RSpec.configure do |config|
 
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
-  #   # This allows you to limit a spec run to individual examples or groups
-  #   # you care about by tagging them with `:focus` metadata. When nothing
-  #   # is tagged with `:focus`, all examples get run. RSpec also provides
-  #   # aliases for `it`, `describe`, and `context` that include `:focus`
-  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
-  #
+
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend
   #   # you configure your source control system to ignore this file.

--- a/spec/system/public_referrals/user_adds_allegation_evidence_spec.rb
+++ b/spec/system/public_referrals/user_adds_allegation_evidence_spec.rb
@@ -5,6 +5,34 @@ RSpec.feature "Evidence", type: :system do
   include CommonSteps
   include SummaryListHelpers
 
+  scenario "A member of public uploads maximum number of evidence uploads" do
+    given_the_service_is_open
+    and_i_am_signed_in
+    and_the_referral_form_feature_is_active
+    and_i_am_a_member_of_the_public_with_an_existing_referral
+    and_i_visit_the_public_referral
+    then_i_see_the_public_referral_summary
+
+    when_i_edit_the_evidence
+    then_i_am_asked_if_i_have_evidence_to_upload
+
+    when_i_choose_yes_to_uploading_evidence
+    and_i_click_save_and_continue
+    then_i_am_asked_to_upload_evidence_files
+
+    when_i_upload_the_maximum_number_of_files
+    and_i_click_save_and_continue
+    then_i_see_a_list_of_max_uploaded_files
+    then_i_cannot_upload_another_file
+
+    when_i_click_save_and_continue
+    then_i_see_the_check_your_answers_page(
+      "Evidence and supporting information",
+      "allegation_evidence"
+    )
+    then_cannot_add_more_evidence
+  end
+
   scenario "A member of public adds evidence to referral" do
     given_the_service_is_open
     and_i_am_signed_in
@@ -310,5 +338,29 @@ RSpec.feature "Evidence", type: :system do
 
   def when_i_click_on_change_evidence
     click_on "Change if you have anything to upload"
+  end
+
+  def when_i_upload_the_maximum_number_of_files
+    attach_file(
+      "Upload files",
+      FileUploadValidator::MAX_FILES.times.map {
+        Rails.root.join("spec/fixtures/files/upload1.pdf")
+      }
+    )
+  end
+
+  def then_i_cannot_upload_another_file
+    expect(page).not_to have_content("Do you want to upload another file?")
+  end
+
+  def then_cannot_add_more_evidence
+    expect(page).not_to have_content("Add more evidence")
+  end
+
+  def then_i_see_a_list_of_max_uploaded_files
+    expect(page).to have_content("Uploaded evidence")
+    within(".govuk-summary-list") do
+      expect(page).to have_link("upload1.pdf", count: 20, href: /active_storage/)
+    end
   end
 end

--- a/spec/system/public_referrals/user_adds_allegation_evidence_spec.rb
+++ b/spec/system/public_referrals/user_adds_allegation_evidence_spec.rb
@@ -343,9 +343,9 @@ RSpec.feature "Evidence", type: :system do
   def when_i_upload_the_maximum_number_of_files
     attach_file(
       "Upload files",
-      FileUploadValidator::MAX_FILES.times.map {
+      FileUploadValidator::MAX_FILES.times.map do
         Rails.root.join("spec/fixtures/files/upload1.pdf")
-      }
+      end
     )
   end
 

--- a/spec/system/referrals/user_adds_allegation_evidence_spec.rb
+++ b/spec/system/referrals/user_adds_allegation_evidence_spec.rb
@@ -5,6 +5,34 @@ RSpec.feature "Evidence", type: :system do
   include CommonSteps
   include SummaryListHelpers
 
+  scenario "An employer uploads maximum number of evidence uploads" do
+    given_the_service_is_open
+    and_i_am_signed_in
+    and_the_referral_form_feature_is_active
+    and_i_have_an_existing_referral
+    and_i_visit_the_referral
+    then_i_see_the_referral_summary
+
+    when_i_edit_the_evidence
+    then_i_am_asked_if_i_have_evidence_to_upload
+
+    when_i_choose_yes_to_uploading_evidence
+    and_i_click_save_and_continue
+    then_i_am_asked_to_upload_evidence_files
+
+    when_i_upload_the_maximum_number_of_files
+    and_i_click_save_and_continue
+    then_i_see_a_list_of_max_uploaded_files
+    then_i_cannot_upload_another_file
+
+    when_i_click_save_and_continue
+    then_i_see_the_check_your_answers_page(
+      "Evidence and supporting information",
+      "allegation_evidence"
+    )
+    then_cannot_add_more_evidence
+  end
+
   scenario "An employer adds evidence to a referral" do
     given_the_service_is_open
     and_i_am_signed_in
@@ -319,5 +347,29 @@ RSpec.feature "Evidence", type: :system do
 
   def when_i_click_on_change_evidence
     click_on "Change if you have anything to upload"
+  end
+
+  def when_i_upload_the_maximum_number_of_files
+    attach_file(
+      "Upload files",
+      FileUploadValidator::MAX_FILES.times.map do
+        Rails.root.join("spec/fixtures/files/upload1.pdf")
+      end
+    )
+  end
+
+  def then_i_see_a_list_of_max_uploaded_files
+    expect(page).to have_content("Uploaded evidence")
+    within(".govuk-summary-list") do
+      expect(page).to have_link("upload1.pdf", count: 20, href: /active_storage/)
+    end
+  end
+
+  def then_i_cannot_upload_another_file
+    expect(page).not_to have_content("Do you want to upload another file?")
+  end
+
+  def then_cannot_add_more_evidence
+    expect(page).not_to have_content("Add more evidence")
   end
 end

--- a/spec/validators/file_upload_validator_spec.rb
+++ b/spec/validators/file_upload_validator_spec.rb
@@ -42,19 +42,9 @@ RSpec.describe FileUploadValidator do
 
   context "with too many files" do
     let(:files) do
-      [
-        fixture_file_upload("upload1.pdf", "application/pdf"),
-        fixture_file_upload("upload1.pdf", "application/pdf"),
-        fixture_file_upload("upload1.pdf", "application/pdf"),
-        fixture_file_upload("upload1.pdf", "application/pdf"),
-        fixture_file_upload("upload1.pdf", "application/pdf"),
-        fixture_file_upload("upload1.pdf", "application/pdf"),
-        fixture_file_upload("upload1.pdf", "application/pdf"),
-        fixture_file_upload("upload1.pdf", "application/pdf"),
-        fixture_file_upload("upload1.pdf", "application/pdf"),
-        fixture_file_upload("upload1.pdf", "application/pdf"),
+      (described_class::MAX_FILES + 1).times.map do
         fixture_file_upload("upload1.pdf", "application/pdf")
-      ]
+      end
     end
 
     it { is_expected.to be_invalid }


### PR DESCRIPTION
# Context

- Users want to be able to upload more files than the current limit of 10

# Changes

- Increased max file count limit from 10 to 20
- Updated rspec config so able to focus on tests
- Removed ability to add more evidence when max file count limit has been reached