### PR TITLE
Fix feedback link

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -20,6 +20,7 @@ class UserMailer < ApplicationMailer
 
   def referral_submitted(referral)
     @link = users_referral_url(referral)
+    @feedback_url = feedbacks_url
     @user = referral.user
     mailer_options = {
       to: @user.email,

--- a/app/views/user_mailer/referral_submitted.erb
+++ b/app/views/user_mailer/referral_submitted.erb
@@ -17,6 +17,7 @@ You’ll be sent an email with the decision.
 
 # Giving Feedback
 
-<%= govuk_link_to("Tell us what you think of this service", feedbacks_url) %>
+[Tell us what you think of this service](<%=@feedback_url%>)
+
 
 <%= render "shared/mailers/get_help" %>

--- a/spec/system/public_referrals/user_submits_referral_spec.rb
+++ b/spec/system/public_referrals/user_submits_referral_spec.rb
@@ -68,6 +68,8 @@ RSpec.feature "A member of the public submits a referral", type: :system do
     expect(message.subject).to eq("Your referral of serious misconduct has been sent")
     expect(message.to).to include(@referral.user.email)
     expect(message.body).to include(users_referral_path(@referral))
+    expect(message.body).not_to include("<a")
+    expect(message.body).to include("Tell us what you think of this service")
   end
 
   def and_event_tracking_is_working


### PR DESCRIPTION
Prevent govuk link html tag from appearing rendered inline.

![image](https://github.com/DFE-Digital/refer-serious-misconduct/assets/44261976/2b4b7e78-0c33-499e-a271-a7f8911ec42b)
