### PR TITLE
Remove downtime banner

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -36,7 +36,6 @@
       <%= govuk_back_link(href: yield(:back_link_url)) if content_for?(:back_link_url) %>
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
-        <%= govuk_notification_banner title_text: "Planned downtime", text: "The service will be unavailable on Wednesday 4th December between 11am and 12am while we carry out essential maintenance" %>
         <%= render(FlashMessageComponent.new(flash: flash)) %>
         <%= yield :content %>
       </main>


### PR DESCRIPTION
### Context

Remove downtime banner as migration has been carried out. 

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
