### PR TITLE
Update email about deleting drafts in 90 days

### DIFF
--- a/app/views/user_mailer/referral_link.erb
+++ b/app/views/user_mailer/referral_link.erb
@@ -4,4 +4,6 @@ Complete your referral:
 
 <%= polymorphic_url([:edit, @referral.routing_scope, @referral]) %>
 
+Draft referrals will be deleted after 90 days of no activity. We’ll send you an email before deleting it.
+
 <%= render "shared/mailers/get_help" %>


### PR DESCRIPTION
# Context

- We delete draft referrals but don't inform users of this in corresponding emails

# Changes

- Updated email copy when user creates a draft referral, it now includes notice of 90 days of inactivity leads to deletion 