### PR TITLE
Remove christmas downtime banner

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -36,7 +36,6 @@
       <%= govuk_back_link(href: yield(:back_link_url)) if content_for?(:back_link_url) %>
       <%= yield(:breadcrumbs) if content_for?(:breadcrumbs) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
-        <%= govuk_notification_banner title_text: "Important", text: "We will not reply to queries from 23 December 2024 to 3 January 2025 due to Christmas and New Year holidays." %>
         <%= render(FlashMessageComponent.new(flash: flash)) %>
         <%= yield :content %>
       </main>


### PR DESCRIPTION
### Context

Christmas period is over; the banner should be removed.

### Changes proposed in this pull request

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
