### PR TITLE
Fix dataset name gcp config

### DIFF
--- a/terraform/application/config/preprod.tfvars.json
+++ b/terraform/application/config/preprod.tfvars.json
@@ -1,5 +1,6 @@
 {
   "cluster": "test",
   "namespace": "tra-test",
-  "enable_postgres_backup_storage": true
+  "enable_postgres_backup_storage": true,
+  "dataset_name": "events_preprod"
 }

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -7,6 +7,7 @@
   },
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "enable_postgres_backup_storage": true,
+  "dataset_name": "events_production",
   "postgres_enable_high_availability": true,
   "send_traffic_to_maintenance_page": false,
   "account_replication_type": "GRS",


### PR DESCRIPTION
### Context

Fix dataset name gcp terraform config for production and preprod 

### Changes proposed in this pull request

add dataset name for gcp for production and preprod 

### Guidance to review

review code correct 

### Link to Trello card

[RSM: migrate to GCP WIF](https://trello.com/c/LWrbrLTn/2145-rsm-migrate-to-gcp-wif)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
