### PR TITLE
Condense Validation Upload Size Errors

### DIFF
--- a/app/lib/upload_wrapper.rb
+++ b/app/lib/upload_wrapper.rb
@@ -1,14 +1,16 @@
 class UploadWrapper
   include ActiveSupport::NumberHelper
 
-  attr_reader :upload
+  attr_reader :upload, :count
 
-  def initialize(upload:)
+  def initialize(upload:, count:)
     @upload = upload
+    @count = count
   end
 
   def as_json(*args)
     r = super
-    r.merge(file_size: number_to_human_size(upload.size, strip_insignificant_zeros: false))
+    r.merge(file_size: number_to_human_size(upload.size, strip_insignificant_zeros: false),
+            files_with_errors_count: count)
   end
 end

--- a/app/models/concerns/validation_tracking.rb
+++ b/app/models/concerns/validation_tracking.rb
@@ -44,9 +44,10 @@ module ValidationTracking
     value = public_send(field)
 
     if value.instance_of?(Array)
+      count = value.count {|file| file.size >= FileUploadValidator::MAX_FILE_SIZE }
       value = value.map do |upload|
         if upload.instance_of?(ActionDispatch::Http::UploadedFile)
-          UploadWrapper.new(upload:)
+          UploadWrapper.new(upload:, count:)
         else
           upload
         end

--- a/spec/lib/upload_wrapper_spec.rb
+++ b/spec/lib/upload_wrapper_spec.rb
@@ -3,13 +3,18 @@ require "rails_helper"
 RSpec.describe UploadWrapper do
   describe "#as_json" do
     subject(:upload_wrapper) do
-      described_class.new(upload:)
+      described_class.new(upload:, count:)
     end
 
     let(:upload) { file_fixture("upload1.pdf") }
+    let(:count) { 4 }
 
     it "includes file size" do
       expect(upload_wrapper.as_json[:file_size]).to eql("4.98 KB")
+    end
+
+    it "includes the count" do
+      expect(upload_wrapper.as_json[:files_with_errors_count]).to be(4)
     end
   end
 end

--- a/spec/models/concerns/validation_tracking_spec.rb
+++ b/spec/models/concerns/validation_tracking_spec.rb
@@ -38,5 +38,49 @@ RSpec.describe ValidationTracking do
         expect(ValidationError.last.details.dig("evidence_uploads", "value", 0, "file_size")).to eql("4.98 KB")
       end
     end
+
+    context "when an uploaded file is over maximum size" do
+      subject(:instance) do
+        klass.new(evidence_uploads: [ActionDispatch::Http::UploadedFile.new(tempfile: file_fixture("upload1.pdf"))])
+      end
+
+      it "persists the count of files over the max size" do
+        stub_const("FileUploadValidator::MAX_FILE_SIZE", 1.kilobyte)
+        expect {
+          instance.valid?
+        }.to change(ValidationError, :count).by(1)
+        expect(ValidationError.last.details.dig("evidence_uploads", "value", 0, "files_with_errors_count")).to be(1)
+      end
+    end
+
+    context "when multiple files are uploaded together and one is over the maximum size" do
+      subject(:instance) do
+        klass.new(evidence_uploads: [ActionDispatch::Http::UploadedFile.new(tempfile: file_fixture("upload1.pdf")),
+                                     ActionDispatch::Http::UploadedFile.new(tempfile: file_fixture("upload.txt"))])
+      end
+
+      it "persists the count of files over the max size" do
+        stub_const("FileUploadValidator::MAX_FILE_SIZE", 1.kilobyte)
+        expect {
+          instance.valid?
+        }.to change(ValidationError, :count).by(1)
+        expect(ValidationError.last.details.dig("evidence_uploads", "value", 0, "files_with_errors_count")).to be(1)
+      end
+    end
+
+    context "when multiple uploaded files are over maximum size" do
+      subject(:instance) do
+        klass.new(evidence_uploads: [ActionDispatch::Http::UploadedFile.new(tempfile: file_fixture("upload1.pdf")),
+                                     ActionDispatch::Http::UploadedFile.new(tempfile: file_fixture("upload2.pdf"))])
+      end
+
+      it "persists the count of files over the max size" do
+        stub_const("FileUploadValidator::MAX_FILE_SIZE", 1.kilobyte)
+        expect {
+          instance.valid?
+        }.to change(ValidationError, :count).by(1)
+        expect(ValidationError.last.details.dig("evidence_uploads", "value", 0, "files_with_errors_count")).to be(2)
+      end
+    end
   end
 end


### PR DESCRIPTION
Add wrapper in refer-serious-misconduct/app/models/concerns/validation_tracking.rb that checks in the value for field method that checks for ant files over size limit. This will allow support staff to quickly assess how many files in a batch upload are over the file size limit.