### PR TITLE
Create storage groups for postgres backup

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -124,6 +124,15 @@ variable "allegations_storage_account_name" {
   default = null
 }
 
+variable "enable_postgres_backup_storage" {
+  default     = false
+  description = "Create a storage account to store database dumps"
+}
+
+variable "database_backup_storage_account_name" {
+  default = null
+}
+
 variable "region_name" {
   default = "west europe"
   type    = string

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -9,5 +9,7 @@
   "storage_log_categories": [],
   "resource_prefix": "s165t01-rsm",
   "domain": "preprod.refer-serious-misconduct.education.gov.uk",
-  "allegations_storage_account_name": "s165t01rsmallegationspp"
+  "allegations_storage_account_name": "s165t01rsmallegationspp",
+  "enable_postgres_backup_storage": true,
+  "database_backup_storage_account_name": "s165t01rsmdbbackuppp"
 }

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -9,5 +9,7 @@
   "storage_log_categories": [],
   "resource_prefix": "s165t01-rsm",
   "domain": "test.refer-serious-misconduct.education.gov.uk",
-  "allegations_storage_account_name": "s165t01rsmallegationsts"
+  "allegations_storage_account_name": "s165t01rsmallegationsts",
+  "enable_postgres_backup_storage": true,
+  "database_backup_storage_account_name": "s165t01rsmdbbackupts"
 }


### PR DESCRIPTION
### Context

To be able to test postgres migration from s165 to s189 subscriptions we need storage groups in test and preprod environment to hold the postgres database backup in the same convention as production. 

### Changes proposed in this pull request

add terraform code to create the storage group and container name in same convention as existing s165 production. 

this code has been tested via  
export TF_VAR_rsm_docker_image=ghcr.io/dfe-digital/refer-serious-misconduct:2c5e8df75248572afb2ed623e88fc66c7b77b19e
make test terraform-apply 
make preprod terraform-apply 

### Guidance to review

review code. check the new storage groups added in azure portal
- s165t01rsmdbbackuppp 
- s165t01rsmdbbackuppp 
### Link to Trello card

[RSM: migrate test environment](https://trello.com/c/x2VRnDDx/2126-rsm-migrate-test-environment)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
