### PR TITLE
Pin exact third party github action versions

### DIFF
--- a/.github/actions/deploy-environment-aks/action.yml
+++ b/.github/actions/deploy-environment-aks/action.yml
@@ -30,7 +30,7 @@ runs:
   using: composite
 
   steps:
-    - uses: hashicorp/setup-terraform@v3
+    - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # Pinned at v3.1.2
       with:
         terraform_version: 1.6.4
         terraform_wrapper: false

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -44,7 +44,7 @@ runs:
         key: GOVUK_NOTIFY_API_KEY,SUPPORT_USERNAME,SUPPORT_PASSWORD
 
     # Run deployment smoke test
-    - uses: nick-fields/retry@v2.8.3
+    - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # Pinned at v2.8.3
       with:
         max_attempts: 5
         timeout_minutes: 3

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -66,7 +66,7 @@ jobs:
           pull-request-number: ${{ github.event.pull_request.number }}
 
       - name: Post comment to Pull Request ${{ github.event.pull_request.number }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # Pinned at v2.9.4
         with:
           header: aks
           message: |
@@ -153,7 +153,7 @@ jobs:
             echo "SLACK_WEBHOOK=$SLACK_WEBHOOK" >> $GITHUB_OUTPUT
 
       - name: Notify Slack channel on job failure
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
         env:
           SLACK_USERNAME: CI Deployment
           SLACK_TITLE: Deployment of refer-serious-misconduct ${{ env.REVIEW && 'review' }} failed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           GROVER_NO_SANDBOX: "true"
 
       - name: Test coverage report
-        uses: aki77/simplecov-report-action@v1
+        uses: aki77/simplecov-report-action@7fd5fa551dd583dd437a11c640b2a1cf23d6cdaa # Pinned to v1.5.2
         with:
           failedThreshold: 90
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Context

Github action tags can be changed and pointed at new versions of a repo, this can lead to supply chain attacks and evidence of this occuring on other projects outside DfE exists.

Pinning to exact git hashes ensures that the version of the action cannot be changed without us explicitly changing it.

### Changes proposed in this pull request

- Pin exact github action versions

### Guidance to review

- Check actions working

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
