### PR TITLE
increase upload threshold to 40 files

### DIFF
--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -2,7 +2,7 @@ class FileUploadValidator < ActiveModel::EachValidator
   include FileSizeHelper
 
   MAX_FILE_SIZE = 100.megabytes
-  MAX_FILES = 20
+  MAX_FILES = 40
 
   CONTENT_TYPES = {
     ".apng" => "image/apng",

--- a/app/views/public_referrals/allegation_evidence/upload/edit.html.erb
+++ b/app/views/public_referrals/allegation_evidence/upload/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop ">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: form, url: form_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/public_referrals/allegation_evidence/upload/edit.html.erb
+++ b/app/views/public_referrals/allegation_evidence/upload/edit.html.erb
@@ -34,7 +34,7 @@
           :evidence_uploads,
           multiple: true,
           label: { text: "Upload files", size: "m" },
-          hint: { text: "You can upload up to 20 files. Each file must be smaller than #{max_allowed_file_size}. Larger files may take longer to upload. We will let you know when it is done." }
+          hint: { text: "You can upload up to #{FileUploadValidator::MAX_FILES} files. Each file must be smaller than #{max_allowed_file_size}. Larger files may take longer to upload. We will let you know when it is done." }
       ) %>
 
       <%= f.govuk_submit "Save and continue" %>

--- a/app/views/referrals/allegation_evidence/upload/edit.html.erb
+++ b/app/views/referrals/allegation_evidence/upload/edit.html.erb
@@ -44,7 +44,7 @@
           :evidence_uploads,
           multiple: true,
           label: { text: "Upload files", size: "m" },
-          hint: { text: "Must be smaller than #{max_allowed_file_size}" }
+          hint: { text: "You can upload up to #{FileUploadValidator::MAX_FILES} files. Each file must be smaller than #{max_allowed_file_size}. Larger files may take longer to upload. We will let you know when it is done." }
       ) %>
 
       <%= f.govuk_submit "Save and continue" %>

--- a/spec/forms/referrals/allegation_evidence/upload_form_spec.rb
+++ b/spec/forms/referrals/allegation_evidence/upload_form_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Referrals::AllegationEvidence::UploadForm, type: :model do
           fixture_file_upload("upload.txt")
         end
         expect(upload_form.save).to be false
-        expect(upload_form.errors[:evidence_uploads]).to eq(["You can only upload 20 files"])
+        expect(upload_form.errors[:evidence_uploads]).to eq(["You can only upload 40 files"])
       end
     end
   end

--- a/spec/system/public_referrals/user_adds_allegation_evidence_spec.rb
+++ b/spec/system/public_referrals/user_adds_allegation_evidence_spec.rb
@@ -360,7 +360,7 @@ RSpec.feature "Evidence", type: :system do
   def then_i_see_a_list_of_max_uploaded_files
     expect(page).to have_content("Uploaded evidence")
     within(".govuk-summary-list") do
-      expect(page).to have_link("upload1.pdf", count: 20, href: /active_storage/)
+      expect(page).to have_link("upload1.pdf", count: 40, href: /active_storage/)
     end
   end
 end

--- a/spec/system/referrals/user_adds_allegation_evidence_spec.rb
+++ b/spec/system/referrals/user_adds_allegation_evidence_spec.rb
@@ -361,7 +361,7 @@ RSpec.feature "Evidence", type: :system do
   def then_i_see_a_list_of_max_uploaded_files
     expect(page).to have_content("Uploaded evidence")
     within(".govuk-summary-list") do
-      expect(page).to have_link("upload1.pdf", count: 20, href: /active_storage/)
+      expect(page).to have_link("upload1.pdf", count: 40, href: /active_storage/)
     end
   end
 


### PR DESCRIPTION
# Context

- Increase file upload count limit from 20 to 40 so users can upload more evidence

# Screenshots

![Screenshot 2024-01-25 at 12 15 46](https://github.com/DFE-Digital/refer-serious-misconduct/assets/92580/ec1e4122-f9ad-4c88-9647-687178056034)