### PR TITLE
Build of evidence upload changes

### DIFF
--- a/app/views/public_referrals/allegation_evidence/upload/edit.html.erb
+++ b/app/views/public_referrals/allegation_evidence/upload/edit.html.erb
@@ -34,7 +34,7 @@
           :evidence_uploads,
           multiple: true,
           label: { text: "Upload files", size: "m" },
-          hint: { text: "Must be smaller than #{max_allowed_file_size}" }
+          hint: { text: "You can upload up to 20 files. Each file must be smaller than #{max_allowed_file_size}. Larger files may take longer to upload. We will let you know when it is done." }
       ) %>
 
       <%= f.govuk_submit "Save and continue" %>


### PR DESCRIPTION
Currently the only specified criteria for evidence upload is that it must be smaller than 50MB.  Given validation errors around this area are high and people are unaware, it would be good to look at the language on this page and amend to make it clearer what evidence is accepted to prevent errors.