### PR TITLE
[1839] Azurerm update fixes

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -137,6 +137,9 @@ resource "azurerm_linux_web_app" "rsm-app" {
     minimum_tls_version = "1.2"
     health_check_path   = "/health"
 
+    ip_restriction_default_action     = "Deny"
+    scm_ip_restriction_default_action = "Deny"
+
     dynamic "ip_restriction" {
       for_each = var.domain != null ? [1] : []
 
@@ -144,12 +147,12 @@ resource "azurerm_linux_web_app" "rsm-app" {
         name     = "FrontDoor"
         action   = "Allow"
         priority = 1
-        headers = {
+        headers = [{
           x_azure_fdid      = try([local.infrastructure_secrets.FRONTDOOR_ID], [])
           x_fd_health_probe = []
           x_forwarded_for   = []
           x_forwarded_host  = []
-        }
+        }]
         service_tag               = "AzureFrontDoor.Backend"
         ip_address                = null
         virtual_network_subnet_id = null

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -25,6 +25,8 @@ resource "azurerm_storage_encryption_scope" "allegations-encryption" {
   name               = "microsoftmanaged"
   storage_account_id = azurerm_storage_account.allegations.id
   source             = "Microsoft.Storage"
+
+  infrastructure_encryption_required = true
 }
 
 


### PR DESCRIPTION
## Description
- ip_restriction headers must be a list
- ip_restriction ip_restriction_default_action and scm_ip_restriction_default_action must be set explicitly
- azurerm_storage_account infrastructure_encryption_enabled must be set explicitly

## How to review
make production terraform-plan