### PR TITLE
Remove closed TMU phone number from contact details

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -47,8 +47,6 @@
         <h2 class="govuk-heading-m">Get help</h2>
         <p class="govuk-!-font-size-16">Email: <%= govuk_link_to("misconduct.teacher@education.gov.uk", "misconduct.teacher@education.gov.uk", class: "govuk-footer__link") %><br>You’ll get a response within 3 working days.</p>
 
-        <p class="govuk-!-font-size-16">Phone: 020 7593 5393<br>Monday to Friday, 9am to 5pm (except public holidays)</p>
-
         <h2 class="govuk-visually-hidden">Footer links</h2>
 
         <ul class="govuk-footer__inline-list">

--- a/app/views/pages/complete.html.erb
+++ b/app/views/pages/complete.html.erb
@@ -46,7 +46,5 @@
     <h3 class="govuk-heading-m">Get help with your referral</h3>
     <p>If you need more information about making a referral, you can contact <abbr title="Teaching Regulation Agency">TRA</abbr>.</p>
     <p>Email: <%= mail_to t('service.email') %><br>We aim to respond within 3 working days.</p>
-    <p>Phone: 020 7593 5393<br>Monday to Friday, 9am to 5pm (except Mondays and Fridays)</p>
-    <p><a href="https://www.gov.uk/call-charges">Find out about call charges</a>.</p>
   </div>
 </div>

--- a/app/views/shared/mailers/_get_help.erb
+++ b/app/views/shared/mailers/_get_help.erb
@@ -2,6 +2,3 @@
 
 Email: misconduct.teacher@education.gov.uk
 We aim to respond within 3 working days.
-
-Phone: 020 7593 5393
-Monday to Friday, 9am to 5pm (except public holidays)

--- a/spec/support/shared_examples/mailers_get_help.rb
+++ b/spec/support/shared_examples/mailers_get_help.rb
@@ -6,8 +6,4 @@ RSpec.shared_examples "email with `Get help` section" do
   it "includes the contact email" do
     expect(email.body).to include("misconduct.teacher@education.gov.uk")
   end
-
-  it "includes the contact phone number" do
-    expect(email.body).to include("020 7593 5393")
-  end
 end


### PR DESCRIPTION
### Context

TMU closed its phone line in early July 2026, but the service still advertised the number `020 7593 5393` and its "Monday to Friday, 9am to 5pm" opening hours. Requested via [DFE-Digital/teaching-record-team-project-board#375](https://github.com/DFE-Digital/teaching-record-team-project-board/issues/375).

### Changes proposed in this pull request

Remove the phone number and opening hours from the three places they appeared:

- the site footer (`app/views/layouts/base.html.erb`)
- the referral confirmation page (`app/views/pages/complete.html.erb`) — plus the now-orphaned "Find out about call charges" link
- the shared email partial (`app/views/shared/mailers/_get_help.erb`), which feeds the submission, draft-reminder, OTP, and referral-link emails

The mailer spec assertion for the number is dropped accordingly. The email address, response-time line, and postal address are left in place — the issue confirmed those should stay.

### Guidance to review

- `grep -rn "020 7593 5393" app spec` returns nothing.
- `bundle exec rspec spec/mailers/user_mailer_spec.rb` passes (these examples render the `_get_help` partial through all four mailers).
- Rubocop and Prettier pass on the changed files.

### Link to Trello card

N/A — tracked in [teaching-record-team-project-board#375](https://github.com/DFE-Digital/teaching-record-team-project-board/issues/375).

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
