### PR TITLE
enable sentry performance

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -20,4 +20,12 @@ Sentry.init do |config|
     "ActionDispatch::Http::Parameters::ParseError",
     "Mime::Type::InvalidMimeType"
   ]
+
+  config.traces_sampler = lambda do |sampling_context|
+    rack_env = sampling_context[:env]
+
+    return 0.001 if rack_env['PATH_INFO'] =~ /health/
+
+    0.1
+  end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -22,7 +22,7 @@ Sentry.init do |config|
   ]
 
   config.traces_sampler = lambda do |sampling_context|
-    rack_env = sampling_context[:env]
+    rack_env = sampling_context[:env] || {}
 
     return 0.001 if rack_env['PATH_INFO'] =~ /health/
 


### PR DESCRIPTION
# Context

- We want to be able to track performance so we can identify any bottlenecks or any issues that creep in

# Changes

- Enabled tracing for sentry to track performance
- It samples 10% percent of requests and 0.1% of the health check requests