### PR TITLE
Increase file upload size limit to 100 mb

### DIFF
--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -1,7 +1,7 @@
 class FileUploadValidator < ActiveModel::EachValidator
   include FileSizeHelper
 
-  MAX_FILE_SIZE = 50.megabytes
+  MAX_FILE_SIZE = 100.megabytes
   MAX_FILES = 20
 
   CONTENT_TYPES = {

--- a/spec/helpers/file_size_helper_spec.rb
+++ b/spec/helpers/file_size_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe FileSizeHelper, type: :helper do
     subject { max_allowed_file_size }
 
     context "when called returns the max allowed file size human formatted with space removed" do
-      it { is_expected.to eq "50MB" }
+      it { is_expected.to eq "100MB" }
     end
   end
 end

--- a/spec/validators/file_upload_validator_spec.rb
+++ b/spec/validators/file_upload_validator_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe FileUploadValidator do
   context "with a large file" do
     let(:files) { fixture_file_upload("upload1.pdf", "application/pdf") }
 
-    before { allow(files).to receive(:size).and_return(51.megabytes) }
+    before { allow(files).to receive(:size).and_return(101.megabytes) }
 
     it { is_expected.to be_invalid }
   end


### PR DESCRIPTION
Rationale:  Employer UR and validation errors identified that users were unable some evidence due to the capacity on the service.  We have agreed with the business to increase this capacity to 100MB to start with and to review after a few months to see further.

User need:  As an Employer, I want to upload evidence that is over 50MB so that my referral can be considered fully by the TRA.