### PR TITLE
enable DfE analytics entity checks

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -1,6 +1,7 @@
 DfE::Analytics.configure do |config|
   config.queue = :analytics
   config.environment = HostingEnvironment.environment_name
+  config.entity_table_checks_enabled = true
 
   config.enable_analytics =
     proc do

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -9,3 +9,7 @@ draft_referral_reminder:
 fetch_malware_scan_results:
   cron: "*/30 * * * *"
   class: FetchMalwareScanResultsJob
+
+send_entity_table_checks_to_bigquery:
+  cron: "30 3 * * *" # Every day at 03:30
+  class: "DfE::Analytics::EntityTableCheckJob"


### PR DESCRIPTION
# Context

- Enable DfE analytics checks to ensure correct analytics are being stored