### PR TITLE
Remove the maintenance window

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -8,6 +8,4 @@ DfE::Analytics.configure do |config|
       disabled_by_default = Rails.env.development?
       ENV.fetch("BIGQUERY_DISABLE", disabled_by_default.to_s) != "true"
     end
-
-  config.bigquery_maintenance_window = "19-08-2024 18:00..19-08-2024 19:00"
 end


### PR DESCRIPTION
We have performed the encryption task on this BigQuery table and the
maintenance window is in the past. It is safe to remove the config for
this.
