### PR TITLE
Update copy to reflect policy changes

### DIFF
--- a/app/views/public_referrals/allegation_evidence/upload/edit.html.erb
+++ b/app/views/public_referrals/allegation_evidence/upload/edit.html.erb
@@ -9,6 +9,8 @@
       <span class="govuk-caption-l"><%= section_label %></span>
       <h1 class="govuk-heading-l"><%= form_label %></h1>
 
+      <p>You must send all available information. A decision whether to begin an investigation will be based on the evidence provided. We may not contact you for additional information before making a decision.</p>
+
       <p>For example:</p>
 
       <ul class="govuk-list govuk-list--bullet">
@@ -19,6 +21,8 @@
         <li>complaint made to the local authority or any other agency or body</li>
         <li>signed witness statements</li>
       </ul>
+
+      <p>You must have the appropriate permission to send some documents to us, for example, if you are providing any documents from Family Court proceedings, then the appropriate permission from the Family Court should be obtained before they are sent to us.</p>
 
       <p>Make sure the file names describe the content, for example ‘signed witness statement’.</p>
 

--- a/app/views/referrals/allegation_details/details/edit.html.erb
+++ b/app/views/referrals/allegation_details/details/edit.html.erb
@@ -8,7 +8,11 @@
 
       <span class="govuk-caption-l"><%= section_label %></span>
       <div class="govuk-form-group">
-        <%= f.govuk_radio_buttons_fieldset(:allegation_format, legend: { size: "l", text: form_label, tag: 'h1' }) do %>
+        <%= f.govuk_radio_buttons_fieldset(
+          :allegation_format,
+          legend: { size: "l", text: form_label, tag: 'h1' },
+          hint: { text: t("referral_form.forms.allegation_details.hint") }
+        ) do %>
           <%= f.govuk_radio_button :allegation_format, "upload", label: { text: "Upload file" }, link_errors: true do %>
             <% if current_referral.allegation_upload_file&.attached? %>
               <div class="app-uploaded-file">

--- a/app/views/referrals/allegation_evidence/upload/edit.html.erb
+++ b/app/views/referrals/allegation_evidence/upload/edit.html.erb
@@ -9,6 +9,8 @@
       <span class="govuk-caption-l"><%= section_label %></span>
       <h1 class="govuk-heading-l"><%= form_label %></h1>
 
+      <p>You must send all available information. A decision whether to begin an investigation will be based on the evidence provided. We may not contact you for additional information before making a decision.</p>
+
       <p>For example:</p>
 
       <ul class="govuk-list govuk-list--bullet">
@@ -29,6 +31,8 @@
         Do not redact any of the documents. This will make it difficult to consider the evidence. All
         information given is treated in strict confidence.
       </p>
+
+      <p>You must have the appropriate permission to send some documents to us, for example, if you are providing any documents from Family Court proceedings, then the appropriate permission from the Family Court should be obtained before they are sent to us.</p>
 
       <p>Make sure the file names describe the content, for example ‘signed witness statement’.</p>
 

--- a/app/views/shared/_declaration.html.erb
+++ b/app/views/shared/_declaration.html.erb
@@ -7,4 +7,6 @@
   <li>you have permission from the relevant third parties for any evidence and supporting information to be shared, for example the police or <abbr title="Disclosure and Barring Service">DBS</abbr></li>
   <li>you may need to attend a hearing and give evidence if your allegation reaches that stage</li>
   <li>your report will be kept on file for 50 years</li>
+  <li>you have provided all the information / documents you have available</li>
+  <li>you have permission from the relevant third parties for any evidence and supporting information to be shared, for example the police, DBS or the Family Court</li>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
         work_location: Name and address of the organisation where they’re employed
       allegation_details:
         details: How do you want to give details about the allegation?
+        hint: Please provide as much detail as possible about the allegation. The TRA will make a decision on whether or not to begin an investigation based on the details of the allegations about the teacher provided below.
         considerations: How this complaint has been considered
         dbs: Telling DBS about this case
       allegation_previous_misconduct:


### PR DESCRIPTION
### Context

TMU has requested us to make some changes to the Refer service to align with their latest policy and process changes:

Please find below the details of changes to be made on the respective pages. Screenshots of the pages are attached to the ticket as reference.

Details of the Allegation

1. Please add the following after the heading:

Please provide as much detail as possible about the allegation. The TRA will make a decision on whether or not to begin an investigation based on the details of the allegations about the teacher provided below.

Evidence and supporting information

1. After the heading could you include:

You must send all available information. A decision whether to begin an investigation will be based on the evidence provided. We may not contact you for additional information before making a decision.

2. Could we add the following under

You must have the appropriate permission to send some documents to us, for example, if you are providing any documents from Family Court proceedings, then the appropriate permission from the Family Court should be obtained before they are sent to us.

Check details and send report

1. Can you add additional bullet points:

you have provided all the information / documents you have available

you have permission from the relevant third parties for any evidence and supporting information to be shared, for example the police, DBS or the Family Court

### Changes proposed in this pull request

- Add copy to required pages

### Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/XQCzSWIR)
