### PR TITLE
Review wording for adding feedback link from refer page to email content

### DIFF
--- a/app/views/referrals/confirmation/show.html.erb
+++ b/app/views/referrals/confirmation/show.html.erb
@@ -26,7 +26,7 @@
 
     <h2 class="govuk-heading-m">Give feedback</h2>
     <p class="govuk_body">
-      <%= govuk_link_to("Give feedback about this service", feedbacks_path) %> (takes 30 seconds).
+      <%= govuk_link_to("Tell us what you think of this service", feedbacks_path) %>
     </p>
   </div>
 </div>

--- a/app/views/user_mailer/referral_submitted.erb
+++ b/app/views/user_mailer/referral_submitted.erb
@@ -15,4 +15,8 @@ It could be decided that:
 
 You’ll be sent an email with the decision.
 
+# Giving Feedback
+
+<%= govuk_link_to("Tell us what you think of this service", feedbacks_url) %>
+
 <%= render "shared/mailers/get_help" %>


### PR DESCRIPTION
Edit the content on the submit feedback link. Add the link to the email confirming that a referral has been submitted.