### PR TITLE
Format dates in human readable format, update complained column to sh…

### DIFF
--- a/app/controllers/support_interface/eligibility_checks_controller.rb
+++ b/app/controllers/support_interface/eligibility_checks_controller.rb
@@ -35,7 +35,6 @@ module SupportInterface
             is_teacher
             teaching_in_england
             serious_misconduct
-            unsupervised_teaching
             eligibility_check_started
             eligibility_check_last_updated
             draft_referral_created
@@ -57,15 +56,14 @@ module SupportInterface
         [
           check.id,
           check.reporting_as,
-          (check.complained? ? "yes" : "no"),
+          check.format_complained,
           check.is_teacher,
           check.teaching_in_england,
           check.serious_misconduct,
-          check.unsupervised_teaching,
-          check.updated_at,
-          check.created_at,
-          check.referral&.created_at,
-          check.referral&.submitted_at
+          check.updated_at&.strftime("%d/%m/%Y"),
+          check.created_at&.strftime("%d/%m/%Y"),
+          check.referral&.created_at&.strftime("%d/%m/%Y"),
+          check.referral&.submitted_at&.strftime("%d/%m/%Y")
         ]
       )
     end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -26,6 +26,17 @@ class EligibilityCheck < ApplicationRecord
     %w[yes not_sure].include?(unsupervised_teaching)
   end
 
+  def format_complained
+    states = {"received" => "Yes, complaint submitted",
+              "awaiting" => "Yes, awaiting response",
+              "no" => "No complaint submitted"}
+    if reporting_as == "public" && complaint_status.present?
+      states[complaint_status]
+    elsif reporting_as == "employer"
+      complained? ? "yes" : "no"
+    end
+  end
+
   def clear_answers!
     unless reporting_as.nil?
       update!(

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -118,4 +118,60 @@ RSpec.describe EligibilityCheck, type: :model do
       expect(eligibility_check.unsupervised_teaching).to be_nil
     end
   end
+
+  describe "#format_complained" do
+    let(:formatted_complaint_field) do
+ described_class.new(complained:, complaint_status:, reporting_as:).format_complained end
+
+    context "when employer submitted has not complained" do
+      let(:reporting_as) { :employer }
+      let(:complained) { false }
+      let(:complaint_status) { nil }
+
+      it "correctly outputs the correct message" do
+        expect(formatted_complaint_field).to eql("no")
+      end
+    end
+
+    context "when employer submitted has complained" do
+      let(:reporting_as) { :employer }
+      let(:complained) { true }
+      let(:complaint_status) { nil }
+
+      it "correctly outputs the correct message" do
+        expect(formatted_complaint_field).to eql("yes")
+      end
+    end
+
+    context "when public submitted has not complained" do
+      let(:reporting_as) { :public }
+      let(:complained) { false }
+      let(:complaint_status) { "no" }
+
+      it "correctly outputs the correct message" do
+        expect(formatted_complaint_field).to eql("No complaint submitted")
+      end
+    end
+
+    context "when public submitted has complained with response" do
+      let(:reporting_as) { :public }
+      let(:complained) { true }
+      let(:complaint_status) { "received" }
+
+      it "correctly outputs the correct message" do
+        expect(formatted_complaint_field).to eql("Yes, complaint submitted")
+      end
+    end
+
+    context "when public submitted has complained, awaiting response" do
+      let(:reporting_as) { :public }
+      let(:complained) { true }
+      let(:complaint_status) { "awaiting" }
+
+      it "correctly outputs the correct message" do
+
+        expect(formatted_complaint_field).to eql("Yes, awaiting response")
+      end
+    end
+  end
 end


### PR DESCRIPTION
…ow all 5 states

A collection of small changes to improve the usability of the eligibility checker export:

- CSV output now shows dates in format dd/mm/yyyy
- Complained field now has correct 5 possible states.
- Unsupervised teaching column removed.