### PR TITLE
Enable database backup

### DIFF
--- a/terraform/application/config/preprod.tfvars.json
+++ b/terraform/application/config/preprod.tfvars.json
@@ -1,4 +1,5 @@
 {
   "cluster": "test",
-  "namespace": "tra-test"
+  "namespace": "tra-test",
+  "enable_postgres_backup_storage": true
 }

--- a/terraform/application/config/test.tfvars.json
+++ b/terraform/application/config/test.tfvars.json
@@ -1,4 +1,5 @@
 {
   "cluster": "test",
-  "namespace": "tra-test"
+  "namespace": "tra-test",
+  "enable_postgres_backup_storage": true
 }


### PR DESCRIPTION
### Context

To be able to test database migration from the s165 subscription to the s189 subscription we need storage groups to contain backups so enabling database backup in test and preprod (it is already enabled in prod)

### Changes proposed in this pull request

enable database backups in test and preprod

### Guidance to review

review change

### Link to Trello card

[RSM: migrate test environment](https://trello.com/c/x2VRnDDx/2126-rsm-migrate-test-environment)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
