### PR TITLE
Edit content to state zip files cant be uploaded

### DIFF
--- a/app/views/public_referrals/allegation_evidence/upload/edit.html.erb
+++ b/app/views/public_referrals/allegation_evidence/upload/edit.html.erb
@@ -34,7 +34,7 @@
           :evidence_uploads,
           multiple: true,
           label: { text: "Upload files", size: "m" },
-          hint: { text: "You can upload up to #{FileUploadValidator::MAX_FILES} files. Each file must be smaller than #{max_allowed_file_size}. Larger files may take longer to upload. We will let you know when it is done." }
+          hint: { text: "You can upload up to #{FileUploadValidator::MAX_FILES} files. Each file must be smaller than #{max_allowed_file_size}. You cannot upload zip files." }
       ) %>
 
       <%= f.govuk_submit "Save and continue" %>

--- a/app/views/referrals/allegation_details/details/edit.html.erb
+++ b/app/views/referrals/allegation_details/details/edit.html.erb
@@ -24,13 +24,13 @@
                 </p>
                 <%= f.govuk_file_field :allegation_upload_file,
                   label: { text: "Upload new file", size: "s" },
-                  hint: { text: "Must be smaller than #{max_allowed_file_size}" }
+                  hint: { text: "Must be smaller than #{max_allowed_file_size}. You cannot upload zip files." }
                 %>
               </div>
             <% else %>
               <%= f.govuk_file_field :allegation_upload_file,
                 label: { text: "Upload file", size: "s" },
-                hint: { text: "Must be smaller than #{max_allowed_file_size}" }
+                hint: { text: "Must be smaller than #{max_allowed_file_size}. You cannot upload zip files." }
               %>
             <% end %>
           <% end %>

--- a/app/views/referrals/allegation_evidence/upload/edit.html.erb
+++ b/app/views/referrals/allegation_evidence/upload/edit.html.erb
@@ -44,7 +44,7 @@
           :evidence_uploads,
           multiple: true,
           label: { text: "Upload files", size: "m" },
-          hint: { text: "You can upload up to #{FileUploadValidator::MAX_FILES} files. Each file must be smaller than #{max_allowed_file_size}. Larger files may take longer to upload. We will let you know when it is done." }
+          hint: { text: "You can upload up to #{FileUploadValidator::MAX_FILES} files. Each file must be smaller than #{max_allowed_file_size}. Larger files may take longer to upload. We will let you know when it is done. You cannot upload zip files." }
       ) %>
 
       <%= f.govuk_submit "Save and continue" %>

--- a/app/views/referrals/allegation_previous_misconduct/detailed_account/edit.html.erb
+++ b/app/views/referrals/allegation_previous_misconduct/detailed_account/edit.html.erb
@@ -31,13 +31,13 @@
                 </p>
                 <%= f.govuk_file_field :previous_misconduct_upload_file,
                   label: { text: "Upload new file", size: "s" },
-                  hint: { text: "Must be smaller than #{max_allowed_file_size}" }
+                  hint: { text: "Must be smaller than #{max_allowed_file_size}. You cannot upload zip files." }
                 %>
               </div>
             <% else %>
               <%= f.govuk_file_field :previous_misconduct_upload_file,
                 label: { text: "Upload file", size: "s" },
-                hint: { text: "Must be smaller than #{max_allowed_file_size}" }
+                hint: { text: "Must be smaller than #{max_allowed_file_size}. You cannot upload zip files." }
               %>
             <% end %>
           <% end %>

--- a/app/views/referrals/teacher_role/duties/edit.html.erb
+++ b/app/views/referrals/teacher_role/duties/edit.html.erb
@@ -24,13 +24,13 @@
                 </p>
                 <%= f.govuk_file_field :duties_upload_file,
                   label: { text: "Upload new file", size: "s" },
-                  hint: { text: "For example, a job description. Must be smaller than #{max_allowed_file_size}" }
+                  hint: { text: "For example, a job description. Must be smaller than #{max_allowed_file_size}. You cannot upload zip files." }
                 %>
               </div>
             <% else %>
               <%= f.govuk_file_field :duties_upload_file,
                 label: { text: "Upload file", size: "s" },
-                hint: { text: "For example, a job description. Must be smaller than #{max_allowed_file_size}" }
+                hint: { text: "For example, a job description. Must be smaller than #{max_allowed_file_size}. You cannot upload zip files." }
               %>
             <% end %>
           <% end %>


### PR DESCRIPTION
Users are getting error messages because they’re trying to upload zip files.

The hint in the upload file fields has been changed to advise that this cannot be done.