### PR TITLE
add abbr tags to copy

### DIFF
--- a/app/views/pages/complete.html.erb
+++ b/app/views/pages/complete.html.erb
@@ -11,13 +11,13 @@
       <p>You’ll need to follow these steps:</p>
       <ul class="govuk-list govuk-list--number">
         <li>Report your concerns locally</li>
-        <li>Check if TRA will deal with the allegation</li>
-        <li>Report the teacher to TRA using this service (online or using the paper form)</li>
-        <li>Wait to hear back from TRA</li>
-        <li>If TRA decide to investigate, they’ll send a copy of the allegations to the teacher</li>
-        <li>TRA will decide whether there is a case to answer</li>
+        <li>Check if <abbr title="Teaching Regulation Agency">TRA</abbr> will deal with the allegation</li>
+        <li>Report the teacher to <abbr title="Teaching Regulation Agency">TRA</abbr> using this service (online or using the paper form)</li>
+        <li>Wait to hear back from <abbr title="Teaching Regulation Agency">TRA</abbr></li>
+        <li>If <abbr title="Teaching Regulation Agency">TRA</abbr> decide to investigate, they’ll send a copy of the allegations to the teacher</li>
+        <li><abbr title="Teaching Regulation Agency">TRA</abbr> will decide whether there is a case to answer</li>
         <li>A professional conduct panel meeting or hearing takes place</li>
-        <li>TRA confirm the outcome of the meeting or hearing</li>
+        <li><abbr title="Teaching Regulation Agency">TRA</abbr> confirm the outcome of the meeting or hearing</li>
       </ul>
     <% end %>
 
@@ -44,7 +44,7 @@
     </p>
 
     <h3 class="govuk-heading-m">Get help with your referral</h3>
-    <p>If you need more information about making a referral, you can contact TRA.</p>
+    <p>If you need more information about making a referral, you can contact <abbr title="Teaching Regulation Agency">TRA</abbr>.</p>
     <p>Email: <%= mail_to t('service.email') %><br>We aim to respond within 3 working days.</p>
     <p>Phone: 020 7593 5393<br>Monday to Friday, 9am to 5pm (except Mondays and Fridays)</p>
     <p><a href="https://www.gov.uk/call-charges">Find out about call charges</a>.</p>

--- a/app/views/referrals/allegation_details/dbs/edit.html.erb
+++ b/app/views/referrals/allegation_details/dbs/edit.html.erb
@@ -11,7 +11,7 @@
 
       <p>DBS (Disclosure and Barring Service) need to know about any allegations that involve harm to a child, or the risk of harm to a child.</p>
 
-      <p>If you have not told DBS about your allegation, we’ll pass your report onto them if it meets all the legal requirements.</p>
+      <p>If you have not told <abbr title="Disclosure and Barring Service">DBS</abbr> about your allegation, we’ll pass your report onto them if it meets all the legal requirements.</p>
 
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset(:dbs_notified, legend: { text: "Have you told DBS about this case?", size: "m" }) do %>

--- a/app/views/shared/_declaration.html.erb
+++ b/app/views/shared/_declaration.html.erb
@@ -4,7 +4,7 @@
   <li>your allegation will be investigated, which could result in the person you’re referring being stopped from teaching</li>
   <li>your answers are true to the best of your knowledge and belief</li>
   <li>your referral, any evidence and supporting information will be shared with the person you’re referring and any employer</li>
-  <li>you have permission from the relevant third parties for any evidence and supporting information to be shared, for example the police or DBS</li>
+  <li>you have permission from the relevant third parties for any evidence and supporting information to be shared, for example the police or <abbr title="Disclosure and Barring Service">DBS</abbr></li>
   <li>you may need to attend a hearing and give evidence if your allegation reaches that stage</li>
   <li>your referral will be kept on file for 50 years</li>
 </ul>


### PR DESCRIPTION
# Context

- Guidance at https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms suggest acronyms should use the `<abbr>` tag

# Changes

- Add `<abbr>` tags to relevant abbreviations in copy