### PR TITLE
enable more possible upload file formats

### DIFF
--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -9,18 +9,23 @@ class FileUploadValidator < ActiveModel::EachValidator
     ".avif" => "image/avif",
     ".doc" => "application/msword",
     ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".eml" => "message/rfc822",
     ".gif" => "image/gif",
     ".heic" => "image/heic",
     ".heif" => "image/heif",
     ".jpg" => "image/jpeg",
     ".jpeg" => "image/jpeg",
+    ".m4a" => "audio/mp4",
+    ".mov" => "video/quicktime",
     ".mp3" => "audio/mpeg",
     ".mp4" => "video/mp4",
-    ".mov" => "video/quicktime",
+    ".msg" => "application/x-ole-storage",
     ".pdf" => "application/pdf",
     ".png" => "image/png",
+    ".rtf" => "application/rtf",
     ".txt" => "text/plain",
-    ".webp" => "image/webp"
+    ".webp" => "image/webp",
+    ".xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   }.freeze
 
   def validate_each(record, attribute, uploaded_files)

--- a/spec/validators/file_upload_validator_spec.rb
+++ b/spec/validators/file_upload_validator_spec.rb
@@ -1,17 +1,18 @@
 require "rails_helper"
 
 RSpec.describe FileUploadValidator do
-  subject(:model) { Validatable.new }
+  subject(:model) do
+    instance = klass.new
+    instance.files = files
+    instance
+  end
 
-  let(:files) { nil }
-
-  before do
-    stub_const("Validatable", Class.new).class_eval do
+  let(:klass) do
+    Class.new do
       include ActiveModel::Validations
       attr_accessor :files
       validates :files, file_upload: true
     end
-    model.files = files
   end
 
   context "with a valid file" do
@@ -60,9 +61,31 @@ RSpec.describe FileUploadValidator do
     it { is_expected.to be_invalid }
   end
 
-  it "supports common media and document file types" do
+  it "supports selected media and document file types" do
     expect(described_class::CONTENT_TYPES.keys).to eq(
-      %w[.apng .avif .doc .docx .gif .heic .heif .jpg .jpeg .mp3 .mp4 .mov .pdf .png .txt .webp]
+      %w[
+        .apng
+        .avif
+        .doc
+        .docx
+        .eml
+        .gif
+        .heic
+        .heif
+        .jpg
+        .jpeg
+        .m4a
+        .mov
+        .mp3
+        .mp4
+        .msg
+        .pdf
+        .png
+        .rtf
+        .txt
+        .webp
+        .xlsx
+      ]
     )
   end
 end


### PR DESCRIPTION
# Context

- Allow users to be able to upload more file types

# Changes

- Added the following file formats: `.eml`, `.m4a`, `.msg`, `.rtf`, `.webp`, `.xlsx`