### PR TITLE
Introduce developer role + hide features behind it

### DIFF
--- a/app/controllers/developer_interface/developer_interface_controller.rb
+++ b/app/controllers/developer_interface/developer_interface_controller.rb
@@ -1,0 +1,26 @@
+module DeveloperInterface
+  class DeveloperInterfaceController < ApplicationController
+    include Pundit::Authorization
+
+    rescue_from Pundit::NotAuthorizedError, with: :staff_user_not_authorized
+
+    layout "support_layout"
+
+    before_action :authenticate_staff!, :authorize_developer
+
+    private
+
+    def staff_user_not_authorized
+      # FeatureFlags::Engine is a mounted engine and we can't control the
+      # behaviour from this level. Attempting to do the redirect
+      # here ends up in multiple redirects.
+      redirect_to forbidden_path unless is_a?(FeatureFlags::FeatureFlagsController)
+    end
+
+    def authorize_developer
+      authorize :developer
+    end
+
+    alias_method :pundit_user, :current_staff
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,13 +25,16 @@ module ApplicationHelper
   def navigation
     govuk_header(service_name:) do |header|
       case current_namespace
-      when "manage", "staff"
-        if current_staff # TODO: replace with case worker user type
-          header.with_navigation_item(
-            active: current_page?(main_app.manage_interface_referrals_path),
-            href: main_app.manage_interface_referrals_path,
-            text: "Referrals"
-          )
+      when "manage", "staff", "support", "developer"
+        if current_staff
+          if current_staff.manage_referrals?
+            header.with_navigation_item(
+              active: current_page?(main_app.manage_interface_referrals_path),
+              href: main_app.manage_interface_referrals_path,
+              text: "Referrals"
+            )
+          end
+
           if current_staff.view_support?
             header.with_navigation_item(
               active: current_page?(main_app.support_interface_validation_errors_path),
@@ -42,11 +45,6 @@ module ApplicationHelper
               active: current_page?(main_app.support_interface_eligibility_checks_path),
               href: main_app.support_interface_eligibility_checks_path,
               text: "Eligibility Checks"
-            )
-            header.with_navigation_item(
-              active: current_page?(main_app.support_interface_feature_flags_path),
-              href: main_app.support_interface_feature_flags_path,
-              text: "Features"
             )
             header.with_navigation_item(
               active: request.path.start_with?("/support/staff"),
@@ -61,45 +59,15 @@ module ApplicationHelper
               )
             end
           end
-          header.with_navigation_item(href: main_app.manage_sign_out_path, text: "Sign out")
-        end
-      when "support"
-        if current_staff.manage_referrals?
-          header.with_navigation_item(
-            active: current_page?(main_app.manage_interface_referrals_path),
-            href: main_app.manage_interface_referrals_path,
-            text: "Referrals"
-          )
-        end
-        header.with_navigation_item(
-          active: current_page?(main_app.support_interface_validation_errors_path),
-          href: main_app.support_interface_validation_errors_path,
-          text: "Validation Errors"
-        )
-        header.with_navigation_item(
-          active: current_page?(main_app.support_interface_eligibility_checks_path),
-          href: main_app.support_interface_eligibility_checks_path,
-          text: "Eligibility Checks"
-        )
-        header.with_navigation_item(
-          active: current_page?(main_app.support_interface_feature_flags_path),
-          href: main_app.support_interface_feature_flags_path,
-          text: "Features"
-        )
-        header.with_navigation_item(
-          active: request.path.start_with?("/support/staff"),
-          text: "Staff",
-          href: main_app.support_interface_staff_index_path
-        )
-        if HostingEnvironment.test_environment?
-          header.with_navigation_item(
-            active: request.path.start_with?(main_app.support_interface_test_users_path),
-            text: "Test Users",
-            href: main_app.support_interface_test_users_path
-          )
-        end
 
-        if current_staff
+          if current_staff.developer?
+            header.with_navigation_item(
+              active: current_page?(main_app.developer_interface_feature_flags_path),
+              href: main_app.developer_interface_feature_flags_path,
+              text: "Features"
+            )
+          end
+
           header.with_navigation_item(href: main_app.manage_sign_out_path, text: "Sign out")
         end
       else

--- a/app/policies/developer_policy.rb
+++ b/app/policies/developer_policy.rb
@@ -1,0 +1,13 @@
+class DeveloperPolicy < ApplicationPolicy
+  def index?
+    user.developer?
+  end
+
+  def deactivate?
+    user.developer?
+  end
+
+  def activate?
+    user.developer?
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -8,5 +8,6 @@
     - confirmation_token
     - unlock_token
     - invitation_token
+    - developer
   :referrals:
     - declaration

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,5 +1,5 @@
 layout: support_layout
-parent_controller: "SupportInterface::SupportInterfaceController"
+parent_controller: "DeveloperInterface::DeveloperInterfaceController"
 feature_flags:
   service_open:
     author: Felix Clack

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -267,8 +267,6 @@ to: "public_eligibility_screener/consider_if_you_should_make_a_referral#create"
       get :history, on: :collection
     end
 
-    mount FeatureFlags::Engine => "/features"
-
     devise_scope :staff do
       authenticate :staff do
         # Mount engines that require staff authentication here
@@ -277,6 +275,10 @@ to: "public_eligibility_screener/consider_if_you_should_make_a_referral#create"
     end
 
     get "/eligibility-checks", to: "eligibility_checks#index"
+  end
+
+  namespace :developer_interface, path: "/developer" do
+    mount FeatureFlags::Engine => "/features"
   end
 
   namespace :manage_interface, path: "/manage" do

--- a/db/migrate/20240221164638_add_developer_to_staff.rb
+++ b/db/migrate/20240221164638_add_developer_to_staff.rb
@@ -1,0 +1,5 @@
+class AddDeveloperToStaff < ActiveRecord::Migration[7.0]
+  def change
+    add_column :staff, :developer, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_15_122821) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_21_164638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -205,6 +205,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_15_122821) do
     t.boolean "view_support", default: false
     t.boolean "manage_referrals", default: false
     t.datetime "deleted_at", precision: nil
+    t.boolean "developer", default: false
     t.index ["confirmation_token"], name: "index_staff_on_confirmation_token", unique: true
     t.index ["email"], name: "index_staff_on_email", unique: true
     t.index ["invitation_token"], name: "index_staff_on_invitation_token", unique: true

--- a/spec/factories/staffs.rb
+++ b/spec/factories/staffs.rb
@@ -22,6 +22,10 @@ FactoryBot.define do
     manage_referrals { true }
   end
 
+  trait :developer do
+    developer { true }
+  end
+
   trait :random do
     email { "#{SecureRandom.hex(5)}@example.com" }
     password { "Example123!" }

--- a/spec/policies/developer_policy_spec.rb
+++ b/spec/policies/developer_policy_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe DeveloperPolicy do
+  subject(:policy) { described_class.new(user, record) }
+
+  let(:user) { nil }
+  let(:record) { :developer }
+
+  [:index?, :deactivate?, :activate?].each do |action|
+    describe "##{action}" do
+      context "when developer" do
+        let(:user) { build(:staff, :developer) }
+
+        it "can be performed" do
+          expect(policy.public_send(action)).to be_truthy
+        end
+      end
+
+      context "when non-developer" do
+        let(:user) { build(:staff) }
+
+        it "cannot be performed" do
+          expect(policy.public_send(action)).to be_falsey
+        end
+      end
+    end
+  end
+end

--- a/spec/support/system/authorization_steps.rb
+++ b/spec/support/system/authorization_steps.rb
@@ -29,6 +29,17 @@ module AuthorizationSteps
     click_on "Sign in"
   end
 
+  def when_i_login_as_staff_with_permissions(view_support: false, manage_referrals: false, developer: false)
+    create(:staff, :confirmed, view_support:, manage_referrals:, developer:)
+
+    visit manage_sign_in_path
+
+    fill_in "Email", with: "test@example.org"
+    fill_in "Password", with: "Example123!"
+
+    click_on "Sign in"
+  end
+
   def when_i_visit_staff_sign_in_page
     visit manage_sign_in_path
   end

--- a/spec/system/support/staff_user_with_developer_permissions_spec.rb
+++ b/spec/system/support/staff_user_with_developer_permissions_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "Support" do
+  include CommonSteps
+
+  scenario "a staff user with developer permissions can visit the developer interface", type: :system do
+    given_the_service_is_open
+    when_i_login_as_staff_with_permissions(view_support: true, developer: true)
+    then_i_see_the_staff_index
+    and_i_visit_the_developer_features_page
+    then_i_see_the_developer_features_page
+  end
+
+  private
+
+  def and_i_visit_the_developer_features_page
+    click_link "Features"
+  end
+
+  def then_i_see_the_developer_features_page
+    expect(page).to have_content("Service open")
+  end
+end

--- a/spec/system/support/staff_user_with_permissions_can_visit_the_support_interface_spec.rb
+++ b/spec/system/support/staff_user_with_permissions_can_visit_the_support_interface_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Support" do
     and_i_do_not_see_referrals_link
 
     when_i_visit_the_features_page
-    then_i_see_the_feature_page
+    then_i_dont_see_the_feature_page
   end
 
   private
@@ -38,11 +38,11 @@ RSpec.describe "Support" do
     expect(page).to have_content("Eligibility checks (1)")
   end
 
-  def then_i_see_the_feature_page
-    expect(page).to have_content("Features")
+  def then_i_dont_see_the_feature_page
+    expect(page).not_to have_content("Features")
   end
 
   def when_i_visit_the_features_page
-    visit support_interface_feature_flags_path
+    visit developer_interface_feature_flags_path
   end
 end


### PR DESCRIPTION
# Context

- Feature flag toggling was available to any staff user with support access role
- We want to limit to a smaller subset of staff users to be able to access this feature 

# Changes

- Feature flag toggling is now only available to staff users with `developer` access role
- Introduce `developer` access role so the above is possible
- Tidy up helper that generates the navigation links by removing duplicate code