### PR TITLE
Feedback backoffice

### DIFF
--- a/app/components/support_interface/feedback_summary_card_component.html.erb
+++ b/app/components/support_interface/feedback_summary_card_component.html.erb
@@ -1,0 +1,3 @@
+<%= govuk_summary_card(title:) do |card| %>
+  <%= card.with_summary_list(rows:) %>
+<% end %>

--- a/app/components/support_interface/feedback_summary_card_component.rb
+++ b/app/components/support_interface/feedback_summary_card_component.rb
@@ -1,0 +1,50 @@
+module SupportInterface
+  class FeedbackSummaryCardComponent < ViewComponent::Base
+    include ActiveModel::Model
+
+    attr_accessor :feedback
+
+    def rows
+      feedback
+        .attributes
+        .keep_if { |k,_v| whitelisted_keys.include?(k) }
+        .map do |k,v|
+          {
+            key: { text: k.humanize },
+            value: { text: formatted_value(v) }
+          }
+        end
+    end
+
+    def title
+      feedback.id
+    end
+
+    private
+
+    def formatted_value(value)
+      case value
+      when String
+        value
+      when TrueClass
+        "Yes"
+      when FalseClass
+        "No"
+      when ActiveSupport::TimeWithZone
+        value.to_formatted_s(:govuk_time_on_date)
+      else
+        value.class
+      end
+    end
+
+    def whitelisted_keys
+      %w[
+        satisfaction_rating
+        improvement_suggestion
+        contact_permission_given
+        email
+        created_at
+      ]
+    end
+  end
+end

--- a/app/controllers/support_interface/feedback_controller.rb
+++ b/app/controllers/support_interface/feedback_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SupportInterface
+  class FeedbackController < SupportInterfaceController
+    def index
+      @feedbacks = Feedback.all
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,6 +51,11 @@ module ApplicationHelper
               text: "Staff",
               href: main_app.support_interface_staff_index_path
             )
+            header.with_navigation_item(
+              active: request.path.start_with?("/support/feedback"),
+              text: "Feedback",
+              href: main_app.support_interface_feedback_index_path
+            )
             if HostingEnvironment.test_environment?
               header.with_navigation_item(
                 active: request.path.start_with?(main_app.support_interface_test_users_path),

--- a/app/views/support_interface/feedback/index.html.erb
+++ b/app/views/support_interface/feedback/index.html.erb
@@ -1,0 +1,3 @@
+<% @feedbacks.each do |feedback| %>
+  <%= render SupportInterface::FeedbackSummaryCardComponent.new(feedback:) %>
+<% end %>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:govuk_time_on_date] = "%-I:%M%P on %-d %B %Y"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -267,6 +267,8 @@ to: "public_eligibility_screener/consider_if_you_should_make_a_referral#create"
       get :history, on: :collection
     end
 
+    resources :feedback
+
     devise_scope :staff do
       authenticate :staff do
         # Mount engines that require staff authentication here

--- a/spec/components/support_interface/eligibility_check_component_spec.rb
+++ b/spec/components/support_interface/eligibility_check_component_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe SupportInterface::EligibilityCheckComponent, type: :component do
     )
   end
 
-  before { render_inline(component) }
-
   context "with an employer referral" do
     it "renders the correct labels" do
       expect(row_labels).to eq(

--- a/spec/components/support_interface/feedback_summary_card_component_spec.rb
+++ b/spec/components/support_interface/feedback_summary_card_component_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe SupportInterface::FeedbackSummaryCardComponent, type: :component do
+  subject(:component) { described_class.new(feedback:) }
+
+  let(:feedback) { create(:feedback) }
+
+  before { render_inline(component) }
+
+  around do |example|
+    travel_to(Time.zone.local(2000, 12, 28, 13, 59)) do
+      example.run
+    end
+  end
+
+  it "renders id" do
+    expect(page).to have_text(feedback.id)
+  end
+
+  it "renders card keys" do
+    expect(page).to have_text("Satisfaction rating")
+    expect(page).to have_text("Improvement suggestion")
+    expect(page).to have_text("Contact permission given")
+    expect(page).to have_text("Email")
+    expect(page).to have_text("Created at")
+  end
+
+  it "renders correct data" do
+    expect(page).to have_text(feedback.satisfaction_rating)
+    expect(page).to have_text(feedback.improvement_suggestion)
+    expect(page).to have_text(feedback.contact_permission_given ? "Yes" : "No")
+    expect(page).to have_text(feedback.email)
+    expect(page).to have_text("1:59pm on 28 December 2000")
+  end
+end

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :feedback do
+    satisfaction_rating { "very_satisfied" }
+    improvement_suggestion { "feedback goes here" }
+    contact_permission_given { [true, false].sample }
+    email { "#{SecureRandom.hex(5)}@example.com" }
+  end
+end

--- a/spec/system/support/feedback_spec.rb
+++ b/spec/system/support/feedback_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.feature "Feedback back office" do
+  include CommonSteps
+
+  let(:feedback) { create(:feedback) }
+
+  scenario "Manage user" do
+    given_the_service_is_open
+    when_i_login_as_staff_with_permissions(manage_referrals: true)
+    then_i_see_manage_referrals_page
+    and_i_do_not_see_feedback_navigation
+
+    when_i_visit_the_feedback_page
+    then_i_see_403
+  end
+
+  scenario "Support user" do
+    given_the_service_is_open
+    and_feedback_exists
+    when_i_login_as_staff_with_permissions(view_support: true)
+    then_i_see_the_staff_index
+    and_i_see_feedback_navigation
+
+    when_i_click_feedback_navigation
+    then_i_see_feedback
+  end
+
+  def and_i_see_feedback_navigation
+    expect(page).to have_content("Feedback")
+  end
+
+  def and_i_do_not_see_feedback_navigation
+    expect(page).not_to have_content("Feedback")
+  end
+
+  def when_i_click_feedback_navigation
+    click_link "Feedback"
+  end
+
+  def and_feedback_exists
+    feedback
+  end
+
+  def then_i_see_feedback
+    expect(page).to have_content(feedback.email)
+  end
+
+  def when_i_visit_the_feedback_page
+    visit("/support/feedback")
+  end
+
+  def then_i_see_403
+    expect(page).to have_current_path("/403")
+    expect(page).to have_content("You do not have permission to view this page")
+  end
+end


### PR DESCRIPTION
# Context

- There is currently no back office system to be able to view feedback provided by users

# Changes

- Introduce ability to view feedback from users in the back office area
- Only available to `Staff` that have the role `view_support: true`

# Notes for review

- This is built atop https://github.com/DFE-Digital/refer-serious-misconduct/pull/1033 which should be reviewed and merged first. This is because it contains some changes which was needed for this PR