### PR TITLE
Implement delete-review-app action

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -2,8 +2,7 @@ name: Delete Review App
 
 on:
   pull_request:
-    types: [closed]
-    branches: [main]
+    types: [closed, unlabeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -12,56 +11,37 @@ on:
         type: string
 
 jobs:
-  delete-review-app-aks:
-    name: Delete Review App AKS ${{ github.event.pull_request.number }}
-    concurrency: deploy_review_${{ github.event.pull_request.number }}
-    if: contains(github.event.pull_request.labels.*.name, 'deploy-aks') ||  ${{ github.event_name }} == 'workflow_dispatch'
+  delete-review-app:
+    name: Delete review app ${{ github.event.pull_request.number }}
+    concurrency: deploy_review_${{ github.event.pull_request.number || github.event.inputs.pr_number }}
     runs-on: ubuntu-latest
-    environment: review
+    if: >
+      github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy-aks') ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'deploy-aks') || (github.event_name == 'workflow_dispatch')
     permissions:
       pull-requests: write
       id-token: write
+      contents: read
+    environment: review
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: set PR_NUMBER
-        id: config
+      - name: Set PR_NUMBER
+        id: pr_number
         run: |
-          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
-            PR_NUMBER=${{ github.event.inputs.pr_number }}
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "PR_NUMBER=${{ github.event.inputs.pr_number }}" >> $GITHUB_ENV
           else
-            PR_NUMBER=${{ github.event.pull_request.number }}
+            echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           fi
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: DFE-Digital/github-actions/delete-review-app@master
         with:
-          terraform_version: 1.6.4
-          terraform_wrapper: false
-
-      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
-        with:
+          pr-number: ${{ env.PR_NUMBER }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: refer-serious-misconduct
-          workload_identity_provider: projects/737868692824/locations/global/workloadIdentityPools/refer-serious-misconduct/providers/refer-serious-misconduct
-
-      - name: Terraform Destroy
-        run: |
-          make ci review terraform-destroy PR_NUMBER=${{ env.PR_NUMBER }}
-        env:
-          PR_NUMBER: ${{ env.PR_NUMBER }}
-
-      - name: Post Pull Request Comment
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: aks
-          message: |
-            Review app refer serious misconduct deployed to <https://refer-serious-misconduct-${{ env.PR_NUMBER }}.test.teacherservices.cloud> was deleted
+          resource-group-name: s189t01-rsm-rv-rg
+          storage-account-name: s189t01rsmrvtfsa
+          tf-state-file: pr-${{ env.PR_NUMBER }}_kubernetes.tfstate
+          gcp-wip: projects/737868692824/locations/global/workloadIdentityPools/refer-serious-misconduct/providers/refer-serious-misconduct
+          gcp-project-id: refer-serious-misconduct


### PR DESCRIPTION
### Context

The delete-review-app workflow needed updating to align with our deployment workflow and correctly implement the DFE-Digital GitHub Action. Previously.

### Changes proposed in this pull request

- Updated the conditional check to use the 'deploy-aks' label instead of 'deploy' to match our deployment workflow
- Added Google Cloud Platform (GCP) workload identity pool and project ID parameters needed for DFE Analytics integration
- Corrected the storage account name to properly match our infrastructure
- Ensured the tfstate file format is consistent with what's used in deployments
- Maintained compatibility with the DFE-Digital shared action for deleting review apps

These changes ensure that our review apps are properly cleaned up when pull requests are closed or manually triggered, preventing orphaned resources and potential cost implications.

### Guidance to review

- Verify that the label name ('deploy-aks') matches what's used in the build-and-deploy workflow
- Check that the GCP parameters match our project configuration
- Confirm the storage account name is correct
- Test by closing a PR with the 'deploy-aks' label and verify resources are properly cleaned up
- Alternatively, test the workflow manually using the workflow_dispatch trigger with a PR number
- https://github.com/DFE-Digital/refer-serious-misconduct/actions/runs/14918160145/job/41908238103

### Link to Trello card

https://trello.com/c/7M3ZvinR/2323-use-delete-review-app-github-action

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
