### PR TITLE
add autocomplete to fields

### DIFF
--- a/app/views/referrals/referrer_details/name/edit.html.erb
+++ b/app/views/referrals/referrer_details/name/edit.html.erb
@@ -9,8 +9,8 @@
       <span class="govuk-caption-l"><%= section_label %></span>
       <h1 class="govuk-heading-l"><%= form_label %></h1>
 
-      <%= f.govuk_text_field :first_name, label: { size: 'm', text: "First name" }, hint: { text: "Or given name" } %>
-      <%= f.govuk_text_field :last_name, label: { size: 'm', text: "Last name" }, hint: { text: "Or family name" } %>
+      <%= f.govuk_text_field :first_name, autocomplete: "given-name", label: { size: 'm', text: "First name" }, hint: { text: "Or given name" } %>
+      <%= f.govuk_text_field :last_name, autocomplete: "family-name",  label: { size: 'm', text: "Last name" }, hint: { text: "Or family name" } %>
       <%= f.govuk_submit 'Save and continue' %>
     <% end %>
   </div>

--- a/app/views/referrals/referrer_organisation/address/edit.html.erb
+++ b/app/views/referrals/referrer_organisation/address/edit.html.erb
@@ -8,7 +8,7 @@
 
       <h1 class="govuk-heading-l"><%= section_label %></h1>
 
-      <%= f.govuk_text_field :name, label: { size: "m", text: "Organisation name" } %>
+      <%= f.govuk_text_field :name, autocomplete: "organization", label: { size: "m", text: "Organisation name" } %>
       <%= f.govuk_text_field :street_1, autocomplete: "address-line1", label: { size: "m", text: "Address line 1" } %>
       <%= f.govuk_text_field :street_2, autocomplete: "address-line2", label: { size: "m", text: "Address line 2 (optional)" } %>
       <%= f.govuk_text_field :city, autocomplete: "address-level2", label: { size: "m", text: "Town or city" } %>

--- a/app/views/referrals/teacher_contact_details/address/edit.html.erb
+++ b/app/views/referrals/teacher_contact_details/address/edit.html.erb
@@ -9,11 +9,11 @@
       <span class="govuk-caption-l"><%= section_label %></span>
       <h1 class="govuk-heading-l"><%= form_label %></h1>
 
-      <%= f.govuk_text_field :address_line_1, label: { size: 'm', text: "Address line 1" } %>
-      <%= f.govuk_text_field :address_line_2, label: { size: 'm', text: "Address line 2 (optional)" } %>
-      <%= f.govuk_text_field :town_or_city, label: { size: 'm', text: "Town or city" } %>
-      <%= f.govuk_text_field :postcode, label: { size: 'm', text: "Postcode" } %>
-      <%= f.govuk_text_field :country, label: { size: 'm', text: "Country (optional)" } %>
+      <%= f.govuk_text_field :address_line_1, autocomplete: "address-line1", label: { size: 'm', text: "Address line 1" } %>
+      <%= f.govuk_text_field :address_line_2, autocomplete: "address-line2", label: { size: 'm', text: "Address line 2 (optional)" } %>
+      <%= f.govuk_text_field :town_or_city, autocomplete: "address-level2" ,label: { size: 'm', text: "Town or city" } %>
+      <%= f.govuk_text_field :postcode, autocomplete: "postal-code", label: { size: 'm', text: "Postcode" } %>
+      <%= f.govuk_text_field :country, autocomplete: "country", label: { size: 'm', text: "Country (optional)" } %>
       <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>

--- a/app/views/referrals/teacher_contact_details/email/edit.html.erb
+++ b/app/views/referrals/teacher_contact_details/email/edit.html.erb
@@ -10,7 +10,7 @@
       <%= f.govuk_radio_buttons_fieldset :email_known, legend: { tag: 'h1', size: 'l', text: form_label }  do %>
         <%= f.hidden_field :email_known %>
         <%= f.govuk_radio_button :email_known, true, label: { text: "Yes" }, link_errors: true do %>
-          <%= f.govuk_text_field :email_address, label: { text: "Email address", size: 's' } %>
+          <%= f.govuk_text_field :email_address, autocomplete: "email", label: { text: "Email address", size: 's' } %>
         <% end %>
         <%= f.govuk_radio_button :email_known, false, label: { text: "No" } %>
       <% end %>

--- a/app/views/referrals/teacher_personal_details/name/edit.html.erb
+++ b/app/views/referrals/teacher_personal_details/name/edit.html.erb
@@ -12,6 +12,7 @@
       <div class="govuk-form-group">
         <%= f.govuk_text_field(
           :first_name,
+          autocomplete: "given-name",
           label: { text: "First name", class: "govuk-label--m" },
           hint: { text: "Or given name - enter their initial if you do not know their first name" }
         ) %>
@@ -19,6 +20,7 @@
       <div class="govuk-form-group">
         <%= f.govuk_text_field(
           :last_name,
+          autocomplete: "family-name",
           label: { text: "Last name", class: "govuk-label--m" },
           hint: { text: "Or family name" }
         ) %>
@@ -30,7 +32,7 @@
             hint: { text: "For example, if they’ve changed their name after getting married" }
         ) do %>
           <%= f.govuk_radio_button :name_has_changed, "yes", label: { text: "Yes" }, link_errors: true do %>
-            <%= f.govuk_text_field :previous_name, label: { text: "Other name", class: "govuk-label--s" } %>
+            <%= f.govuk_text_field :previous_name, autocomplete: "nickname", label: { text: "Other name", class: "govuk-label--s" } %>
           <% end %>
           <%= f.govuk_radio_button :name_has_changed, "no", label: { text: "No" } %>
         <% end %>

--- a/app/views/referrals/teacher_role/organisation_address/edit.html.erb
+++ b/app/views/referrals/teacher_role/organisation_address/edit.html.erb
@@ -11,11 +11,11 @@
         Name and address of the organisation where the alleged misconduct took place
       </h1>
 
-      <%= f.govuk_text_field :organisation_name, label: { text: "Organisation name", size: "m" } %>
-      <%= f.govuk_text_field :organisation_address_line_1, label: { text: "Address line 1", size: "m" } %>
-      <%= f.govuk_text_field :organisation_address_line_2, label: { text: "Address line 2 (optional)", size: "m" } %>
-      <%= f.govuk_text_field :organisation_town_or_city, label: { text: "Town or city", size: "m" } %>
-      <%= f.govuk_text_field :organisation_postcode, label: { text: "Postcode", size: "m" } %>
+      <%= f.govuk_text_field :organisation_name, autocomplete: "organization", label: { text: "Organisation name", size: "m" } %>
+      <%= f.govuk_text_field :organisation_address_line_1, autocomplete: "address-line1", label: { text: "Address line 1", size: "m" } %>
+      <%= f.govuk_text_field :organisation_address_line_2, autocomplete: "address-line2", label: { text: "Address line 2 (optional)", size: "m" } %>
+      <%= f.govuk_text_field :organisation_town_or_city, autocomplete: "address-level2", label: { text: "Town or city", size: "m" } %>
+      <%= f.govuk_text_field :organisation_postcode, autocomplete: "postal-code", label: { text: "Postcode", size: "m" } %>
       <%= f.govuk_submit 'Save and continue' %>
     <% end %>
   </div>

--- a/app/views/referrals/teacher_role/work_location/edit.html.erb
+++ b/app/views/referrals/teacher_role/work_location/edit.html.erb
@@ -9,11 +9,11 @@
       <span class="govuk-caption-l"><%= section_label %></span>
       <h1 class="govuk-heading-l"><%= form_label %></h1>
 
-      <%= f.govuk_text_field :work_organisation_name, label: { text: "Organisation name", size: "m" } %>
-      <%= f.govuk_text_field :work_address_line_1, label: { text: "Address line 1", size: "m" } %>
-      <%= f.govuk_text_field :work_address_line_2, label: { text: "Address line 2 (optional)", size: "m" } %>
-      <%= f.govuk_text_field :work_town_or_city, label: { text: "Town or city", size: "m" } %>
-      <%= f.govuk_text_field :work_postcode, label: { text: "Postcode", size: "m" } %>
+      <%= f.govuk_text_field :work_organisation_name, autocomplete: "organization", label: { text: "Organisation name", size: "m" } %>
+      <%= f.govuk_text_field :work_address_line_1, autocomplete: "address-line1", label: { text: "Address line 1", size: "m" } %>
+      <%= f.govuk_text_field :work_address_line_2, autocomplete: "address-line2", label: { text: "Address line 2 (optional)", size: "m" } %>
+      <%= f.govuk_text_field :work_town_or_city, autocomplete: "address-level2", label: { text: "Town or city", size: "m" } %>
+      <%= f.govuk_text_field :work_postcode, autocomplete: "postal-code", label: { text: "Postcode", size: "m" } %>
       <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>

--- a/app/views/staff/invitations/new.html.erb
+++ b/app/views/staff/invitations/new.html.erb
@@ -7,7 +7,7 @@
     <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :email, label: { text: "Email address", size: "m" } %>
+      <%= f.govuk_text_field :email, autocomplete: "email", label: { text: "Email address", size: "m" } %>
 
       <%= f.govuk_check_boxes_fieldset :permissions, legend: { text: "Permissions", size: "m" } do %>
         <%= f.govuk_check_box :view_support, 1, multiple: false,  label: { text: "view support" } %>


### PR DESCRIPTION
# Context

- Need to add `autocomplete` to fields in order to conform to WCAG 2.1 AA

# Changes

- Updated relevant fields to have `autocomplete` attribute