### PR TITLE
Fix back links

### DIFF
--- a/app/controllers/public_referrals/allegation_details/considerations_controller.rb
+++ b/app/controllers/public_referrals/allegation_details/considerations_controller.rb
@@ -7,6 +7,7 @@ module PublicReferrals
         @form =
           Referrals::AllegationDetails::ConsiderationsForm.new(
             referral: current_referral,
+            changing:,
             allegation_consideration_details: current_referral.allegation_consideration_details
           )
       end
@@ -14,7 +15,10 @@ module PublicReferrals
       def update
         @form =
           Referrals::AllegationDetails::ConsiderationsForm.new(
-            allegation_considerations_params.merge(referral: current_referral)
+            allegation_considerations_params.merge(
+              referral: current_referral,
+              changing:,
+            )
           )
 
         if @form.save

--- a/app/controllers/referrals/allegation_details/check_answers_controller.rb
+++ b/app/controllers/referrals/allegation_details/check_answers_controller.rb
@@ -10,7 +10,9 @@ module Referrals
       end
 
       def update
-        @form = CheckAnswersForm.new(check_answers_params.merge(referral: current_referral))
+        @form = CheckAnswersForm.new(
+          check_answers_params.merge(referral: current_referral)
+        )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/allegation_details/dbs_controller.rb
+++ b/app/controllers/referrals/allegation_details/dbs_controller.rb
@@ -2,11 +2,20 @@ module Referrals
   module AllegationDetails
     class DbsController < Referrals::BaseController
       def edit
-        @form = DbsForm.new(referral: current_referral, dbs_notified: current_referral.dbs_notified)
+        @form = DbsForm.new(
+          referral: current_referral,
+          changing:,
+          dbs_notified: current_referral.dbs_notified
+        )
       end
 
       def update
-        @form = DbsForm.new(allegation_dbs_params.merge(referral: current_referral))
+        @form = DbsForm.new(
+          allegation_dbs_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/allegation_details/details_controller.rb
+++ b/app/controllers/referrals/allegation_details/details_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           DetailsForm.new(
             referral: current_referral,
+            changing:,
             allegation_details: current_referral.allegation_details,
             allegation_format: current_referral.allegation_format,
             allegation_upload_file: current_referral.allegation_upload_file
@@ -12,7 +13,12 @@ module Referrals
       end
 
       def update
-        @form = DetailsForm.new(allegation_details_params.merge(referral: current_referral))
+        @form = DetailsForm.new(
+          allegation_details_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/allegation_evidence/check_answers_controller.rb
+++ b/app/controllers/referrals/allegation_evidence/check_answers_controller.rb
@@ -12,7 +12,9 @@ module Referrals
       end
 
       def update
-        @form = CheckAnswersForm.new(check_answers_params.merge(referral: current_referral))
+        @form = CheckAnswersForm.new(
+          check_answers_params.merge(referral: current_referral)
+        )
 
         if @form.save
           redirect_to @form.next_path
@@ -22,11 +24,17 @@ module Referrals
       end
 
       def delete
-        @form = CheckAnswersForm.new(referral: current_referral)
+        @form = CheckAnswersForm.new(
+          changing:,
+          referral: current_referral
+        )
       end
 
       def destroy
-        @form = CheckAnswersForm.new(referral: current_referral)
+        @form = CheckAnswersForm.new(
+          changing:,
+          referral: current_referral
+        )
         filename = evidence.filename
         evidence.destroy
 

--- a/app/controllers/referrals/allegation_evidence/start_controller.rb
+++ b/app/controllers/referrals/allegation_evidence/start_controller.rb
@@ -5,11 +5,20 @@ module Referrals
 
       def edit
         @form =
-          StartForm.new(referral: current_referral, has_evidence: current_referral.has_evidence)
+          StartForm.new(
+            referral: current_referral,
+            changing:,
+            has_evidence: current_referral.has_evidence
+          )
       end
 
       def update
-        @form = StartForm.new(start_params.merge(referral: current_referral))
+        @form = StartForm.new(
+          start_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.save
           redirect_path = [

--- a/app/controllers/referrals/allegation_evidence/upload_controller.rb
+++ b/app/controllers/referrals/allegation_evidence/upload_controller.rb
@@ -4,11 +4,19 @@ module Referrals
       include ReferralHelper
 
       def edit
-        @form = UploadForm.new(referral: current_referral)
+        @form = UploadForm.new(
+          referral: current_referral,
+          changing:,
+        )
       end
 
       def update
-        @form = UploadForm.new(upload_params.merge(referral: current_referral))
+        @form = UploadForm.new(
+          upload_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.save
           redirect_to [

--- a/app/controllers/referrals/allegation_evidence/uploaded_controller.rb
+++ b/app/controllers/referrals/allegation_evidence/uploaded_controller.rb
@@ -4,11 +4,19 @@ module Referrals
       include ReferralHelper
 
       def edit
-        @form = UploadedForm.new(referral: current_referral)
+        @form = UploadedForm.new(
+          referral: current_referral,
+          changing:,
+        )
       end
 
       def update
-        @form = UploadedForm.new(more_evidence_params.merge(referral: current_referral))
+        @form = UploadedForm.new(
+          more_evidence_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.valid?(:update)
           subsection =

--- a/app/controllers/referrals/allegation_previous_misconduct/detailed_account_controller.rb
+++ b/app/controllers/referrals/allegation_previous_misconduct/detailed_account_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           DetailedAccountForm.new(
             referral: current_referral,
+            changing:,
             previous_misconduct_format: current_referral.previous_misconduct_format,
             previous_misconduct_details: current_referral.previous_misconduct_details,
             previous_misconduct_upload_file: current_referral.previous_misconduct_upload_file
@@ -13,7 +14,12 @@ module Referrals
 
       def update
         @form =
-          DetailedAccountForm.new(detailed_account_form_params.merge(referral: current_referral))
+          DetailedAccountForm.new(
+            detailed_account_form_params.merge(
+              referral: current_referral,
+              changing:,
+            )
+          )
         if @form.save
           redirect_to @form.next_path
         else

--- a/app/controllers/referrals/allegation_previous_misconduct/reported_controller.rb
+++ b/app/controllers/referrals/allegation_previous_misconduct/reported_controller.rb
@@ -2,11 +2,19 @@ module Referrals
   module AllegationPreviousMisconduct
     class ReportedController < Referrals::BaseController
       def edit
-        @form = ReportedForm.new(referral: current_referral)
+        @form = ReportedForm.new(
+          referral: current_referral,
+          changing:,
+        )
       end
 
       def update
-        @form = ReportedForm.new(reported_form_params.merge(referral: current_referral))
+        @form = ReportedForm.new(
+          reported_form_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
         if @form.save
           redirect_to @form.next_path
         else

--- a/app/controllers/referrals/base_controller.rb
+++ b/app/controllers/referrals/base_controller.rb
@@ -34,5 +34,9 @@ module Referrals
 
     attr_reader :form
     helper_method :form
+
+    def changing
+      params[:return_to].present?
+    end
   end
 end

--- a/app/controllers/referrals/referrer_details/job_title_controller.rb
+++ b/app/controllers/referrals/referrer_details/job_title_controller.rb
@@ -2,13 +2,19 @@ module Referrals
   module ReferrerDetails
     class JobTitleController < Referrals::BaseController
       def edit
-        @form = Referrals::ReferrerDetails::JobTitleForm.new(referral: current_referral)
+        @form = Referrals::ReferrerDetails::JobTitleForm.new(
+          referral: current_referral,
+          changing:,
+        )
       end
 
       def update
         @form =
           Referrals::ReferrerDetails::JobTitleForm.new(
-            job_title_params.merge(referral: current_referral)
+            job_title_params.merge(
+              referral: current_referral,
+              changing:,
+            )
           )
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/referrer_details/name_controller.rb
+++ b/app/controllers/referrals/referrer_details/name_controller.rb
@@ -2,12 +2,20 @@ module Referrals
   module ReferrerDetails
     class NameController < Referrals::BaseController
       def edit
-        @form = Referrals::ReferrerDetails::NameForm.new(referral: current_referral)
+        @form = Referrals::ReferrerDetails::NameForm.new(
+          referral: current_referral,
+          changing:,
+        )
       end
 
       def update
         @form =
-          Referrals::ReferrerDetails::NameForm.new(name_params.merge(referral: current_referral))
+          Referrals::ReferrerDetails::NameForm.new(
+            name_params.merge(
+              referral: current_referral,
+              changing:,
+            )
+          )
         if @form.save
           redirect_to @form.next_path
         else

--- a/app/controllers/referrals/referrer_details/phone_controller.rb
+++ b/app/controllers/referrals/referrer_details/phone_controller.rb
@@ -2,13 +2,19 @@ module Referrals
   module ReferrerDetails
     class PhoneController < Referrals::BaseController
       def edit
-        @form = Referrals::ReferrerDetails::PhoneForm.new(referral: current_referral)
+        @form = Referrals::ReferrerDetails::PhoneForm.new(
+          referral: current_referral,
+          changing:,
+        )
       end
 
       def update
         @form =
           Referrals::ReferrerDetails::PhoneForm.new(
-            referrer_phone_form_params.merge(referral: current_referral)
+            referrer_phone_form_params.merge(
+              referral: current_referral,
+              changing:,
+            )
           )
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/referrer_organisation/address_controller.rb
+++ b/app/controllers/referrals/referrer_organisation/address_controller.rb
@@ -2,11 +2,19 @@ module Referrals
   module ReferrerOrganisation
     class AddressController < BaseController
       def edit
-        @form = AddressForm.new(referral: current_referral)
+        @form = AddressForm.new(
+          referral: current_referral,
+          changing:,
+        )
       end
 
       def update
-        @form = AddressForm.new(organisation_address_form_params.merge(referral: current_referral))
+        @form = AddressForm.new(
+          organisation_address_form_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
         if @form.save
           redirect_to @form.next_path
         else

--- a/app/controllers/referrals/teacher_contact_details/address_controller.rb
+++ b/app/controllers/referrals/teacher_contact_details/address_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           AddressForm.new(
             referral: current_referral,
+            changing:,
             address_line_1: current_referral.address_line_1,
             address_line_2: current_referral.address_line_2,
             town_or_city: current_referral.town_or_city,
@@ -15,7 +16,12 @@ module Referrals
 
       def update
         @form =
-          AddressForm.new(contact_details_address_form_params.merge(referral: current_referral))
+          AddressForm.new(
+            contact_details_address_form_params.merge(
+              referral: current_referral,
+              changing:,
+            )
+          )
         if @form.save
           redirect_to @form.next_path
         else

--- a/app/controllers/referrals/teacher_contact_details/address_known_controller.rb
+++ b/app/controllers/referrals/teacher_contact_details/address_known_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           AddressKnownForm.new(
             referral: current_referral,
+            changing:,
             address_known: current_referral.address_known
           )
       end
@@ -12,7 +13,10 @@ module Referrals
       def update
         @form =
           AddressKnownForm.new(
-            contact_details_address_known_form_params.merge(referral: current_referral)
+            contact_details_address_known_form_params.merge(
+              referral: current_referral,
+              changing:,
+            )
           )
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/teacher_contact_details/email_controller.rb
+++ b/app/controllers/referrals/teacher_contact_details/email_controller.rb
@@ -5,13 +5,19 @@ module Referrals
         @form =
           EmailForm.new(
             referral: current_referral,
+            changing:,
             email_known: current_referral.email_known,
             email_address: current_referral.email_address
           )
       end
 
       def update
-        @form = EmailForm.new(contact_details_email_form_params.merge(referral: current_referral))
+        @form = EmailForm.new(
+          contact_details_email_form_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
         if @form.save
           redirect_to @form.next_path
         else

--- a/app/controllers/referrals/teacher_contact_details/telephone_controller.rb
+++ b/app/controllers/referrals/teacher_contact_details/telephone_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           TelephoneForm.new(
             referral: current_referral,
+            changing:,
             phone_known: current_referral.phone_known,
             phone_number: current_referral.phone_number
           )
@@ -12,7 +13,12 @@ module Referrals
 
       def update
         @form =
-          TelephoneForm.new(contact_details_telephone_form_params.merge(referral: current_referral))
+          TelephoneForm.new(
+            contact_details_telephone_form_params.merge(
+              referral: current_referral,
+              changing:,
+            )
+          )
         if @form.save
           redirect_to @form.next_path
         else

--- a/app/controllers/referrals/teacher_personal_details/age_controller.rb
+++ b/app/controllers/referrals/teacher_personal_details/age_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           AgeForm.new(
             referral: current_referral,
+            changing:,
             age_known: current_referral.age_known,
             date_of_birth: current_referral.date_of_birth
           )
@@ -13,7 +14,11 @@ module Referrals
       def update
         @form =
           AgeForm.new(
-            age_params.merge(date_params: date_of_birth_params, referral: current_referral)
+            age_params.merge(
+              date_params: date_of_birth_params,
+              referral: current_referral,
+              changing:,
+            )
           )
 
         if @form.save

--- a/app/controllers/referrals/teacher_personal_details/name_controller.rb
+++ b/app/controllers/referrals/teacher_personal_details/name_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           NameForm.new(
             referral: current_referral,
+            changing:,
             first_name: current_referral.first_name,
             last_name: current_referral.last_name,
             name_has_changed: current_referral.name_has_changed,
@@ -13,7 +14,12 @@ module Referrals
       end
 
       def update
-        @form = NameForm.new(name_params.merge(referral: current_referral))
+        @form = NameForm.new(
+          name_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/teacher_personal_details/ni_number_controller.rb
+++ b/app/controllers/referrals/teacher_personal_details/ni_number_controller.rb
@@ -5,13 +5,19 @@ module Referrals
         @form =
           NiNumberForm.new(
             referral: current_referral,
+            changing:,
             ni_number: current_referral.ni_number,
             ni_number_known: current_referral.ni_number_known
           )
       end
 
       def update
-        @form = NiNumberForm.new(ni_number_form_params.merge(referral: current_referral))
+        @form = NiNumberForm.new(
+          ni_number_form_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
         if @form.save
           redirect_to @form.next_path
         else

--- a/app/controllers/referrals/teacher_personal_details/qts_controller.rb
+++ b/app/controllers/referrals/teacher_personal_details/qts_controller.rb
@@ -2,11 +2,20 @@ module Referrals
   module TeacherPersonalDetails
     class QtsController < Referrals::BaseController
       def edit
-        @form = QtsForm.new(referral: current_referral, has_qts: current_referral.has_qts)
+        @form = QtsForm.new(
+          referral: current_referral,
+          changing:,
+          has_qts: current_referral.has_qts
+        )
       end
 
       def update
-        @form = QtsForm.new(qts_params.merge(referral: current_referral))
+        @form = QtsForm.new(
+          qts_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/teacher_personal_details/trn_controller.rb
+++ b/app/controllers/referrals/teacher_personal_details/trn_controller.rb
@@ -5,13 +5,19 @@ module Referrals
         @form =
           TrnForm.new(
             referral: current_referral,
+            changing:,
             trn: current_referral.trn,
             trn_known: current_referral.trn_known
           )
       end
 
       def update
-        @form = TrnForm.new(trn_params.merge(referral: current_referral))
+        @form = TrnForm.new(
+          trn_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/teacher_role/duties_controller.rb
+++ b/app/controllers/referrals/teacher_role/duties_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           DutiesForm.new(
             referral: current_referral,
+            changing:,
             duties_details: current_referral.duties_details,
             duties_format: current_referral.duties_format,
             duties_upload_file: current_referral.duties_upload_file
@@ -12,7 +13,12 @@ module Referrals
       end
 
       def update
-        @form = DutiesForm.new(duties_params.merge(referral: current_referral))
+        @form = DutiesForm.new(
+          duties_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/teacher_role/employment_status_controller.rb
+++ b/app/controllers/referrals/teacher_role/employment_status_controller.rb
@@ -5,12 +5,18 @@ module Referrals
         @form =
           EmploymentStatusForm.new(
             referral: current_referral,
+            changing:,
             employment_status: current_referral.employment_status
           )
       end
 
       def update
-        @form = EmploymentStatusForm.new(employment_status_params.merge(referral: current_referral))
+        @form = EmploymentStatusForm.new(
+          employment_status_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/teacher_role/end_date_controller.rb
+++ b/app/controllers/referrals/teacher_role/end_date_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           EndDateForm.new(
             referral: current_referral,
+            changing:,
             role_end_date_known: current_referral.role_end_date_known,
             role_end_date: current_referral.role_end_date
           )
@@ -13,7 +14,11 @@ module Referrals
       def update
         @form =
           EndDateForm.new(
-            role_params.merge(date_params: end_date_params, referral: current_referral)
+            role_params.merge(
+              date_params: end_date_params,
+              referral: current_referral,
+              changing:,
+            )
           )
 
         if @form.save

--- a/app/controllers/referrals/teacher_role/job_title_controller.rb
+++ b/app/controllers/referrals/teacher_role/job_title_controller.rb
@@ -2,11 +2,20 @@ module Referrals
   module TeacherRole
     class JobTitleController < Referrals::BaseController
       def edit
-        @form = JobTitleForm.new(referral: current_referral, job_title: current_referral.job_title)
+        @form = JobTitleForm.new(
+          referral: current_referral,
+          changing:,
+          job_title: current_referral.job_title,
+        )
       end
 
       def update
-        @form = JobTitleForm.new(job_title_params.merge(referral: current_referral))
+        @form = JobTitleForm.new(
+          job_title_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/teacher_role/organisation_address_controller.rb
+++ b/app/controllers/referrals/teacher_role/organisation_address_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           OrganisationAddressForm.new(
             referral: current_referral,
+            changing:,
             organisation_name: current_referral.organisation_name,
             organisation_address_line_1: current_referral.organisation_address_line_1,
             organisation_address_line_2: current_referral.organisation_address_line_2,
@@ -15,7 +16,12 @@ module Referrals
 
       def update
         @form =
-          OrganisationAddressForm.new(organisation_address_params.merge(referral: current_referral))
+          OrganisationAddressForm.new(
+            organisation_address_params.merge(
+              referral: current_referral,
+              changing:,
+            )
+          )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/teacher_role/organisation_address_known_controller.rb
+++ b/app/controllers/referrals/teacher_role/organisation_address_known_controller.rb
@@ -5,14 +5,18 @@ module Referrals
         @form =
           OrganisationAddressKnownForm.new(
             referral: current_referral,
-            organisation_address_known: current_referral.organisation_address_known
+            changing:,
+            organisation_address_known: current_referral.organisation_address_known,
           )
       end
 
       def update
         @form =
           OrganisationAddressKnownForm.new(
-            organisation_address_known_params.merge(referral: current_referral)
+            organisation_address_known_params.merge(
+              referral: current_referral,
+              changing:,
+            )
           )
 
         if @form.save

--- a/app/controllers/referrals/teacher_role/reason_leaving_role_controller.rb
+++ b/app/controllers/referrals/teacher_role/reason_leaving_role_controller.rb
@@ -5,13 +5,19 @@ module Referrals
         @form =
           ReasonLeavingRoleForm.new(
             referral: current_referral,
+            changing:,
             reason_leaving_role: current_referral.reason_leaving_role
           )
       end
 
       def update
         @form =
-          ReasonLeavingRoleForm.new(reason_leaving_role_params.merge(referral: current_referral))
+          ReasonLeavingRoleForm.new(
+            reason_leaving_role_params.merge(
+              referral: current_referral,
+              changing:,
+            )
+          )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/teacher_role/same_organisation_controller.rb
+++ b/app/controllers/referrals/teacher_role/same_organisation_controller.rb
@@ -5,12 +5,18 @@ module Referrals
         @form =
           SameOrganisationForm.new(
             referral: current_referral,
+            changing:,
             same_organisation: current_referral.same_organisation
           )
       end
 
       def update
-        @form = SameOrganisationForm.new(same_organisation_params.merge(referral: current_referral))
+        @form = SameOrganisationForm.new(
+          same_organisation_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/teacher_role/start_date_controller.rb
+++ b/app/controllers/referrals/teacher_role/start_date_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           StartDateForm.new(
             referral: current_referral,
+            changing:,
             role_start_date_known: current_referral.role_start_date_known,
             role_start_date: current_referral.role_start_date
           )
@@ -13,7 +14,11 @@ module Referrals
       def update
         @form =
           StartDateForm.new(
-            role_params.merge(date_params: start_date_params, referral: current_referral)
+            role_params.merge(
+              date_params: start_date_params,
+              referral: current_referral,
+              changing:,
+            )
           )
 
         if @form.save

--- a/app/controllers/referrals/teacher_role/work_location_controller.rb
+++ b/app/controllers/referrals/teacher_role/work_location_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           WorkLocationForm.new(
             referral: current_referral,
+            changing:,
             work_organisation_name: current_referral.work_organisation_name,
             work_address_line_1: current_referral.work_address_line_1,
             work_address_line_2: current_referral.work_address_line_2,
@@ -14,7 +15,12 @@ module Referrals
       end
 
       def update
-        @form = WorkLocationForm.new(work_location_params.merge(referral: current_referral))
+        @form = WorkLocationForm.new(
+          work_location_params.merge(
+            referral: current_referral,
+            changing:,
+          )
+        )
 
         if @form.save
           redirect_to @form.next_path

--- a/app/controllers/referrals/teacher_role/work_location_known_controller.rb
+++ b/app/controllers/referrals/teacher_role/work_location_known_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           WorkLocationKnownForm.new(
             referral: current_referral,
+            changing:,
             work_location_known: current_referral.work_location_known
           )
       end

--- a/app/controllers/referrals/teacher_role/working_somewhere_else_controller.rb
+++ b/app/controllers/referrals/teacher_role/working_somewhere_else_controller.rb
@@ -5,6 +5,7 @@ module Referrals
         @form =
           WorkingSomewhereElseForm.new(
             referral: current_referral,
+            changing:,
             working_somewhere_else: current_referral.working_somewhere_else
           )
       end
@@ -12,7 +13,10 @@ module Referrals
       def update
         @form =
           WorkingSomewhereElseForm.new(
-            working_somewhere_else_params.merge(referral: current_referral)
+            working_somewhere_else_params.merge(
+              referral: current_referral,
+              changing:,
+            )
           )
 
         if @form.save

--- a/app/forms/referrals/form_item.rb
+++ b/app/forms/referrals/form_item.rb
@@ -5,11 +5,15 @@ module Referrals
     include ValidationTracking
     include CustomAttrs
 
-    attr_accessor :referral
+    attr_accessor :referral, :changing
 
     validates :referral, presence: true
 
     delegate :label, to: :section, prefix: true
+
+    def changing?
+      changing
+    end
 
     def complete?
       valid_without_tracking?
@@ -21,6 +25,10 @@ module Referrals
 
     def path
       [:edit, referral.routing_scope, referral, section.slug, slug]
+    end
+
+    def check_answers_path
+      [:edit, referral.routing_scope, referral, section.slug, :check_answers]
     end
 
     def edit_path
@@ -40,7 +48,13 @@ module Referrals
     end
 
     def previous_path
-      check_answers? || first? ? edit_path : section.previous_path
+      if changing?
+        check_answers_path
+      elsif check_answers? || first?
+        edit_path
+      else
+        section.previous_path
+      end
     end
 
     def first?

--- a/spec/system/referrals/user_adds_teacher_personal_details_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_personal_details_spec.rb
@@ -32,6 +32,10 @@ RSpec.feature "Personal details", type: :system do
     then_i_see_the_check_your_answers_page("Personal details", "teacher_personal_details")
 
     when_i_click_on_change_their_name
+    and_i_click_back
+    then_i_see_the_check_your_answers_page("Personal details", "teacher_personal_details")
+
+    when_i_click_on_change_their_name
     and_i_am_asked_their_name
     and_i_click_save_and_continue
     then_i_am_asked_their_date_of_birth

--- a/spec/system/referrals/user_adds_teacher_role_spec.rb
+++ b/spec/system/referrals/user_adds_teacher_role_spec.rb
@@ -550,10 +550,6 @@ RSpec.feature "Teacher role", type: :system do
     )
   end
 
-  def when_i_click_on_change_their_duties_format
-    click_on "Change how you want to give details about their main duties"
-  end
-
   def then_i_see_the_completed_section_in_the_referral_summary
     within(all(".app-task-list__section")[1]) do
       within(all(".app-task-list__item")[2]) do


### PR DESCRIPTION
# Context

- There is an issue with back links when changing answers
- Instead of taking them back to `check your answers` page it would take them the the previous page of the section

# Changes

- On changing answers the back link now takes the user back to the `check your answers` page
- Each form is passed state on whether the user is `changing` answer or not
- Therefore the form can then work out what the back link should link to