### PR TITLE
Limit max length of filename to prevent zip file errors

### DIFF
--- a/app/lib/referral_zip_file.rb
+++ b/app/lib/referral_zip_file.rb
@@ -51,7 +51,7 @@ class ReferralZipFile
   end
 
   def filename_for(upload:, index:)
-    base_filename = "#{referral.id}-#{index}-#{upload.filename}"
+    base_filename = "#{referral.id}-#{index}-#{upload.filename.truncate(200)}"
     return "#{base_filename}-file-removed-due-to-suspected-virus.txt" if upload.scan_result_suspect?
     return "#{base_filename}-file-being-checked-for-viruses.txt" if upload.scan_result_pending?
 


### PR DESCRIPTION
An exception is raised if the filename for a generated zip file is too long. In order to prevent this happening again the max length of a zip file is truncated to 200 characters.