### PR TITLE
Enable monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,11 @@ deploy-arm-resources: arm-deployment ## Validate ARM resource deployment. Usage:
 
 validate-arm-resources: set-what-if arm-deployment ## Validate ARM resource deployment. Usage: make domains validate-arm-resources
 
+action-group-resources: set-azure-account # make env action-group-resources ACTION_GROUP_EMAIL=notificationemail@domain.com . Must be run before setting enable_monitoring=true for each subscription
+	$(if $(ACTION_GROUP_EMAIL), , $(error Please specify a notification email for the action group))
+	az group create -l uksouth -g ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-mn-rg --tags "Product=Refer Serious Misconduct"
+	az monitor action-group create -n ${AZURE_RESOURCE_PREFIX}-${SERVICE_NAME} -g ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-mn-rg --action email ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-email ${ACTION_GROUP_EMAIL}
+
 aks-terraform-init: composed-variables bin/terrafile aks-set-azure-account
 	$(if ${DOCKER_IMAGE_TAG}, , $(eval DOCKER_IMAGE_TAG=main))
 

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -13,7 +13,8 @@
   "account_replication_type": "GRS",
   "cluster": "production",
   "enable_logit": true,
-  "enable_monitoring": false,
+  "enable_monitoring": true,
+  "statuscake_contact_groups": [288912, 282453],
   "namespace": "tra-production",
   "allegations_container_delete_retention_days": 30
 }

--- a/terraform/application/config/production.yml
+++ b/terraform/application/config/production.yml
@@ -1,1 +1,2 @@
 ---
+EXTERNAL_DOMAIN: refer-serious-misconduct.education.gov.uk

--- a/terraform/application/statuscake.tf
+++ b/terraform/application/statuscake.tf
@@ -1,12 +1,10 @@
-/*
 module "statuscake" {
   count = var.enable_monitoring ? 1 : 0
 
   source = "./vendor/modules/aks//monitoring/statuscake"
 
-  uptime_urls = compact([module.web_application.probe_url, var.external_url])
-  ssl_urls    = compact([var.external_url])
+  uptime_urls = compact([module.web_application.probe_url, "https://${local.external_domain}/health"])
+  ssl_urls    = compact(["https://${local.external_domain}/"])
 
   contact_groups = var.statuscake_contact_groups
 }
-*/

--- a/terraform/application/terraform.tf
+++ b/terraform/application/terraform.tf
@@ -41,6 +41,6 @@ provider "kubernetes" {
   }
 }
 
-/*provider "statuscake" {
+provider "statuscake" {
   api_token = module.infrastructure_secrets.map.STATUSCAKE-API-TOKEN
-}*/
+}


### PR DESCRIPTION
### Context
RSM Migration to AKS production environment and it requires monitoring. 

### Changes proposed in this pull request
Enable azure monitoring, prometheus metric scrapping and status cake alerting

### Guidance to review
Check if azure monitoring is enabled for cloud resources. 
Check if the metrics can be scrapped from the prometheus metrics endpoint.

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
[2161-rsm-enable-monitoring](https://trello.com/c/wBMRU68q)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
